### PR TITLE
Feature/transform serverless

### DIFF
--- a/src/cfnlint/__main__.py
+++ b/src/cfnlint/__main__.py
@@ -20,8 +20,7 @@ import logging
 import json
 from yaml.parser import ParserError, ScannerError
 import cfnlint.helpers
-from cfnlint import RulesCollection
-from cfnlint import Match
+from cfnlint import RulesCollection, TransformsCollection, Match
 import cfnlint.formatters as formatters
 import cfnlint.cfn_json
 from cfnlint.version import __version__
@@ -148,6 +147,12 @@ def main():
         print(rules)
         return 0
 
+    transforms = TransformsCollection()
+    transformdirs = [cfnlint.DEFAULT_TRANSFORMSDIR]
+    for transformdir in transformdirs:
+        transforms.extend(
+            TransformsCollection.create_from_directory(transformdir))
+
     if vars(args)['regions']:
         supported_regions = [
             'ap-south-1',
@@ -174,8 +179,8 @@ def main():
     if vars(args)['template']:
         matches = list()
         runner = cfnlint.Runner(
-            rules, vars(args)['template'], template, vars(args)['ignore_checks'],
-            vars(args)['regions'])
+            rules, transforms, vars(args)['template'], template,
+            vars(args)['ignore_checks'], vars(args)['regions'])
         matches.extend(runner.run())
         matches.sort(key=lambda x: (x.filename, x.linenumber, x.rule.id))
         exit_code = len(matches)

--- a/src/cfnlint/__main__.py
+++ b/src/cfnlint/__main__.py
@@ -181,7 +181,10 @@ def main():
         runner = cfnlint.Runner(
             rules, transforms, vars(args)['template'], template,
             vars(args)['ignore_checks'], vars(args)['regions'])
-        matches.extend(runner.run())
+        matches.extend(runner.transform())
+        # Only do rule analysis if Transform was successful
+        if not matches:
+            matches.extend(runner.run())
         matches.sort(key=lambda x: (x.filename, x.linenumber, x.rule.id))
         exit_code = len(matches)
         if vars(args)['format'] == 'json':

--- a/src/cfnlint/rules/resources/properties/Properties.py
+++ b/src/cfnlint/rules/resources/properties/Properties.py
@@ -52,7 +52,7 @@ class Properties(CloudFormationLintRule):
                         message = "Property %s has an illegal function %s" % ('/'.join(map(str, proppath)), sub_key)
                         matches.append(RuleMatch(proppath, message))
         elif isinstance(value, str):
-            if primtype in ['Integer', 'Double']:
+            if primtype in ['Integer', 'Double', 'Long']:
                 try:
                     int(value)
                 except ValueError:
@@ -76,7 +76,7 @@ class Properties(CloudFormationLintRule):
                 pass
                 # LOGGER.info("%s is an int but should be %s for resource %s",
                 #            text[prop], primtype, resourcename)
-            elif primtype != "Integer":
+            elif primtype not in ["Integer", "Long"]:
                 message = "Property %s should be of type Integer" % ('/'.join(map(str, proppath)))
                 matches.append(RuleMatch(proppath, message))
         elif isinstance(value, list):

--- a/src/cfnlint/rules/templates/Base.py
+++ b/src/cfnlint/rules/templates/Base.py
@@ -26,21 +26,7 @@ class Base(CloudFormationLintRule):
                   'are propery configured'
     tags = ['base']
 
-    valid_keys = [
-        'AWSTemplateFormatVersion',
-        'Resources',
-        'Description',
-        'Metadata',
-        'Parameters',
-        'Outputs',
-        'Mappings',
-        'Conditions',
-        'Rules',
-        'Transform'
-    ]
-
     required_keys = [
-        'AWSTemplateFormatVersion',
         'Resources'
     ]
 
@@ -51,19 +37,13 @@ class Base(CloudFormationLintRule):
         top_level = []
         for x in cfn.template:
             top_level.append(x)
-            if x not in self.valid_keys:
+            if x not in cfn.sections:
                 message = "Top level item {0} isn't valid"
-                matches.append(RuleMatch(
-                    [x],
-                    message.format(x)
-                ))
+                matches.append(RuleMatch([x], message.format(x)))
 
         for y in self.required_keys:
             if y not in top_level:
                 message = "Missing top level item {0} to file module"
-                matches.append(RuleMatch(
-                    ['AWSTemplateFormatVersion'],
-                    message.format(y)
-                ))
+                matches.append(RuleMatch([y], message.format(y)))
 
         return matches

--- a/src/cfnlint/transforms/Serverless/Api.py
+++ b/src/cfnlint/transforms/Serverless/Api.py
@@ -14,7 +14,7 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-from cfnlint import CloudFormationTransform
+from cfnlint import CloudFormationTransform, transforms
 
 
 class Api(CloudFormationTransform):
@@ -29,15 +29,24 @@ class Api(CloudFormationTransform):
         for resource_name, resource_values in cfn.get_resources(resource_type='AWS::Serverless::API').items():
             resource_properties = resource_values.get('Properties', {})
             stage_name = resource_properties.get('StageName', 'Prod')
-            cfn.template['Resources'][resource_name] = {
-                "Type": "AWS::ApiGateway::RestApi",
-                "Properties": {}
-            }
-            cfn.template['Resources'][("%s%sStage" % (resource_name, stage_name))] = {
-                "Type": "AWS::ApiGateway::Stage",
-                "Properties": {}
-            }
-            cfn.template['Resources']['%sDeployment%s' % (resource_name, "SHA")] = {
-                "Type": "AWS::ApiGateway::Deployment",
-                "Properties": {}
-            }
+            transforms.add_resource(
+                cfn, cfn.template['Resources'][resource_name],
+                {
+                    "Type": "AWS::ApiGateway::RestApi",
+                    "Properties": {}
+                }
+            )
+            transforms.add_resource(
+                cfn, "%s%sStage" % (resource_name, stage_name),
+                {
+                    "Type": "AWS::ApiGateway::Stage",
+                    "Properties": {}
+                }
+            )
+            transforms.add_resource(
+                cfn, '%sDeployment%s' % (resource_name, "SHA"),
+                {
+                    "Type": "AWS::ApiGateway::Deployment",
+                    "Properties": {}
+                }
+            )

--- a/src/cfnlint/transforms/Serverless/Api.py
+++ b/src/cfnlint/transforms/Serverless/Api.py
@@ -1,0 +1,43 @@
+"""
+  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this
+  software and associated documentation files (the "Software"), to deal in the Software
+  without restriction, including without limitation the rights to use, copy, modify,
+  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+from cfnlint import CloudFormationTransform
+
+
+class Api(CloudFormationTransform):
+    """Conver Serverless API"""
+    type = 'AWS::Serverless-2016-10-31'
+
+    def resource_transform(self, cfn):
+        """
+            Add resources based on the criteria inside
+            https://awslabs.github.io/serverless-application-model/internals/generated_resources.html
+        """
+        for resource_name, resource_values in cfn.get_resources(resource_type='AWS::Serverless::API').items():
+            resource_properties = resource_values.get('Properties', {})
+            stage_name = resource_properties.get('StageName', 'Prod')
+            cfn.template['Resources'][resource_name] = {
+                "Type": "AWS::ApiGateway::RestApi",
+                "Properties": {}
+            }
+            cfn.template['Resources'][("%s%sStage" % (resource_name, stage_name))] = {
+                "Type": "AWS::ApiGateway::Stage",
+                "Properties": {}
+            }
+            cfn.template['Resources']['%sDeployment%s' % (resource_name, "SHA")] = {
+                "Type": "AWS::ApiGateway::Deployment",
+                "Properties": {}
+            }

--- a/src/cfnlint/transforms/Serverless/Api.py
+++ b/src/cfnlint/transforms/Serverless/Api.py
@@ -26,27 +26,28 @@ class Api(CloudFormationTransform):
             Add resources based on the criteria inside
             https://awslabs.github.io/serverless-application-model/internals/generated_resources.html
         """
-        for resource_name, resource_values in cfn.get_resources(resource_type='AWS::Serverless::API').items():
+        for resource_name, resource_values in cfn.get_resources(resource_type='AWS::Serverless::Api').items():
             resource_properties = resource_values.get('Properties', {})
             stage_name = resource_properties.get('StageName', 'Prod')
-            transforms.add_resource(
-                cfn, cfn.template['Resources'][resource_name],
-                {
-                    "Type": "AWS::ApiGateway::RestApi",
-                    "Properties": {}
-                }
-            )
             transforms.add_resource(
                 cfn, "%s%sStage" % (resource_name, stage_name),
                 {
                     "Type": "AWS::ApiGateway::Stage",
-                    "Properties": {}
+                    "Properties": {
+                        "RestApiId": {
+                            "Ref": resource_name
+                        }
+                    }
                 }
             )
             transforms.add_resource(
                 cfn, '%sDeployment%s' % (resource_name, "SHA"),
                 {
                     "Type": "AWS::ApiGateway::Deployment",
-                    "Properties": {}
+                    "Properties": {
+                        "RestApiId": {
+                            "Ref": resource_name
+                        }
+                    }
                 }
             )

--- a/src/cfnlint/transforms/Serverless/Functions.py
+++ b/src/cfnlint/transforms/Serverless/Functions.py
@@ -14,7 +14,7 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-from cfnlint import CloudFormationTransform
+from cfnlint import CloudFormationTransform, transforms
 
 
 class Functions(CloudFormationTransform):
@@ -28,217 +28,289 @@ class Functions(CloudFormationTransform):
         """
         for resource_name, resource_values in cfn.get_resources(resource_type='AWS::Serverless::Function').items():
             resource_properties = resource_values.get('Properties', {})
-            cfn.template['Resources'][("%sRole" % resource_name)] = {
-                "Type": "AWS::IAM::Role",
-                "Properties": {
-                    "AssumeRolePolicyDocument": {
-                        "Version": "2012-10-17",
-                        "Statement": [{
-                            "Effect": "Allow",
-                            "Principal": {
-                                "Service": ["lambda.amazonaws.com"]
-                            },
-                            "Action": ["sts:AssumeRole"]
-                        }]
+            transforms.add_resource(
+                cfn, "%sRole" % resource_name,
+                {
+                    "Type": "AWS::IAM::Role",
+                    "Properties": {
+                        "AssumeRolePolicyDocument": {
+                            "Version": "2012-10-17",
+                            "Statement": [{
+                                "Effect": "Allow",
+                                "Principal": {
+                                    "Service": ["lambda.amazonaws.com"]
+                                },
+                                "Action": ["sts:AssumeRole"]
+                            }]
+                        }
                     }
                 }
-            }
+            )
             if resource_properties:
                 key_value = resource_properties.get('AutoPublishAlias')
                 if key_value:
                     # Need to figure out SHA256 hashing
-                    cfn.template['Resources'][("%sVersion%s" % (resource_name, key_value))] = {
-                        "Type": "AWS::Lambda::Version",
-                        "Properties": {
-                            "FunctionName": resource_name
+                    transforms.add_resource(
+                        cfn, "%sVersion%s" % (resource_name, key_value),
+                        {
+                            "Type": "AWS::Lambda::Version",
+                            "Properties": {
+                                "FunctionName": resource_name
+                            }
                         }
-                    }
-                    cfn.template['Resources'][("%sAlias%s" % (resource_name, key_value))] = {
-                        "Type": "AWS::Lambda::Alias",
-                        "Properties": {
-                            "FunctionName": resource_name,
-                            "FunctionVersion": "latest",
-                            "Name": key_value
+                    )
+                    transforms.add_resource(
+                        cfn, "%sAlias%s" % (resource_name, key_value),
+                        {
+                            "Type": "AWS::Lambda::Alias",
+                            "Properties": {
+                                "FunctionName": resource_name,
+                                "FunctionVersion": "latest",
+                                "Name": key_value
+                            }
                         }
-                    }
+                    )
 
                 key_value = resource_properties.get('DeploymentPreference', {})
                 if key_value:
-                    cfn.template['Resources']['ServerlessDeploymentApplication'] = {
-                        "Type": "AWS::CodeDeploy::Application",
-                        "Properties": {}
-                    }
-                    cfn.template['Resources'][("%sDeploymentGroup" % resource_name)] = {
-                        "Type": "AWS::CodeDeploy::DeploymentGroup",
-                        "Properties": {
-                            "ApplicationName": {
-                                "Ref": resource_name
-                            },
-                            "ServiceRoleArn": {
-                                "Ref": "CodeDeployServiceRole"
+                    transforms.add_resource(
+                        cfn, 'ServerlessDeploymentApplication',
+                        {
+                            "Type": "AWS::CodeDeploy::Application",
+                            "Properties": {}
+                        }
+                    )
+                    transforms.add_resource(
+                        cfn, "%sDeploymentGroup" % resource_name,
+                        {
+                            "Type": "AWS::CodeDeploy::DeploymentGroup",
+                            "Properties": {
+                                "ApplicationName": {
+                                    "Ref": resource_name
+                                },
+                                "ServiceRoleArn": {
+                                    "Ref": "CodeDeployServiceRole"
+                                }
                             }
                         }
-                    }
-                    cfn.template['Resources']['CodeDeployServiceRole'] = {
-                        "Type": "AWS::IAM::Role",
-                        "Properties": {
-                            "AssumeRolePolicyDocument": {
-                                "Version": "2012-10-17",
-                                "Statement": [{
-                                    "Effect": "Allow",
-                                    "Principal": {
-                                        "Service": ["codedeploy.amazonaws.com"]
-                                    },
-                                    "Action": ["sts:AssumeRole"]
-                                }]
+                    )
+                    transforms.add_resource(
+                        cfn, 'CodeDeployServiceRole',
+                        {
+                            "Type": "AWS::IAM::Role",
+                            "Properties": {
+                                "AssumeRolePolicyDocument": {
+                                    "Version": "2012-10-17",
+                                    "Statement": [{
+                                        "Effect": "Allow",
+                                        "Principal": {
+                                            "Service": ["codedeploy.amazonaws.com"]
+                                        },
+                                        "Action": ["sts:AssumeRole"]
+                                    }]
+                                }
                             }
                         }
-                    }
+                    )
 
                 events = resource_properties.get('Events', {})
                 for event_name, event_value in events.items():
                     event_type = event_value.get('Type', None)
-                    if event_type == 'API':
+                    if event_type == 'Api':
                         rest_api_id = event_value.get('Properties', {}).get('RestApidId')
                         if not rest_api_id:
-                            cfn.template['Resources']['ServerlessRestApi'] = {
-                                "Type": "AWS::ApiGateway::RestApi",
-                                "Properties": {}
-                            }
-                            cfn.template['Resources'][("ServerlessRestApi%sStage", "Prod")] = {
-                                "Type": "AWS::ApiGateway::Stage",
-                                "Properties": {}
-                            }
-                            cfn.template['Resources']['ServerlessRestApiDeployment%s' % ("SHA")] = {
-                                "Type": "AWS::ApiGateway::Deployment",
-                                "Properties": {}
-                            }
-                        cfn.template['Resources'][("%s%sPermission%s" % (resource_name, event_name, "Prod"))] = {
-                            "Type": "AWS::Lambda::Permission",
-                            "Properties": {
-                                "Principal": "apigateway.amazonaws.com",
-                                "Action": "lambda:InvokeFunction",
-                                "FunctionName": {
-                                    "Fn::GetAtt": [
-                                        resource_name,
-                                        "Arn"
-                                    ]
+                            transforms.add_resource(
+                                cfn, 'ServerlessRestApi',
+                                {
+                                    "Type": "AWS::ApiGateway::RestApi",
+                                    "Properties": {}
+                                }
+                            )
+                            transforms.add_resource(
+                                cfn, 'ServerlessRestApi%sStage' % 'Prod',
+                                {
+                                    "Type": "AWS::ApiGateway::Stage",
+                                    "Properties": {
+                                        "RestApiId": {
+                                            "Ref": "ServerlessRestApi"
+                                        }
+                                    }
+                                }
+                            )
+                            transforms.add_resource(
+                                cfn, 'ServerlessRestApiDeployment%s' % ("SHA"),
+                                {
+                                    "Type": "AWS::ApiGateway::Deployment",
+                                    "Properties": {
+                                        "RestApiId": {
+                                            "Ref": "ServerlessRestApi"
+                                        }
+                                    }
+                                }
+                            )
+
+                        transforms.add_resource(
+                            cfn, '%s%sPermission%s' % (resource_name, event_name, "Prod"),
+                            {
+                                "Type": "AWS::Lambda::Permission",
+                                "Properties": {
+                                    "Principal": "apigateway.amazonaws.com",
+                                    "Action": "lambda:InvokeFunction",
+                                    "FunctionName": {
+                                        "Fn::GetAtt": [
+                                            resource_name,
+                                            "Arn"
+                                        ]
+                                    }
                                 }
                             }
-                        }
+                        )
                     elif event_type == 'S3':
-                        cfn.template['Resources']['%s%sPermission' % (resource_name, event_name)] = {
-                            "Type": "AWS::Lambda::Permission",
-                            "Properties": {
-                                "Principal": "s3.amazonaws.com",
-                                "Action": "lambda:InvokeFunction",
-                                "FunctionName": {
-                                    "Fn::GetAtt": [
-                                        resource_name,
-                                        "Arn"
-                                    ]
+                        transforms.add_resource(
+                            cfn, '%s%sPermission' % (resource_name, event_name),
+                            {
+                                "Type": "AWS::Lambda::Permission",
+                                "Properties": {
+                                    "Principal": "s3.amazonaws.com",
+                                    "Action": "lambda:InvokeFunction",
+                                    "FunctionName": {
+                                        "Fn::GetAtt": [
+                                            resource_name,
+                                            "Arn"
+                                        ]
+                                    }
                                 }
                             }
-                        }
+                        )
                     elif event_type == 'SNS':
-                        cfn.template['Resources']['%s%sPermission' % (resource_name, event_name)] = {
-                            "Type": "AWS::Lambda::Permission",
-                            "Properties": {
-                                "Principal": "sns.amazonaws.com",
-                                "Action": "lambda:InvokeFunction",
-                                "FunctionName": {
-                                    "Fn::GetAtt": [
-                                        resource_name,
-                                        "Arn"
-                                    ]
+                        transforms.add_resource(
+                            cfn, '%s%sPermission' % (resource_name, event_name),
+                            {
+                                "Type": "AWS::Lambda::Permission",
+                                "Properties": {
+                                    "Principal": "sns.amazonaws.com",
+                                    "Action": "lambda:InvokeFunction",
+                                    "FunctionName": {
+                                        "Fn::GetAtt": [
+                                            resource_name,
+                                            "Arn"
+                                        ]
+                                    }
                                 }
                             }
-                        }
-                        cfn.template['Resources']['%s%s' % (resource_name, event_name)] = {
-                            "Type": "AWS::SNS::Subscription",
-                            "Properties": {}
-                        }
+                        )
+                        transforms.add_resource(
+                            cfn, '%s%s' % (resource_name, event_name),
+                            {
+                                "Type": "AWS::SNS::Subscription",
+                                "Properties": {}
+                            }
+                        )
                     elif event_type == 'Kinesis':
-                        cfn.template['Resources']['%s%sPermission' % (resource_name, event_name)] = {
-                            "Type": "AWS::Lambda::Permission",
-                            "Properties": {
-                                "Principal": "kinesis.amazonaws.com",
-                                "Action": "lambda:InvokeFunction",
-                                "FunctionName": {
-                                    "Fn::GetAtt": [
-                                        resource_name,
-                                        "Arn"
-                                    ]
+                        transforms.add_resource(
+                            cfn, '%s%sPermission' % (resource_name, event_name),
+                            {
+                                "Type": "AWS::Lambda::Permission",
+                                "Properties": {
+                                    "Principal": "kinesis.amazonaws.com",
+                                    "Action": "lambda:InvokeFunction",
+                                    "FunctionName": {
+                                        "Fn::GetAtt": [
+                                            resource_name,
+                                            "Arn"
+                                        ]
+                                    }
                                 }
                             }
-                        }
-                        cfn.template['Resources']['%s%s' % (resource_name, event_name)] = {
-                            "Type": "AWS::Lambda::EventSourceMapping",
-                            "Properties": {
-                                "FunctionName": {
-                                    "Ref": resource_name
-                                },
-                                "EventSourceArn": "anArn",
-                                "StartingPosition": "1"
+                        )
+                        transforms.add_resource(
+                            cfn, '%s%s' % (resource_name, event_name),
+                            {
+                                "Type": "AWS::Lambda::EventSourceMapping",
+                                "Properties": {
+                                    "FunctionName": {
+                                        "Ref": resource_name
+                                    },
+                                    "EventSourceArn": "anArn",
+                                    "StartingPosition": "1"
+                                }
                             }
-                        }
+                        )
                     elif event_type == 'DynamoDb':
-                        cfn.template['Resources']['%s%sPermission' % (resource_name, event_name)] = {
-                            "Type": "AWS::Lambda::Permission",
-                            "Properties": {
-                                "Principal": "dynamodb.amazonaws.com",
-                                "Action": "lambda:InvokeFunction",
-                                "FunctionName": {
-                                    "Fn::GetAtt": [
-                                        resource_name,
-                                        "Arn"
-                                    ]
+                        transforms.add_resource(
+                            cfn, '%s%sPermission' % (resource_name, event_name),
+                            {
+                                "Type": "AWS::Lambda::Permission",
+                                "Properties": {
+                                    "Principal": "dynamodb.amazonaws.com",
+                                    "Action": "lambda:InvokeFunction",
+                                    "FunctionName": {
+                                        "Fn::GetAtt": [
+                                            resource_name,
+                                            "Arn"
+                                        ]
+                                    }
                                 }
                             }
-                        }
-                        cfn.template['Resources']['%s%s' % (resource_name, event_name)] = {
-                            "Type": "AWS::Lambda::EventSourceMapping",
-                            "Properties": {
-                                "FunctionName": {
-                                    "Ref": resource_name
-                                },
-                                "EventSourceArn": "anArn",
-                                "StartingPosition": "1"
+                        )
+                        transforms.add_resource(
+                            cfn, '%s%s' % (resource_name, event_name),
+                            {
+                                "Type": "AWS::Lambda::EventSourceMapping",
+                                "Properties": {
+                                    "FunctionName": {
+                                        "Ref": resource_name
+                                    },
+                                    "EventSourceArn": "anArn",
+                                    "StartingPosition": "1"
+                                }
                             }
-                        }
+                        )
                     elif event_type == 'Schedule':
-                        cfn.template['Resources']['%s%sPermission' % (resource_name, event_name)] = {
-                            "Type": "AWS::Lambda::Permission",
-                            "Properties": {
-                                "Principal": "events.amazonaws.com",
-                                "Action": "lambda:InvokeFunction",
-                                "FunctionName": {
-                                    "Fn::GetAtt": [
-                                        resource_name,
-                                        "Arn"
-                                    ]
+                        transforms.add_resource(
+                            cfn, '%s%sPermission' % (resource_name, event_name),
+                            {
+                                "Type": "AWS::Lambda::Permission",
+                                "Properties": {
+                                    "Principal": "events.amazonaws.com",
+                                    "Action": "lambda:InvokeFunction",
+                                    "FunctionName": {
+                                        "Fn::GetAtt": [
+                                            resource_name,
+                                            "Arn"
+                                        ]
+                                    }
                                 }
                             }
-                        }
-                        cfn.template['Resources']['%s%s' % (resource_name, event_name)] = {
-                            "Type": "AWS::Events::Rule",
-                            "Properties": {}
-                        }
+                        )
+                        transforms.add_resource(
+                            cfn, '%s%s' % (resource_name, event_name),
+                            {
+                                "Type": "AWS::Events::Rule",
+                                "Properties": {}
+                            }
+                        )
                     elif event_type == 'CloudWatchEvent':
-                        cfn.template['Resources']['%s%sPermission' % (resource_name, event_name)] = {
-                            "Type": "AWS::Lambda::Permission",
-                            "Properties": {
-                                "Principal": "events.amazonaws.com",
-                                "Action": "lambda:InvokeFunction",
-                                "FunctionName": {
-                                    "Fn::GetAtt": [
-                                        resource_name,
-                                        "Arn"
-                                    ]
+                        transforms.add_resource(
+                            cfn, '%s%sPermission' % (resource_name, event_name),
+                            {
+                                "Type": "AWS::Lambda::Permission",
+                                "Properties": {
+                                    "Principal": "events.amazonaws.com",
+                                    "Action": "lambda:InvokeFunction",
+                                    "FunctionName": {
+                                        "Fn::GetAtt": [
+                                            resource_name,
+                                            "Arn"
+                                        ]
+                                    }
                                 }
                             }
-                        }
-                        cfn.template['Resources']['%s%s' % (resource_name, event_name)] = {
-                            "Type": "AWS::Events::Rule",
-                            "Properties": {}
-                        }
+                        )
+                        transforms.add_resource(
+                            cfn, '%s%s' % (resource_name, event_name),
+                            {
+                                "Type": "AWS::Events::Rule",
+                                "Properties": {}
+                            }
+                        )

--- a/src/cfnlint/transforms/Serverless/Functions.py
+++ b/src/cfnlint/transforms/Serverless/Functions.py
@@ -1,0 +1,244 @@
+"""
+  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this
+  software and associated documentation files (the "Software"), to deal in the Software
+  without restriction, including without limitation the rights to use, copy, modify,
+  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+from cfnlint import CloudFormationTransform
+
+
+class Functions(CloudFormationTransform):
+    """Check Base Template Settings"""
+    type = 'AWS::Serverless-2016-10-31'
+
+    def resource_transform(self, cfn):
+        """
+            Add resources based on the criteria inside
+            https://awslabs.github.io/serverless-application-model/internals/generated_resources.html
+        """
+        for resource_name, resource_values in cfn.get_resources(resource_type='AWS::Serverless::Function').items():
+            resource_properties = resource_values.get('Properties', {})
+            cfn.template['Resources'][("%sRole" % resource_name)] = {
+                "Type": "AWS::IAM::Role",
+                "Properties": {
+                    "AssumeRolePolicyDocument": {
+                        "Version": "2012-10-17",
+                        "Statement": [{
+                            "Effect": "Allow",
+                            "Principal": {
+                                "Service": ["lambda.amazonaws.com"]
+                            },
+                            "Action": ["sts:AssumeRole"]
+                        }]
+                    }
+                }
+            }
+            if resource_properties:
+                key_value = resource_properties.get('AutoPublishAlias')
+                if key_value:
+                    # Need to figure out SHA256 hashing
+                    cfn.template['Resources'][("%sVersion%s" % (resource_name, key_value))] = {
+                        "Type": "AWS::Lambda::Version",
+                        "Properties": {
+                            "FunctionName": resource_name
+                        }
+                    }
+                    cfn.template['Resources'][("%sAlias%s" % (resource_name, key_value))] = {
+                        "Type": "AWS::Lambda::Alias",
+                        "Properties": {
+                            "FunctionName": resource_name,
+                            "FunctionVersion": "latest",
+                            "Name": key_value
+                        }
+                    }
+
+                key_value = resource_properties.get('DeploymentPreference', {})
+                if key_value:
+                    cfn.template['Resources']['ServerlessDeploymentApplication'] = {
+                        "Type": "AWS::CodeDeploy::Application",
+                        "Properties": {}
+                    }
+                    cfn.template['Resources'][("%sDeploymentGroup" % resource_name)] = {
+                        "Type": "AWS::CodeDeploy::DeploymentGroup",
+                        "Properties": {
+                            "ApplicationName": {
+                                "Ref": resource_name
+                            },
+                            "ServiceRoleArn": {
+                                "Ref": "CodeDeployServiceRole"
+                            }
+                        }
+                    }
+                    cfn.template['Resources']['CodeDeployServiceRole'] = {
+                        "Type": "AWS::IAM::Role",
+                        "Properties": {
+                            "AssumeRolePolicyDocument": {
+                                "Version": "2012-10-17",
+                                "Statement": [{
+                                    "Effect": "Allow",
+                                    "Principal": {
+                                        "Service": ["codedeploy.amazonaws.com"]
+                                    },
+                                    "Action": ["sts:AssumeRole"]
+                                }]
+                            }
+                        }
+                    }
+
+                events = resource_properties.get('Events', {})
+                for event_name, event_value in events.items():
+                    event_type = event_value.get('Type', None)
+                    if event_type == 'API':
+                        rest_api_id = event_value.get('Properties', {}).get('RestApidId')
+                        if not rest_api_id:
+                            cfn.template['Resources']['ServerlessRestApi'] = {
+                                "Type": "AWS::ApiGateway::RestApi",
+                                "Properties": {}
+                            }
+                            cfn.template['Resources'][("ServerlessRestApi%sStage", "Prod")] = {
+                                "Type": "AWS::ApiGateway::Stage",
+                                "Properties": {}
+                            }
+                            cfn.template['Resources']['ServerlessRestApiDeployment%s' % ("SHA")] = {
+                                "Type": "AWS::ApiGateway::Deployment",
+                                "Properties": {}
+                            }
+                        cfn.template['Resources'][("%s%sPermission%s" % (resource_name, event_name, "Prod"))] = {
+                            "Type": "AWS::Lambda::Permission",
+                            "Properties": {
+                                "Principal": "apigateway.amazonaws.com",
+                                "Action": "lambda:InvokeFunction",
+                                "FunctionName": {
+                                    "Fn::GetAtt": [
+                                        resource_name,
+                                        "Arn"
+                                    ]
+                                }
+                            }
+                        }
+                    elif event_type == 'S3':
+                        cfn.template['Resources']['%s%sPermission' % (resource_name, event_name)] = {
+                            "Type": "AWS::Lambda::Permission",
+                            "Properties": {
+                                "Principal": "s3.amazonaws.com",
+                                "Action": "lambda:InvokeFunction",
+                                "FunctionName": {
+                                    "Fn::GetAtt": [
+                                        resource_name,
+                                        "Arn"
+                                    ]
+                                }
+                            }
+                        }
+                    elif event_type == 'SNS':
+                        cfn.template['Resources']['%s%sPermission' % (resource_name, event_name)] = {
+                            "Type": "AWS::Lambda::Permission",
+                            "Properties": {
+                                "Principal": "sns.amazonaws.com",
+                                "Action": "lambda:InvokeFunction",
+                                "FunctionName": {
+                                    "Fn::GetAtt": [
+                                        resource_name,
+                                        "Arn"
+                                    ]
+                                }
+                            }
+                        }
+                        cfn.template['Resources']['%s%s' % (resource_name, event_name)] = {
+                            "Type": "AWS::SNS::Subscription",
+                            "Properties": {}
+                        }
+                    elif event_type == 'Kinesis':
+                        cfn.template['Resources']['%s%sPermission' % (resource_name, event_name)] = {
+                            "Type": "AWS::Lambda::Permission",
+                            "Properties": {
+                                "Principal": "kinesis.amazonaws.com",
+                                "Action": "lambda:InvokeFunction",
+                                "FunctionName": {
+                                    "Fn::GetAtt": [
+                                        resource_name,
+                                        "Arn"
+                                    ]
+                                }
+                            }
+                        }
+                        cfn.template['Resources']['%s%s' % (resource_name, event_name)] = {
+                            "Type": "AWS::Lambda::EventSourceMapping",
+                            "Properties": {
+                                "FunctionName": {
+                                    "Ref": resource_name
+                                },
+                                "EventSourceArn": "anArn",
+                                "StartingPosition": "1"
+                            }
+                        }
+                    elif event_type == 'DynamoDb':
+                        cfn.template['Resources']['%s%sPermission' % (resource_name, event_name)] = {
+                            "Type": "AWS::Lambda::Permission",
+                            "Properties": {
+                                "Principal": "dynamodb.amazonaws.com",
+                                "Action": "lambda:InvokeFunction",
+                                "FunctionName": {
+                                    "Fn::GetAtt": [
+                                        resource_name,
+                                        "Arn"
+                                    ]
+                                }
+                            }
+                        }
+                        cfn.template['Resources']['%s%s' % (resource_name, event_name)] = {
+                            "Type": "AWS::Lambda::EventSourceMapping",
+                            "Properties": {
+                                "FunctionName": {
+                                    "Ref": resource_name
+                                },
+                                "EventSourceArn": "anArn",
+                                "StartingPosition": "1"
+                            }
+                        }
+                    elif event_type == 'Schedule':
+                        cfn.template['Resources']['%s%sPermission' % (resource_name, event_name)] = {
+                            "Type": "AWS::Lambda::Permission",
+                            "Properties": {
+                                "Principal": "events.amazonaws.com",
+                                "Action": "lambda:InvokeFunction",
+                                "FunctionName": {
+                                    "Fn::GetAtt": [
+                                        resource_name,
+                                        "Arn"
+                                    ]
+                                }
+                            }
+                        }
+                        cfn.template['Resources']['%s%s' % (resource_name, event_name)] = {
+                            "Type": "AWS::Events::Rule",
+                            "Properties": {}
+                        }
+                    elif event_type == 'CloudWatchEvent':
+                        cfn.template['Resources']['%s%sPermission' % (resource_name, event_name)] = {
+                            "Type": "AWS::Lambda::Permission",
+                            "Properties": {
+                                "Principal": "events.amazonaws.com",
+                                "Action": "lambda:InvokeFunction",
+                                "FunctionName": {
+                                    "Fn::GetAtt": [
+                                        resource_name,
+                                        "Arn"
+                                    ]
+                                }
+                            }
+                        }
+                        cfn.template['Resources']['%s%s' % (resource_name, event_name)] = {
+                            "Type": "AWS::Events::Rule",
+                            "Properties": {}
+                        }

--- a/src/cfnlint/transforms/Serverless/Sections.py
+++ b/src/cfnlint/transforms/Serverless/Sections.py
@@ -1,0 +1,30 @@
+"""
+  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this
+  software and associated documentation files (the "Software"), to deal in the Software
+  without restriction, including without limitation the rights to use, copy, modify,
+  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+from cfnlint import CloudFormationTransform
+
+
+class Sections(CloudFormationTransform):
+    """Add Global Sections"""
+    type = 'AWS::Serverless-2016-10-31'
+
+    def resource_transform(self, cfn):
+        """
+            Add valid sections
+            https://awslabs.github.io/serverless-application-model/globals.html
+        """
+
+        cfn.sections.append('Globals')

--- a/src/cfnlint/transforms/__init__.py
+++ b/src/cfnlint/transforms/__init__.py
@@ -1,0 +1,40 @@
+"""
+  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this
+  software and associated documentation files (the "Software"), to deal in the Software
+  without restriction, including without limitation the rights to use, copy, modify,
+  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+
+
+class TransformError(Exception):
+    """Transform Error"""
+    def __init__(self, resource_name, location, value):
+        super(TransformError, self).__init__()
+        self.value = value
+        self.resource_name = resource_name
+        self.location = location
+
+    def __str__(self):
+        return repr(self.value)
+
+
+def add_resource(cfn, resource_name, body):
+    """Add resource to template and fail if the resource already exists"""
+    if resource_name in cfn.template.get('Resources', {}):
+        path = ['Resources', resource_name]
+        location = cfn.get_location_yaml(cfn.template, path)
+        raise TransformError(
+            resource_name, location,
+            'A resource with ID "%s" already exists within this template' % resource_name)
+
+    cfn.template['Resources'][resource_name] = body

--- a/test/rules/__init__.py
+++ b/test/rules/__init__.py
@@ -14,7 +14,7 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-from cfnlint import Runner, RulesCollection
+from cfnlint import Runner, RulesCollection, TransformsCollection, DEFAULT_TRANSFORMSDIR
 from testlib.testcase import BaseTestCase
 
 
@@ -40,28 +40,34 @@ class BaseRuleTestCase(BaseTestCase):
         'templates/good/functions_sub.yaml',
         'templates/good/functions_cidr.yaml',
         'templates/good/resources_lambda.yaml',
+        'templates/good/transform_serverless_api.yaml',
+        'templates/good/transform_serverless_function.yaml',
+        'templates/good/transform_serverless_globals.yaml',
     ]
 
     def setUp(self):
         """Setup"""
         self.collection = RulesCollection()
+        self.transforms = TransformsCollection()
+        self.transforms.extend(
+            TransformsCollection.create_from_directory(DEFAULT_TRANSFORMSDIR))
 
     def helper_file_positive(self):
         """Success test"""
         for filename in self.success_templates:
             template = self.load_template(filename)
-            good_runner = Runner(self.collection, filename, template, [], ['us-east-1'], [])
+            good_runner = Runner(self.collection, self.transforms, filename, template, [], ['us-east-1'], [])
             self.assertEqual([], good_runner.run())
 
     def helper_file_positive_template(self, filename):
         """Success test with template parameter"""
         template = self.load_template(filename)
-        good_runner = Runner(self.collection, filename, template, [], ['us-east-1'], [])
+        good_runner = Runner(self.collection, self.transforms, filename, template, [], ['us-east-1'], [])
         self.assertEqual([], good_runner.run())
 
     def helper_file_negative(self, filename, err_count):
         """Failure test"""
         template = self.load_template(filename)
-        bad_runner = Runner(self.collection, filename, template, [], ['us-east-1'], [])
+        bad_runner = Runner(self.collection, self.transforms, filename, template, [], ['us-east-1'], [])
         errs = bad_runner.run()
         self.assertEqual(err_count, len(errs))

--- a/test/rules/__init__.py
+++ b/test/rules/__init__.py
@@ -57,17 +57,20 @@ class BaseRuleTestCase(BaseTestCase):
         for filename in self.success_templates:
             template = self.load_template(filename)
             good_runner = Runner(self.collection, self.transforms, filename, template, [], ['us-east-1'], [])
+            good_runner.transform()
             self.assertEqual([], good_runner.run())
 
     def helper_file_positive_template(self, filename):
         """Success test with template parameter"""
         template = self.load_template(filename)
         good_runner = Runner(self.collection, self.transforms, filename, template, [], ['us-east-1'], [])
+        good_runner.transform()
         self.assertEqual([], good_runner.run())
 
     def helper_file_negative(self, filename, err_count):
         """Failure test"""
         template = self.load_template(filename)
         bad_runner = Runner(self.collection, self.transforms, filename, template, [], ['us-east-1'], [])
+        bad_runner.transform()
         errs = bad_runner.run()
         self.assertEqual(err_count, len(errs))

--- a/test/rules/resources/properties/test_image_id.py
+++ b/test/rules/resources/properties/test_image_id.py
@@ -23,7 +23,7 @@ class TestPropertyVpcId(BaseRuleTestCase):
     """Test Password Property Configuration"""
     def setUp(self):
         """Setup"""
-        self.collection = RulesCollection()
+        super(TestPropertyVpcId, self).setUp()
         self.collection.register(ImageId())
 
     success_templates = [

--- a/test/templates/bad/transform_serverless_template.yaml
+++ b/test/templates/bad/transform_serverless_template.yaml
@@ -1,0 +1,79 @@
+---
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Resources:
+  myFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: index.handler
+      Runtime: nodejs4.3
+      CodeUri: 's3://testBucket/mySourceCode.zip'
+      AutoPublishAlias: live
+      DeploymentPreference:
+        Type: Linear10PercentEvery10Minutes
+      Events:
+        ThumbnailApi:
+          Type: Api
+          Properties:
+            Path: /thumbnail
+            Method: GET
+        S3Trigger:
+          Type: S3
+          Properties:
+            Bucket: !Ref myBucket
+            Events: s3:ObjectCreated:*
+        MySnsTrigger:
+          Type: SNS
+          Properties:
+            Topic: arn:aws:sns:us-east-1:123456789012:my_topic
+        MyKinesisTrigger:
+          Type: Kinesis
+          Properties:
+            Stream: arn:aws:kinesis:us-east-1:123456789012:stream/my-stream
+            StartingPosition: TRIM_HORIZON
+        MyDynamoDbTrigger:
+          Type: DynamoDb
+          Properties:
+            Stream: arn:aws:dynamodb:us-east-1:123456789012:table/TestTable/stream/2016-08-11T21:21:33.291
+            StartingPosition: TRIM_HORIZON
+        MyTimer:
+          Type: Schedule
+          Properties:
+            Input: rate(5 minutes)
+        OnTerminate:
+          Type: CloudWatchEvent
+          Properties:
+            Pattern:
+              detail:
+                state:
+                  - terminated
+  myBucket:
+    Type: AWS::S3::Bucket
+    Properties: {}
+  myFunctionRole:
+    Type: AWS::DynamoDB::Table
+    Properties:
+
+      KeySchema:
+      -
+        AttributeName: String
+        KeyType: String
+      ProvisionedThroughput:
+        WriteCapacityUnits: 5
+        ReadCapacityUnits: 10
+  myIamPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: "CFNUsers"
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          -
+            Effect: "Allow"
+            Action:
+              - "cloudformation:Describe*"
+              - "cloudformation:List*"
+              - "cloudformation:Get*"
+            Resource: "*"
+      Roles:
+      - !Ref ServerlessRestApi

--- a/test/templates/good/transform_serverless_api.yaml
+++ b/test/templates/good/transform_serverless_api.yaml
@@ -1,0 +1,24 @@
+---
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Resources:
+  myFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: index.handler
+      Runtime: nodejs4.3
+      CodeUri: 's3://testBucket/mySourceCode.zip'
+      DeploymentPreference:
+        Type: Linear10PercentEvery10Minutes
+      Events:
+        ThumbnailApi:
+          Type: Api
+          Properties:
+            Path: /thumbnail
+            Method: GET
+            RestApiId: !Ref myApi
+  myApi:
+    Type: AWS::Serverless::Api
+    Properties:
+      DefinitionUri: s3://bucket/swagger.json
+      StageName: dev

--- a/test/templates/good/transform_serverless_function.yaml
+++ b/test/templates/good/transform_serverless_function.yaml
@@ -1,0 +1,68 @@
+---
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Resources:
+  myFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: index.handler
+      Runtime: nodejs4.3
+      CodeUri: 's3://testBucket/mySourceCode.zip'
+      AutoPublishAlias: live
+      DeploymentPreference:
+        Type: Linear10PercentEvery10Minutes
+      Events:
+        ThumbnailApi:
+          Type: Api
+          Properties:
+            Path: /thumbnail
+            Method: GET
+        S3Trigger:
+          Type: S3
+          Properties:
+            Bucket: !Ref myBucket
+            Events: s3:ObjectCreated:*
+        MySnsTrigger:
+          Type: SNS
+          Properties:
+            Topic: arn:aws:sns:us-east-1:123456789012:my_topic
+        MyKinesisTrigger:
+          Type: Kinesis
+          Properties:
+            Stream: arn:aws:kinesis:us-east-1:123456789012:stream/my-stream
+            StartingPosition: TRIM_HORIZON
+        MyDynamoDbTrigger:
+          Type: DynamoDb
+          Properties:
+            Stream: arn:aws:dynamodb:us-east-1:123456789012:table/TestTable/stream/2016-08-11T21:21:33.291
+            StartingPosition: TRIM_HORIZON
+        MyTimer:
+          Type: Schedule
+          Properties:
+            Input: rate(5 minutes)
+        OnTerminate:
+          Type: CloudWatchEvent
+          Properties:
+            Pattern:
+              detail:
+                state:
+                  - terminated
+  myBucket:
+    Type: AWS::S3::Bucket
+    Properties: {}
+  myIamPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: "CFNUsers"
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          -
+            Effect: "Allow"
+            Action:
+              - "cloudformation:Describe*"
+              - "cloudformation:List*"
+              - "cloudformation:Get*"
+            Resource: "*"
+      Roles:
+      - !Ref myFunctionRole

--- a/test/templates/good/transform_serverless_globals.yaml
+++ b/test/templates/good/transform_serverless_globals.yaml
@@ -1,0 +1,22 @@
+---
+AWSTemplateFormatVersion: '2010-09-09'
+Globals:
+  Function:
+    Runtime: nodejs6.10
+    Timeout: 180
+    Handler: index.handler
+Transform: AWS::Serverless-2016-10-31
+Resources:
+  myFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: 's3://testBucket/mySourceCode.zip'
+      AutoPublishAlias: live
+      DeploymentPreference:
+        Type: Linear10PercentEvery10Minutes
+      Events:
+        ThumbnailApi:
+          Type: Api
+          Properties:
+            Path: /thumbnail
+            Method: GET

--- a/test/transforms/__init__.py
+++ b/test/transforms/__init__.py
@@ -14,3 +14,20 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
+from cfnlint import Runner, TransformsCollection, DEFAULT_TRANSFORMSDIR
+from testlib.testcase import BaseTestCase
+
+
+class BaseTransformTestCase(BaseTestCase):
+    """Used for Testing Transforms"""
+    def setUp(self):
+        """Setup"""
+        self.transforms = TransformsCollection()
+        self.transforms.extend(
+            TransformsCollection.create_from_directory(DEFAULT_TRANSFORMSDIR))
+
+    def helper_transform_template(self, template, test_function):
+        """Success test with template parameter"""
+        good_runner = Runner([], self.transforms, 'test', template, [], ['us-east-1'], [])
+        good_runner.transform()
+        self.assertTrue(test_function(good_runner.cfn.template))

--- a/test/transforms/__init__.py
+++ b/test/transforms/__init__.py
@@ -31,3 +31,9 @@ class BaseTransformTestCase(BaseTestCase):
         good_runner = Runner([], self.transforms, 'test', template, [], ['us-east-1'], [])
         good_runner.transform()
         self.assertTrue(test_function(good_runner.cfn.template))
+
+    def helper_transform_cfn(self, template, test_function):
+        """Test the bigger CFN template"""
+        good_runner = Runner([], self.transforms, 'test', template, [], ['us-east-1'], [])
+        good_runner.transform()
+        self.assertTrue(test_function(good_runner.cfn))

--- a/test/transforms/test_serverless_api.py
+++ b/test/transforms/test_serverless_api.py
@@ -1,0 +1,48 @@
+"""
+  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this
+  software and associated documentation files (the "Software"), to deal in the Software
+  without restriction, including without limitation the rights to use, copy, modify,
+  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+from . import BaseTransformTestCase
+
+
+class TestServerlessApi(BaseTransformTestCase):
+    """Test Transform API """
+    def setUp(self):
+        super(TestServerlessApi, self).setUp()
+        self.template = {
+            "AWSTemplateFormatVersion": "2010-09-09",
+            "Transform": "AWS::Serverless-2016-10-31",
+            "Resources": {
+                "myApi": {
+                    "Type": "AWS::Serverless::Api",
+                    "Properties": {
+                        "DefinitionUri": "s3://bucket/swagger.json",
+                        "StageName": "Dev"
+                    }
+                }
+            }
+        }
+
+    def test_function_autopublish_positive(self):
+        """Test converstion of serverless function to include AutoPublish"""
+
+        def test_success(template):
+            """Test success"""
+            resources = template.get('Resources', {})
+            if resources.get('myApiDevStage') and resources.get('myApiDeploymentSHA'):
+                return True
+            return False
+
+        self.helper_transform_template(self.template, test_success)

--- a/test/transforms/test_serverless_functions.py
+++ b/test/transforms/test_serverless_functions.py
@@ -1,0 +1,85 @@
+"""
+  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this
+  software and associated documentation files (the "Software"), to deal in the Software
+  without restriction, including without limitation the rights to use, copy, modify,
+  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+from . import BaseTransformTestCase
+
+
+class TestServerlessFunction(BaseTransformTestCase):
+    """Test Rules Get Att """
+    def setUp(self):
+        super(TestServerlessFunction, self).setUp()
+        self.template = {
+            "AWSTemplateFormatVersion": "2010-09-09",
+            "Transform": "AWS::Serverless-2016-10-31",
+            "Resources": {
+                "myFunction": {
+                    "Type": "AWS::Serverless::Function",
+                    "Properties": {
+                        "Handler": "index.handler",
+                        "Runtime": "nodejs4.3",
+                        "CodeUri": "s3://testBucket/mySourceCode.zip"
+                    }
+                }
+            }
+        }
+
+    def test_function_autopublish_positive(self):
+        """Test converstion of serverless function to include AutoPublish"""
+
+        def test_success(template):
+            """Test success"""
+            resources = template.get('Resources', {})
+            if resources.get('myFunctionVersionLive') and resources.get('myFunctionAliasLive'):
+                return True
+            return False
+
+        self.template['Resources']['myFunction']['Properties']['AutoPublishAlias'] = 'Live'
+
+        self.helper_transform_template(self.template, test_success)
+
+    def test_function_role_positive(self):
+        """Test converstion of serverless function to include Role"""
+
+        def test_success(template):
+            """Test success"""
+            resource = template.get('Resources', {}).get('myFunctionRole')
+            if resource:
+                return True
+            return False
+
+        self.helper_transform_template(self.template, test_success)
+
+    def test_function_event_api_positive(self):
+        """Test converstion of serverless function to API Event"""
+
+        def test_success(template):
+            """Test success"""
+            resources = template.get('Resources', {})
+            if resources.get('ServerlessRestApi') and resources.get('ServerlessRestApiProdStage'):
+                return True
+            return False
+
+        self.template['Resources']['myFunction']['Properties']['Events'] = {
+            "ThumbnailApi": {
+                "Type": "Api",
+                "Properties": {
+                    "Path": "/thumbnail",
+                    "Method": "GET"
+                }
+            }
+        }
+
+        self.helper_transform_template(self.template, test_success)

--- a/test/transforms/test_serverless_globals.py
+++ b/test/transforms/test_serverless_globals.py
@@ -1,0 +1,53 @@
+"""
+  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this
+  software and associated documentation files (the "Software"), to deal in the Software
+  without restriction, including without limitation the rights to use, copy, modify,
+  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+from . import BaseTransformTestCase
+
+
+class TestServerlessGlobals(BaseTransformTestCase):
+    """Test Transform Globals """
+    def setUp(self):
+        super(TestServerlessGlobals, self).setUp()
+        self.template = {
+            "AWSTemplateFormatVersion": "2010-09-09",
+            "Transform": "AWS::Serverless-2016-10-31",
+            "Globals": {
+                "Function": {
+                    "Runtime": "nodejs6.10",
+                    "Timeout": 180,
+                    "Handler": "index.handler"
+                }
+            },
+            "Resources": {
+                "myFunction": {
+                    "Type": "AWS::Serverless::Function",
+                    "Properties": {
+                        "CodeUri": "s3://testBucket/mySourceCode.zip"
+                    }
+                }
+            }
+        }
+
+    def test_function_autopublish_positive(self):
+        """Test converstion of serverless function to include AutoPublish"""
+
+        def test_success(cfn):
+            """Test success"""
+            if 'Globals' in cfn.sections:
+                return True
+            return False
+
+        self.helper_transform_cfn(self.template, test_success)

--- a/update-cfn-specs.sh
+++ b/update-cfn-specs.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+curl --compressed -o src/cfnlint/data/CloudSpecs/ap-south-1.json https://d2senuesg1djtx.cloudfront.net/latest/gzip/CloudFormationResourceSpecification.json
+curl --compressed -o src/cfnlint/data/CloudSpecs/ap-northeast-2.json https://d1ane3fvebulky.cloudfront.net/latest/gzip/CloudFormationResourceSpecification.json
+curl --compressed -o src/cfnlint/data/CloudSpecs/ap-southeast-2.json https://d2stg8d246z9di.cloudfront.net/latest/gzip/CloudFormationResourceSpecification.json
+curl --compressed -o src/cfnlint/data/CloudSpecs/ap-southeast-1.json https://doigdx0kgq9el.cloudfront.net/latest/gzip/CloudFormationResourceSpecification.json
+curl --compressed -o src/cfnlint/data/CloudSpecs/ap-northeast-1.json https://d33vqc0rt9ld30.cloudfront.net/latest/gzip/CloudFormationResourceSpecification.json
+curl --compressed -o src/cfnlint/data/CloudSpecs/ca-central-1.json https://d2s8ygphhesbe7.cloudfront.net/latest/gzip/CloudFormationResourceSpecification.json
+curl --compressed -o src/cfnlint/data/CloudSpecs/eu-central-1.json https://d1mta8qj7i28i2.cloudfront.net/latest/gzip/CloudFormationResourceSpecification.json
+curl --compressed -o src/cfnlint/data/CloudSpecs/eu-west-2.json https://d1742qcu2c1ncx.cloudfront.net/latest/gzip/CloudFormationResourceSpecification.json
+curl --compressed -o src/cfnlint/data/CloudSpecs/eu-west-1.json https://d3teyb21fexa9r.cloudfront.net/latest/gzip/CloudFormationResourceSpecification.json
+curl --compressed -o src/cfnlint/data/CloudSpecs/sa-east-1.json https://d3c9jyj3w509b0.cloudfront.net/latest/gzip/CloudFormationResourceSpecification.json
+curl --compressed -o src/cfnlint/data/CloudSpecs/us-east-1.json https://d1uauaxba7bl26.cloudfront.net/latest/gzip/CloudFormationResourceSpecification.json
+curl --compressed -o src/cfnlint/data/CloudSpecs/us-east-2.json https://dnwj8swjjbsbt.cloudfront.net/latest/gzip/CloudFormationResourceSpecification.json
+curl --compressed -o src/cfnlint/data/CloudSpecs/us-west-1.json https://d68hl49wbnanq.cloudfront.net/latest/gzip/CloudFormationResourceSpecification.json
+curl --compressed -o src/cfnlint/data/CloudSpecs/us-west-2.json https://d201a2mn26r7lk.cloudfront.net/latest/gzip/CloudFormationResourceSpecification.json


### PR DESCRIPTION
*Issue #, if available:* #15 

*Description of changes:*
- Include a base transformation for Serverless Transforms CloudFormation templates
  - Includes Support for Globals as a top level section
  - Translates Serverless::Function and Serverless::Api to its sub resources along for Ref and GetAtt to work.
- Pluggable model to support future transformations as needed
- Fix an issue that occurs when numbers of type Long are met
- Helper script to update the CloudFormation Specs locally

Basic logic is that the items will happen in the following order:
1. Transformation
1.  Rules 

If there is an issue with Transformation an error will be shown and the rules will not run.

This change does not include:
- Testing Serverless Resources for the appropriate attributes
- Expanding Resources (Function and Api) to completely valid resources.  The goal is to support Ref and GetAtt which we will get from this change.  Not to support translating the template into a working template.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
