### PR TITLE
Prevent errors when file is empty

### DIFF
--- a/src/cfnlint/__main__.py
+++ b/src/cfnlint/__main__.py
@@ -48,7 +48,8 @@ def main():
             loader = cfnlint.parser.MarkedLoader(fp.read())
             loader.add_multi_constructor("!", cfnlint.parser.multi_constructor)
             template = loader.get_single_data()
-            defaults = template.get('Metadata', {}).get('cfn-lint', {}).get('config', {})
+            if template is dict:
+                defaults = template.get('Metadata', {}).get('cfn-lint', {}).get('config', {})
         except ParserError as err:
             if vars(args)['ignore_bad_template']:
                 LOGGER.info('Template %s is maflormed: %s', filename, err)


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:*
- Fix an issue when the template is empty and trying to read out configuration options.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
