### PR TITLE
Check for duplicates

### DIFF
--- a/src/cfnlint/__main__.py
+++ b/src/cfnlint/__main__.py
@@ -19,6 +19,7 @@ import argparse
 import logging
 import json
 from yaml.parser import ParserError, ScannerError
+from cfnlint.parser import DuplicateError
 import cfnlint.helpers
 from cfnlint import RulesCollection, TransformsCollection, Match
 import cfnlint.formatters as formatters
@@ -78,6 +79,9 @@ def main():
             elif e.errno == 13:
                 LOGGER.error('Permission denied when accessing template file: %s', filename)
                 sys.exit(1)
+        except DuplicateError as err:
+            LOGGER.error('Template %s contains duplicates: %s', filename, err)
+            sys.exit(1)
         except (ParserError, ScannerError) as err:
             try:
                 template = json.load(open(filename), cls=cfnlint.cfn_json.CfnJSONDecoder)
@@ -144,7 +148,6 @@ def main():
             custom_spec_data = json.load(open(filename))
 
             cfnlint.helpers.override_specs(custom_spec_data)
-
         except IOError as e:
             if e.errno == 2:
                 LOGGER.error('Override spec file not found: %s', filename)

--- a/src/cfnlint/parser.py
+++ b/src/cfnlint/parser.py
@@ -77,7 +77,7 @@ class NodeConstructor(SafeConstructor):
 
         # Check for duplicate keys on the current level, this is not desirable
         # because a dict does not support this. It overwrites it with the last
-        # occurance, which can give unexpted results
+        # occurance, which can give unexpected results
         mapping = {}
         for key_node, value_node in node.value:
             key = self.construct_object(key_node, False)

--- a/test/module/test_duplicate.py
+++ b/test/module/test_duplicate.py
@@ -17,6 +17,7 @@
 import json
 from cfnlint import Template, RulesCollection, DEFAULT_RULESDIR  # pylint: disable=E0401
 import cfnlint.parser  # pylint: disable=E0401
+import cfnlint.cfn_json  # pylint: disable=E0401
 from testlib.testcase import BaseTestCase
 
 
@@ -46,7 +47,23 @@ class TestDuplocate(BaseTestCase):
 
         assert(True)
 
+    def test_fail_json_run(self):
+        """Test failure run"""
+
     def test_fail_run(self):
+        """Test failure run"""
+
+        filename = 'templates/bad/duplicate.json'
+
+        try:
+            json.load(open(filename), cls=cfnlint.cfn_json.CfnJSONDecoder)
+        except cfnlint.cfn_json.JSONDecodeError:
+            assert(True)
+            return
+
+        assert(False)
+
+    def test_fail_yaml_run(self):
         """Test failure run"""
 
         filename = 'templates/bad/duplicate.yaml'

--- a/test/module/test_duplicate.py
+++ b/test/module/test_duplicate.py
@@ -1,0 +1,63 @@
+"""
+  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this
+  software and associated documentation files (the "Software"), to deal in the Software
+  without restriction, including without limitation the rights to use, copy, modify,
+  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+import json
+from cfnlint import Template, RulesCollection, DEFAULT_RULESDIR  # pylint: disable=E0401
+import cfnlint.parser  # pylint: disable=E0401
+from testlib.testcase import BaseTestCase
+
+
+class TestDuplocate(BaseTestCase):
+    """Test Duplicates Parsing """
+    def setUp(self):
+        """ SetUp template object"""
+        self.rules = RulesCollection()
+        rulesdirs = [DEFAULT_RULESDIR]
+        for rulesdir in rulesdirs:
+            self.rules.extend(
+                RulesCollection.create_from_directory(rulesdir))
+
+    def test_success_run(self):
+        """Test success run"""
+
+        filename = 'templates/good/generic.yaml'
+
+        try:
+            fp = open(filename)
+            loader = cfnlint.parser.MarkedLoader(fp.read())
+            loader.add_multi_constructor('!', cfnlint.parser.multi_constructor)
+            template = loader.get_single_data()
+        except cfnlint.parser.DuplicateError:
+            assert(False)
+            return
+
+        assert(True)
+
+    def test_fail_run(self):
+        """Test failure run"""
+
+        filename = 'templates/bad/duplicate.yaml'
+
+        try:
+            fp = open(filename)
+            loader = cfnlint.parser.MarkedLoader(fp.read())
+            loader.add_multi_constructor('!', cfnlint.parser.multi_constructor)
+            template = loader.get_single_data()
+        except cfnlint.parser.DuplicateError:
+            assert(True)
+            return
+
+        assert(False)

--- a/test/templates/bad/duplicate.json
+++ b/test/templates/bad/duplicate.json
@@ -1,0 +1,24 @@
+{
+	"AWSTemplateFormatVersion": "2010-09-09",
+	"Description": "Some duplicate resources",
+	"Resources": {
+	    "MySNSTopic" : {
+	       "Type" : "AWS::SNS::Topic",
+	       "Properties" : {
+	          "TopicName" : "not-deployed-topic"
+	       }
+	    },
+		"MyEipNat": {
+			"Type": "AWS::EC2::EIP",
+			"Properties": {
+				"Domain": "vpc"
+			}
+		},
+		"MySNSTopic" : {
+		   "Type" : "AWS::SNS::Topic",
+		   "Properties" : {
+		      "TopicName" : "deployed-topic"
+		   }
+		}
+	}
+}

--- a/test/templates/bad/duplicate.yaml
+++ b/test/templates/bad/duplicate.yaml
@@ -1,0 +1,12 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  mySnsTopic:
+    Type: AWS::SNS::Topic
+    Parameters:
+      TopicName: "unused-topic-name"
+  myS3Bucket:
+    Type: AWS::S3::Bucket
+  mySnsTopic:
+    Type: AWS::SNS::Topic
+    Parameters:
+      TopicName: "used-topic-name"

--- a/test/templates/quickstart/vpc-management.json
+++ b/test/templates/quickstart/vpc-management.json
@@ -632,23 +632,6 @@
 				}
 			}
 		},
-		"rENIProductionBastion": {
-			"Type": "AWS::EC2::NetworkInterface",
-			"DependsOn": "rGWAttachmentMgmtIGW",
-			"Properties": {
-				"SubnetId": {
-					"Ref": "rManagementDMZSubnetA"
-				},
-				"GroupSet": [{
-					"Ref": "rSecurityGroupBastion"
-				}],
-				"Description": "Interface for Bastion device",
-				"Tags": [{
-					"Key": "Network",
-					"Value": "MgmtBastionDevice"
-				}]
-			}
-		},
 		"rMgmtBastionInstance": {
 			"Type": "AWS::EC2::Instance",
 			"DependsOn": ["rDeepSecurityInfrastructureTemplate", "rGWAttachmentMgmtIGW"],


### PR DESCRIPTION
*Issue #35*

Now breaks on templates with duplicate resources. Since duplicates don't exists in a dict, it's "imposible" to check this is a normal rule.

Now hooks in the loading and reports the duplicate key name (and the line number) and throws an error at loading. Which sort of makes sense since the template itself is actually "invalid"