### PR TITLE
Tweak the unsupported resource type message

### DIFF
--- a/src/cfnlint/rules/resources/Configuration.py
+++ b/src/cfnlint/rules/resources/Configuration.py
@@ -73,7 +73,7 @@ class Configuration(CloudFormationLintRule):
                     if region in cfn.regions:
                         if resource_type not in specs['ResourceTypes']:
                             if not resource_type.startswith(('Custom::', 'AWS::Serverless::')):
-                                message = 'Invalid Type {0} for resource {1} in {2}'
+                                message = 'Invalid or unsupported Type {0} for resource {1} in {2}'
                                 matches.append(RuleMatch(
                                     ['Resources', resource_name, 'Type'],
                                     message.format(resource_type, resource_name, region)


### PR DESCRIPTION
There are multiple reasons why specified Resource Types are not valid:

- Resource Type is not supported in a specific region
- Resource Type is excluded using a custom_spec file
- A typo 

The current error message (`Invalid Type`) is not clear enough to cover these 3 scenario's, changed it to `Invalid or unsupported Type` to clarify

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
