### PR TITLE
Fix hardcoded AZ check

### DIFF
--- a/src/cfnlint/__init__.py
+++ b/src/cfnlint/__init__.py
@@ -783,11 +783,10 @@ class Template(object):
                         check_split(
                             value=value, path=new_path[:] + child_path, **kwargs))
             elif isinstance(child_path[-1], int):
-                if child_path[-2] == 'Fn::If':
-                    if check_value:
-                        matches.extend(
-                            check_value(
-                                value=value, path=new_path[:] + child_path, **kwargs))
+                if check_value:
+                    matches.extend(
+                        check_value(
+                            value=value, path=new_path[:] + child_path, **kwargs))
 
         return matches
 

--- a/src/cfnlint/rules/parameters/AvailabilityZone.py
+++ b/src/cfnlint/rules/parameters/AvailabilityZone.py
@@ -21,7 +21,7 @@ from cfnlint import RuleMatch
 class AvailabilityZone(CloudFormationLintRule):
     """Check Availibility Zone parameter checks """
     id = 'W2508'
-    shortdesc = 'Availability Zone Parameters are of correct type AWS::EC2::SecurityGroup::Id'
+    shortdesc = 'Availability Zone Parameters are of correct type AWS::EC2::AvailabilityZone::Name'
     description = 'Check if a parameter is being used in a resource for Security ' \
                   'Group.  If it is make sure it is of type AWS::EC2::AvailabilityZone::Name'
     tags = ['base', 'parameters', 'availabilityzone']
@@ -61,7 +61,7 @@ class AvailabilityZone(CloudFormationLintRule):
             self.resource_sub_property_types.append(property_type_spec)
 
     # pylint: disable=W0613
-    def check_sgid_ref(self, value, path, parameters, resources):
+    def check_az_ref(self, value, path, parameters, resources):
         """Check ref for VPC"""
         matches = list()
         if 'AvailabilityZone' in path:
@@ -102,14 +102,14 @@ class AvailabilityZone(CloudFormationLintRule):
         matches.extend(
             cfn.check_value(
                 properties, 'AvailabilityZone', path,
-                check_value=None, check_ref=self.check_sgid_ref,
+                check_value=None, check_ref=self.check_az_ref,
                 check_mapping=None, check_split=None, check_join=None
             )
         )
         matches.extend(
             cfn.check_value(
                 properties, 'AvailabilityZones', path,
-                check_value=None, check_ref=self.check_sgid_ref,
+                check_value=None, check_ref=self.check_az_ref,
                 check_mapping=None, check_split=None, check_join=None
             )
         )

--- a/src/cfnlint/rules/resources/properties/AvailabilityZone.py
+++ b/src/cfnlint/rules/resources/properties/AvailabilityZone.py
@@ -58,8 +58,12 @@ class AvailabilityZone(CloudFormationLintRule):
     def check_az_value(self, value, path):
         """Check ref for VPC"""
         matches = list()
-        message = 'Don\'t hardcode {0} for AvailabilityZones at {1}'
-        matches.append(RuleMatch(path, message.format(value, ('/'.join(path)))))
+
+        if path[-1] != 'Fn::GetAZs':
+            message = 'Don\'t hardcode {0} for AvailabilityZones at {1}'
+            full_path = ('/'.join(str(x) for x in path))
+            matches.append(RuleMatch(path, message.format(value, full_path)))
+
         return matches
 
     def check(self, properties, resource_type, path, cfn):

--- a/test/rules/parameters/test_availability_zone.py
+++ b/test/rules/parameters/test_availability_zone.py
@@ -59,4 +59,4 @@ class TestParameterAvailabilityZone(BaseRuleTestCase):
 
     def test_file_negative(self):
         """Test failure"""
-        self.helper_file_negative('templates/bad/properties_az.yaml', 3)
+        self.helper_file_negative('templates/bad/parameters_az.yaml', 3)

--- a/test/rules/resources/properties/test_availability_zone.py
+++ b/test/rules/resources/properties/test_availability_zone.py
@@ -31,4 +31,4 @@ class TestPropertyAvailabilityZone(BaseRuleTestCase):
 
     def test_file_negative(self):
         """Failure test"""
-        self.helper_file_negative('templates/bad/properties_ec2_network.yaml', 1)
+        self.helper_file_negative('templates/bad/properties_az.yaml', 3)

--- a/test/templates/bad/parameters_az.yaml
+++ b/test/templates/bad/parameters_az.yaml
@@ -1,0 +1,24 @@
+---
+AWSTemplateFormatVersion: "2010-09-09"
+Parameters:
+  myAvailabilityZone:
+    Type: String
+  myAvailabilityZone2:
+    Type: String
+  myAvailabilityZoneList:
+    Type: AWS::EC2::AvailabilityZone::Name
+Resources:
+  myInstance:
+    Type: AWS::EC2::Instance
+    Properties:
+      AvailabilityZone: !Ref myAvailabilityZone
+      ImageId: ami-123456
+  myLoadBalancer:
+    Type: AWS::ElasticLoadBalancing::LoadBalancer
+    Properties:
+      AvailabilityZones:
+      - !Ref myAvailabilityZone2
+  myLoadBalancer2:
+    Type: AWS::ElasticLoadBalancing::LoadBalancer
+    Properties:
+      AvailabilityZones: !Ref myAvailabilityZoneList

--- a/test/templates/bad/properties_az.yaml
+++ b/test/templates/bad/properties_az.yaml
@@ -1,24 +1,38 @@
 ---
 AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  AWS EC2 Good Template
 Parameters:
-  myAvailabilityZone:
+  myEnvironment:
     Type: String
-  myAvailabilityZone2:
-    Type: String
-  myAvailabilityZoneList:
-    Type: AWS::EC2::AvailabilityZone::Name
+    AllowedValues:
+      - prod
+      - dev
+Conditions:
+  isProd:
+    "Fn::Equals":
+    - !Ref myEnvironment
+    - "prod"
 Resources:
-  myInstance:
-    Type: AWS::EC2::Instance
+  MyLaunchConfig:
+    Type: AWS::AutoScaling::LaunchConfiguration
     Properties:
-      AvailabilityZone: !Ref myAvailabilityZone
-      ImageId: ami-123456
+      ImageId: "ami-2f726546"
+      InstanceType: t2.micro
   myLoadBalancer:
-    Type: AWS::ElasticLoadBalancing::LoadBalancer
+    Type: "AWS::AutoScaling::AutoScalingGroup"
     Properties:
       AvailabilityZones:
-      - !Ref myAvailabilityZone2
-  myLoadBalancer2:
-    Type: AWS::ElasticLoadBalancing::LoadBalancer
+        # Hardcoded AZ's
+        - !If [isProd, "eu-west-1a", !Ref "AWS::NoValue"]
+        - "eu-west-1b"
+      MaxSize: 3
+      MinSize: 1
+      LaunchConfigurationName: !Ref MyLaunchConfig
+  mySubnet2-2:
+    Type: AWS::EC2::Subnet
     Properties:
-      AvailabilityZones: !Ref myAvailabilityZoneList
+      # Hardcoded AZ
+      AvailabilityZone: us-east-1a
+      CidrBlock: "172.31.0.0/16"
+      VpcId: vpc-1234567


### PR DESCRIPTION
The (new) check on hardcoded AZ breaks if AZ's are specified at a load balancer. This is an array of values which returned a `IndexError: list index out of range` due to the slice (`child_path[-2]`)

Additional changes:
- Fixe some naming in the AZ parameters check
- Renamed the test of the AZ parameter test to `parameters_az.yaml`
- Created new test file for the AZ properties (`properties_az.yaml`)
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
