### PR TITLE
Fix required property checks

### DIFF
--- a/test/module/test_rules_collections.py
+++ b/test/module/test_rules_collections.py
@@ -60,7 +60,7 @@ class TestTemplate(BaseTestCase):
 
         matches = list()
         matches.extend(self.rules.run(filename, cfn, []))
-        assert(len(matches) == 25)
+        assert(len(matches) == 26)
 
     def test_fail_sub_properties_run(self):
         """Test failure run"""

--- a/test/rules/resources/properties/test_required.py
+++ b/test/rules/resources/properties/test_required.py
@@ -31,4 +31,8 @@ class TestResourceConfiguration(BaseRuleTestCase):
 
     def test_file_negative(self):
         """Test failure"""
-        self.helper_file_negative('templates/bad/generic.yaml', 7)
+        self.helper_file_negative('templates/bad/properties_required.yaml', 3)
+
+    def test_file_negative_generic(self):
+        """Generic Test failure"""
+        self.helper_file_negative('templates/bad/generic.yaml', 8)

--- a/test/templates/bad/properties_required.yaml
+++ b/test/templates/bad/properties_required.yaml
@@ -1,0 +1,43 @@
+---
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  Custom required property
+Parameters:
+  Environment:
+    Type: "String"
+    Default: "production"
+Conditions:
+  IsProduction: !Equals [ !Ref Environment, "production" ]
+Resources:
+  myS3Bucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: "my-bucket-name"
+      CorsConfiguration:
+        CorsRules:
+          - AllowedOrigins:
+              - "*"
+          # Missing: AllowedHeaders
+  myConstraintSet:
+    Type: "AWS::WAF::SizeConstraintSet"
+    Properties:
+      Name: "constraint-set"
+      # Missing: SizeConstraints
+  ApplicationLoadBalancerCertificate:
+    Type: "AWS::CertificateManager::Certificate"
+    Properties:
+      DomainName: "example.com"
+      DomainValidationOptions:
+        - DomainName: "mydomain.example.com"
+          ValidationDomain: "example.com"
+        - !If
+          - AddCustomComain
+          -
+            DomainName: "*.customdomain.com"
+            # Missing: #ValidationDomain
+          - !Ref "AWS::NoValue"
+      SubjectAlternativeNames:
+        - !If
+          - AddCustomComain
+          - "*.customdomain.com"
+          - !Ref "AWS::NoValue"

--- a/test/templates/good/resources_lambda.yaml
+++ b/test/templates/good/resources_lambda.yaml
@@ -52,5 +52,7 @@ Resources:
     Properties:
       Handler: index.handler
       Role: !GetAtt myLambdaExecutionRole.Arn
+      Code:
+        ZipFile: "amilookup.zip"
       Runtime: !Ref myParameterRuntime
       MemorySize: !Ref myParameterMemorySize


### PR DESCRIPTION
Found out the required property linter missed/broke on certain scenario's:

- Required Properties that are not `PrimitiveType` did not get linted
- Conditionals were not supported completed correctly

In this PR:
- Added a `bad` test template with these scenario's (`properties_required.yaml`)
- Rewritten part of the required check to solve the issues.
- Corrected existing `good` template that was actually not good
- Updated generic bad template since there's another issue now in there (`Code` missing is the Lambda function)

