### PR TITLE
Add support for primitivetype Long

### DIFF
--- a/src/cfnlint/rules/resources/properties/Properties.py
+++ b/src/cfnlint/rules/resources/properties/Properties.py
@@ -52,7 +52,7 @@ class Properties(CloudFormationLintRule):
                         message = "Property %s has an illegal function %s" % ('/'.join(map(str, proppath)), sub_key)
                         matches.append(RuleMatch(proppath, message))
         elif isinstance(value, str):
-            if primtype in ['Integer', 'Double']:
+            if primtype in ['Integer', 'Double', 'Long']:
                 try:
                     int(value)
                 except ValueError:
@@ -72,7 +72,7 @@ class Properties(CloudFormationLintRule):
                 message = "Property %s should be of type %s" % ('/'.join(map(str, proppath)), primtype)
                 matches.append(RuleMatch(proppath, message))
         elif isinstance(value, int):
-            if primtype in ["String", "Double"]:
+            if primtype in ["String", "Double", "Long"]:
                 pass
                 # LOGGER.info("%s is an int but should be %s for resource %s",
                 #            text[prop], primtype, resourcename)


### PR DESCRIPTION
There’s a `long` type, currently only used with DynamoDb Provisioned
Throughput and VPN gateway.

Currently the linter breaks with:

```
E3002 - Property Resources/DynamoDbTable/Properties/ProvisionedThroughput/ReadCapacityUnits should be of type Integer (line: 205)

```
Used a custom formatter output

YAML file contains clean integer values:

```
ProvisionedThroughput:
  ReadCapacityUnits: 5
  WriteCapacityUnits: 5
```

This PR adds the correct support for the long datatype

Quick snippet of the Throughput specification:
```
    "AWS::DynamoDB::Table.ProvisionedThroughput": {
      "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-dynamodb-provisionedthroughput.html",
      "Properties": {
        "ReadCapacityUnits": {
          "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-dynamodb-provisionedthroughput.html#cfn-dynamodb-provisionedthroughput-readcapacityunits",
          "PrimitiveType": "Long",
          "Required": true,
          "UpdateType": "Mutable"
        },
        "WriteCapacityUnits": {
          "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-dynamodb-provisionedthroughput.html#cfn-dynamodb-provisionedthroughput-writecapacityunits",
          "PrimitiveType": "Long",
          "Required": true,
          "UpdateType": "Mutable"
        }
      }
    },
```