### PR TITLE
Pass LANG to fix encoding issues in TOX

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ commands = discover
 deps =
   discover
   requests
+setenv = LANG=en_US.UTF-8
 
 [testenv:pylint36]
 changedir =


### PR DESCRIPTION
There are (possible) encoding issues with TOX as described here:

* https://github.com/tox-dev/tox/issues/602
* https://github.com/tox-dev/tox/issues/254

This error exposed after adding a test template containing special characters with the following error:

```
ERROR: test_file_negative (rules.resources.route53.test_txt.TestRoute53TxtRecords)
Test failure
----------------------------------------------------------------------
Traceback (most recent call last):
    self.helper_file_negative('templates/bad/properties_route53.yaml', 2)
  File “/path/to/cfn-python-lint/test/rules/__init__.py", line 72, in helper_file_negative
    template = self.load_template(filename)
  File “/path/to/cfn-python-lint/test/testlib/testcase.py", line 35, in load_template
    loader = MarkedLoader(fp.read())
  File “/path/to/cfn-python-lint/.tox/py36/bin/../lib/python3.6/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 334: ordinal not in range(128)
```
Occurs only with the Python 3.6 tests.

The normal code (the actual listing) works without issues.

Set the LANG variable to force TOX to work with the proper encoding

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
