### PR TITLE
Add Rule on undefined Conditions

### DIFF
--- a/src/cfnlint/__init__.py
+++ b/src/cfnlint/__init__.py
@@ -541,7 +541,7 @@ class Template(object):
                 if key == searchText:
                     pathprop.append(cfndict[key])
                     keys.append(pathprop)
-                elif isinstance(cfndict[key], dict):
+                if isinstance(cfndict[key], dict):
                     keys.extend(self._search_deep_keys(searchText, cfndict[key], pathprop))
                 elif isinstance(cfndict[key], list):
                     for index, item in enumerate(cfndict[key]):

--- a/src/cfnlint/rules/functions/IfExist.py
+++ b/src/cfnlint/rules/functions/IfExist.py
@@ -1,0 +1,57 @@
+"""
+  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this
+  software and associated documentation files (the "Software"), to deal in the Software
+  without restriction, including without limitation the rights to use, copy, modify,
+  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+from cfnlint import CloudFormationLintRule
+from cfnlint import RuleMatch
+
+
+class IfExist(CloudFormationLintRule):
+    """Check if Condition exists"""
+    id = 'E1025'
+    shortdesc = 'Check if Conditions exist'
+    description = 'Making sure the Conditions used in Fn:If functions exist'
+    tags = ['base', 'functions', 'if']
+
+    def match(self, cfn):
+        """Check CloudFormation Conditions"""
+
+        matches = list()
+        if_conditions = list()
+
+        # Build the list of functions
+        iftrees = cfn.search_deep_keys('Fn::If')
+
+        # Get the conditions used in the functions
+        for iftree in iftrees:
+            if isinstance(iftree[-1], list):
+                if_condition = iftree[-1][0]
+            else:
+                if_condition = iftree[-1]
+            # Condations can be referenced multiple times, check them once
+            if not if_condition in if_conditions:
+                if_conditions.append(if_condition)
+
+        conditions = cfn.template.get('Conditions', {})
+
+        for if_condition in if_conditions:
+            if if_condition not in conditions:
+                message = 'Referenced condition {0} not specified'
+                matches.append(RuleMatch(
+                    ['Conditions', if_condition],
+                    message.format(if_condition)
+                ))
+
+        return matches

--- a/test/rules/functions/test_if_exist.py
+++ b/test/rules/functions/test_if_exist.py
@@ -14,16 +14,16 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-from cfnlint.rules.functions.RefExist import RefExist  # pylint: disable=E0401
+from cfnlint.rules.functions.IfExist import IfExist  # pylint: disable=E0401
 from .. import BaseRuleTestCase
 
 
-class TestRulesRefExist(BaseRuleTestCase):
-    """Test Rules Ref exists """
+class TestRulesIfExist(BaseRuleTestCase):
+    """Test Rules If conditions exist """
     def setUp(self):
         """Setup"""
-        super(TestRulesRefExist, self).setUp()
-        self.collection.register(RefExist())
+        super(TestRulesIfExist, self).setUp()
+        self.collection.register(IfExist())
 
     def test_file_positive(self):
         """Test Positive"""
@@ -31,4 +31,4 @@ class TestRulesRefExist(BaseRuleTestCase):
 
     def test_file_negative(self):
         """Test failure"""
-        self.helper_file_negative('templates/bad/functions_ref.yaml', 5)
+        self.helper_file_negative('templates/bad/conditions.yaml', 2)


### PR DESCRIPTION
*Issue #39 *

Added a Rule to check if the Conditions referenced in `Fn::If` functions are actually defined. The reverse check from PR #46 

This rule throws an error (`E1025` )

Added the same fix on the recursive function `_search_deep_keys ` so the fail template (`bad/conditions.yaml`) fails correctly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
