### PR TITLE
Add rule for unused Conditions

### DIFF
--- a/src/cfnlint/rules/conditions/Used.py
+++ b/src/cfnlint/rules/conditions/Used.py
@@ -1,0 +1,63 @@
+"""
+  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this
+  software and associated documentation files (the "Software"), to deal in the Software
+  without restriction, including without limitation the rights to use, copy, modify,
+  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+from cfnlint import CloudFormationLintRule
+from cfnlint import RuleMatch
+
+
+class Used(CloudFormationLintRule):
+    """Check if Conditions are configured correctly"""
+    id = 'W8001'
+    shortdesc = 'Check if Conditions are Used'
+    description = 'Making sure the conditions defined are used'
+    tags = ['base', 'conditions']
+
+    def match(self, cfn):
+        """Check CloudFormation Conditions"""
+
+        matches = list()
+        ref_conditions = list()
+
+        conditions = cfn.template.get('Conditions', {})
+
+        if conditions:
+
+            # Get all "If's" that reference a Condition
+            iftrees = cfn.search_deep_keys('Fn::If')
+
+            for iftree in iftrees:
+
+                if isinstance(iftree[-1], list):
+                    ref_conditions.append(iftree[-1][0])
+                else:
+                    ref_conditions.append(iftree[-1])
+
+            # Get resource's Conditions
+            for _, resource_values in cfn.get_resources().items():
+
+                if 'Condition' in resource_values:
+                    ref_conditions.append(resource_values['Condition'])
+
+            # Check if the confitions are used
+            for condname, _ in conditions.items():
+                if condname not in ref_conditions:
+                    message = 'Condition {0} not used'
+                    matches.append(RuleMatch(
+                        ['Conditions', condname],
+                        message.format(condname)
+                    ))
+
+        return matches

--- a/test/module/test_cfn_json.py
+++ b/test/module/test_cfn_json.py
@@ -49,7 +49,7 @@ class TestCfnJson(BaseTestCase):
             },
             "vpc": {
                 "filename": 'templates/quickstart/vpc.json',
-                "failures": 0
+                "failures": 1
             }
         }
 

--- a/test/module/test_cfn_json.py
+++ b/test/module/test_cfn_json.py
@@ -45,7 +45,7 @@ class TestCfnJson(BaseTestCase):
             },
             "vpc_management": {
                 "filename": 'templates/quickstart/vpc-management.json',
-                "failures": 14
+                "failures": 15
             },
             "vpc": {
                 "filename": 'templates/quickstart/vpc.json',
@@ -63,7 +63,7 @@ class TestCfnJson(BaseTestCase):
 
             matches = list()
             matches.extend(self.rules.run(filename, cfn, []))
-            assert(len(matches) == failures)
+            assert len(matches) == failures, 'Expected {} failures, got {}'.format(failures, len(matches))
 
     def test_fail_run(self):
         """Test failure run"""

--- a/test/rules/conditions/test_used.py
+++ b/test/rules/conditions/test_used.py
@@ -1,0 +1,57 @@
+"""
+  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this
+  software and associated documentation files (the "Software"), to deal in the Software
+  without restriction, including without limitation the rights to use, copy, modify,
+  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+from cfnlint.rules.conditions.Used import Used  # pylint: disable=E0401
+from .. import BaseRuleTestCase
+
+
+class TestUsedConditions(BaseRuleTestCase):
+    """Test template mapping configurations"""
+    def setUp(self):
+        """Setup"""
+        super(TestUsedConditions, self).setUp()
+        self.collection.register(Used())
+
+    success_templates = [
+        'templates/good/generic.yaml',
+        'templates/quickstart/nist_application.yaml',
+        'templates/quickstart/nist_config_rules.yaml',
+        'templates/quickstart/nist_iam.yaml',
+        'templates/quickstart/nist_logging.yaml',
+        'templates/quickstart/nist_vpc_production.yaml',
+        'templates/quickstart/openshift_master.yaml',
+        'templates/quickstart/openshift.yaml',
+        'templates/quickstart/cis_benchmark.yaml',
+        'templates/good/properties_ec2_vpc.yaml',
+        'templates/good/minimal.yaml',
+        'templates/good/transform.yaml',
+        'templates/good/conditions.yaml',
+        'templates/good/properties_elb.yaml',
+        'templates/good/functions_sub.yaml',
+        'templates/good/functions_cidr.yaml',
+        'templates/good/resources_lambda.yaml',
+        'templates/good/transform_serverless_api.yaml',
+        'templates/good/transform_serverless_function.yaml',
+        'templates/good/transform_serverless_globals.yaml',
+    ]
+
+    def test_file_positive(self):
+        """Test Positive"""
+        self.helper_file_positive()
+
+    def test_file_negative(self):
+        """Test failure"""
+        self.helper_file_negative('templates/bad/conditions.yaml', 3)

--- a/test/templates/bad/conditions.yaml
+++ b/test/templates/bad/conditions.yaml
@@ -39,6 +39,7 @@ Parameters:
 Conditions:
   CreateProdResources: !Equals [ !Ref EnvType, prod ]
   BadCondition: String
+  UnusedCondition: !Equals [ !Ref EnvType, prod ]
   TooManyConditions:
     Fn::Equals: [ !Ref EnvType, prod ]
     Fn::Not: !Equals [ !Ref EnvType, prod ]

--- a/test/templates/quickstart/README.md
+++ b/test/templates/quickstart/README.md
@@ -1,0 +1,4 @@
+# Quickstart templates
+
+These templates originate from different [AWS Quickstart](https://aws.amazon.com/quickstart/) guides.
+Please don't alter these templates.


### PR DESCRIPTION
*Issue #39:*

Added a check to see if Conditionals specified are acutally used, made it a warning (`W8001`)

Added test and updated the existing test files to match. Found a gltch in the  `_search_deep_keys ` method that stopped the search if a key if found. But conditions can be used in conditions again (See: https://github.com/awslabs/cfn-python-lint/blob/master/test/templates/good/conditions.yaml#L29 ) 


Found more errors in the quickstart templates when applying this.
In regard to the quickstart templates, added a quick first version of a Readme stating that these templates are "as is" and should not be modified.