### PR TITLE
Fix Circular Dependency Outputs bug

### DIFF
--- a/src/cfnlint/rules/resources/CircularDependency.py
+++ b/src/cfnlint/rules/resources/CircularDependency.py
@@ -129,14 +129,15 @@ class CircularDependency(CloudFormationLintRule):
             elif isinstance(value, (six.text_type, six.string_types)):
                 sub_parameters = self.searchstring(value)
 
-            for sub_parameter in sub_parameters:
-                if sub_parameter not in sub_parameter_values:
-                    if '.' in sub_parameter:
-                        sub_parameter = sub_parameter.split('.')[0]
-                    if cfn.template.get('Resources', {}).get(sub_parameter, {}):
-                        if not resources.get(res_name):
-                            resources[res_name] = []
-                        resources[res_name].append(sub_parameter)
+            if res_type == 'Resources':
+                for sub_parameter in sub_parameters:
+                    if sub_parameter not in sub_parameter_values:
+                        if '.' in sub_parameter:
+                            sub_parameter = sub_parameter.split('.')[0]
+                        if cfn.template.get('Resources', {}).get(sub_parameter, {}):
+                            if not resources.get(res_name):
+                                resources[res_name] = []
+                            resources[res_name].append(sub_parameter)
 
         matches.extend(self.check_circular_dependencies(resources))
         return matches

--- a/test/module/test_template.py
+++ b/test/module/test_template.py
@@ -45,7 +45,7 @@ class TestTemplate(BaseTestCase):
     def test_get_resources_success(self):
         """Test Success on Get Resources"""
         resources = self.template.get_resources()
-        assert len(resources) == 8
+        assert len(resources) == 9
 
     def test_get_resource_names(self):
         """ Test Resource Names"""
@@ -65,7 +65,7 @@ class TestTemplate(BaseTestCase):
     def test_get_valid_refs(self):
         """ Get Valid REFs"""
         refs = self.template.get_valid_refs()
-        assert len(refs) == 20
+        assert len(refs) == 21
 
     def test_conditions_return_object_success(self):
         """Test condition object response and nested IFs"""

--- a/test/templates/good/generic.yaml
+++ b/test/templates/good/generic.yaml
@@ -110,6 +110,10 @@ Resources:
         Fn::Sub:
         - "yum install ${myPackage}"
         - myPackage: !Ref Package1
+  ElasticIP:
+    Type: "AWS::EC2::EIP"
+    Properties:
+      Domain: "vpc"
   ElasticLoadBalancer:
     Type: AWS::ElasticLoadBalancing::LoadBalancer
     Properties:
@@ -140,3 +144,8 @@ Resources:
       Parameters:
         DeploymentName: iam-pipeline
         Deploy: 'auto'
+Outputs:
+  ElasticIP:
+    Value: !Sub "${ElasticIP}/32"
+    Export:
+      Name: "elastic-ip-cidr"


### PR DESCRIPTION
A reference in an Output using `!Sub` to a Resource with the same name as the Output is seen as a circular dependency:

```
E3004 Circular Dependencies for resource ElasticIP.  Circular dependency with [ElasticIP]
test/templates/good/generic.yaml:113:3
```
Added a check on a `Resource` type, just like in the `Ref` and `Fn::GetAtt` part.

Added this scenario to the `good/generic.yaml` template for the tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
