### PR TITLE
Add override spec mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ may need to manually remove the cfn-lint binary.
 | --ignore-checks | ignore_checks | [IGNORE_CHECKS [IGNORE_CHECKS ...]] | Only check rules whose id do not match these values |
 | --log-level | log_level | {info, debug} | Log Level |
 | --update-specs | | | Update the CloudFormation Specs.  You may need sudo to run this.  You will need internet access when running this command |
+| --override-spec | | filename | Spec-style file containing custom definitions. Can be used to override CloudFormation definitions |
 | --version | | | Version of cfn-lint |
 
 ### Command Line

--- a/src/cfnlint/__main__.py
+++ b/src/cfnlint/__main__.py
@@ -156,7 +156,7 @@ def main():
             elif e.errno == 13:
                 LOGGER.error("Permission denied when accessing override spec file: %s", filename)
                 sys.exit(1)
-        except (json.decoder.JSONDecodeError, ScannerError) as err:
+        except (ValueError) as err:
             LOGGER.error('Override spec file %s is malformed: %s', filename, err)
             sys.exit(1)
 

--- a/src/cfnlint/__main__.py
+++ b/src/cfnlint/__main__.py
@@ -114,6 +114,11 @@ def main():
     )
 
     parser.add_argument(
+        '--override-spec', dest='override_spec',
+        help='A CloudFormation Spec override file that allows customization'
+    )
+
+    parser.add_argument(
         '--version', help='Version of cfn-lint', action='version',
         version='%(prog)s {version}'.format(version=__version__)
     )
@@ -133,6 +138,27 @@ def main():
             formatter = formatters.ParseableFormatter()
     else:
         formatter = formatters.Formatter()
+
+    if vars(args)['override_spec']:
+        try:
+            filename = vars(args)['override_spec']
+            custom_spec_data = json.load(open(filename))
+
+            cfnlint.helpers.override_specs(custom_spec_data)
+
+        except IOError as e:
+            if e.errno == 2:
+                LOGGER.error("Override spec file not found: %s", filename)
+                sys.exit(1)
+            elif e.errno == 21:
+                LOGGER.error("Override spec file references a directory, not a file: %s", filename)
+                sys.exit(1)
+            elif e.errno == 13:
+                LOGGER.error("Permission denied when accessing override spec file: %s", filename)
+                sys.exit(1)
+        except (json.decoder.JSONDecodeError, ScannerError) as err:
+            LOGGER.error('Override spec file %s is malformed: %s', filename, err)
+            sys.exit(1)
 
     if vars(args)['update_specs']:
         cfnlint.helpers.update_resource_specs()

--- a/src/cfnlint/helpers.py
+++ b/src/cfnlint/helpers.py
@@ -52,6 +52,24 @@ RESOURCE_SPECS = {}
 for reg in REGIONS:
     RESOURCE_SPECS[reg] = load_resources(filename=("/data/CloudSpecs/%s.json" % reg))
 
+def merge_spec(source, destination):
+    """ Recursive merge spec dict """
+
+    for key, value in source.items():
+        if isinstance(value, dict):
+            node = destination.setdefault(key, {})
+            merge_spec(value, node)
+        else:
+            destination[key] = value
+
+    return destination
+
+def override_specs(override_spec_data):
+    """ Override Resource Specs """
+
+    # Merge override spec file into the AWS Resource specification
+    for region, spec in RESOURCE_SPECS.items():
+        RESOURCE_SPECS[region] = merge_spec(override_spec_data, spec)
 
 def update_resource_specs():
     """ Update Resource Specs """

--- a/src/cfnlint/helpers.py
+++ b/src/cfnlint/helpers.py
@@ -47,10 +47,7 @@ def load_resources(filename='/data/CloudSpecs/us-east-1.json'):
 
     return data
 
-
 RESOURCE_SPECS = {}
-for reg in REGIONS:
-    RESOURCE_SPECS[reg] = load_resources(filename=("/data/CloudSpecs/%s.json" % reg))
 
 def merge_spec(source, destination):
     """ Recursive merge spec dict """
@@ -70,6 +67,13 @@ def override_specs(override_spec_data):
     # Merge override spec file into the AWS Resource specification
     for region, spec in RESOURCE_SPECS.items():
         RESOURCE_SPECS[region] = merge_spec(override_spec_data, spec)
+
+def initialize_specs():
+    """ Reload Resource Specs """
+    for reg in REGIONS:
+        RESOURCE_SPECS[reg] = load_resources(filename=("/data/CloudSpecs/%s.json" % reg))
+
+initialize_specs()
 
 def update_resource_specs():
     """ Update Resource Specs """

--- a/test/module/test_override_spec.py
+++ b/test/module/test_override_spec.py
@@ -1,0 +1,57 @@
+"""
+  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this
+  software and associated documentation files (the "Software"), to deal in the Software
+  without restriction, including without limitation the rights to use, copy, modify,
+  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+from cfnlint import Runner, RulesCollection
+from cfnlint.rules.resources.properties.Required import Required  # pylint: disable=E0401
+from testlib.testcase import BaseTestCase
+import cfnlint.helpers
+import json
+
+class BaseRuleTestCase(BaseTestCase):
+    """Used for Testing Rules"""
+
+    def setUp(self):
+        """Setup"""
+        self.collection = RulesCollection()
+        self.collection.register(Required())
+
+    def tearDown(self):
+        """Tear Down"""
+        # Reset the Spec override to prevent other tests to fail
+        cfnlint.helpers.initialize_specs()
+
+    def test_success_run(self):
+        """Success test"""
+        filename = 'templates/good/override_required.yaml'
+        template = self.load_template(filename)
+        custom_spec = json.load(open('templates/override_spec/required.json'))
+
+        cfnlint.helpers.override_specs(custom_spec)
+
+        good_runner = Runner(self.collection, filename, template, [], ['us-east-1'], [])
+        self.assertEqual([], good_runner.run())
+
+    def test_fail_run(self):
+        """Failure test"""
+        filename = 'templates/bad/override_required.yaml'
+        template = self.load_template(filename)
+        custom_spec = json.load(open('templates/override_spec/required.json'))
+
+        cfnlint.helpers.override_specs(custom_spec)
+
+        bad_runner = Runner(self.collection, filename, template, [], ['us-east-1'], [])
+        errs = bad_runner.run()
+        self.assertEqual(1, len(errs))

--- a/test/templates/bad/override_required.yaml
+++ b/test/templates/bad/override_required.yaml
@@ -1,0 +1,10 @@
+---
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  Custom required property
+Resources:
+  myS3Bucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      # Missing BucketName
+      AccessControl: "Private"

--- a/test/templates/good/override_required.yaml
+++ b/test/templates/good/override_required.yaml
@@ -1,0 +1,9 @@
+---
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  Custom required property
+Resources:
+  myS3Bucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: "my-bucket-name"

--- a/test/templates/override_spec/required.json
+++ b/test/templates/override_spec/required.json
@@ -1,0 +1,11 @@
+{
+  "ResourceTypes": {
+    "AWS::S3::Bucket": {
+      "Properties": {
+        "BucketName": {
+          "Required": true
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Add a simple mechanism to override/alter/customize the AWS Resource Specification.

Example:

```
{
  "PropertyTypes": {
    "AWS::S3::Bucket.WebsiteConfiguration": {
      "Properties": {
        "ErrorDocument": {
          "Required": true
        }
      }
    }
  },
  "ResourceTypes": {
    "AWS::S3::Bucket": {
      "Properties": {
        "BucketName": {
          "Required": true
        }
      }
    }
  }
}

```

This files makes the Bucketname required, just like the Errordocument
(if a WebsiteConfiguration is specified)

This gives people the ability to "customize" the linting rules. Say a company wants to enforce certain values to be specified (like `BucketName`, `Encryption` or `Tags`) this allows the overriding of the AWS specifications.

