### PR TITLE
Fix typo in the RestApiId check (Transform)

### DIFF
--- a/src/cfnlint/transforms/Serverless/Functions.py
+++ b/src/cfnlint/transforms/Serverless/Functions.py
@@ -117,7 +117,7 @@ class Functions(CloudFormationTransform):
                 for event_name, event_value in events.items():
                     event_type = event_value.get('Type', None)
                     if event_type == 'Api':
-                        rest_api_id = event_value.get('Properties', {}).get('RestApidId')
+                        rest_api_id = event_value.get('Properties', {}).get('RestApiId')
                         if not rest_api_id:
                             transforms.add_resource(
                                 cfn, 'ServerlessRestApi',

--- a/test/templates/good/transform_serverless_function.yaml
+++ b/test/templates/good/transform_serverless_function.yaml
@@ -2,6 +2,10 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
 Resources:
+  myApi:
+    Type: AWS::Serverless::Api
+    Properties:
+      StageName: prod
   myFunction:
     Type: AWS::Serverless::Function
     Properties:
@@ -12,11 +16,23 @@ Resources:
       DeploymentPreference:
         Type: Linear10PercentEvery10Minutes
       Events:
+        OriginalApi:
+          Type: Api
+          Properties:
+            Path: /original
+            Method: GET
         ThumbnailApi:
           Type: Api
           Properties:
             Path: /thumbnail
             Method: GET
+            RestApiId: !Ref myApi
+        WatermarkApi:
+          Type: Api
+          Properties:
+            Path: /watermark
+            Method: GET
+            RestApiId: !Ref myApi
         S3Trigger:
           Type: S3
           Properties:


### PR DESCRIPTION
Fix typo in the Transform function that caused the creation of a new `AWS::ApiGateway::RestApi`, always.

```
    return self.resource_transform(template)  # pylint: disable=E1102
  File "/path/to/cfn-python-lint/src/cfnlint/transforms/Serverless/Functions.py", line 132, in resource_transform
    'Properties': {}
  File "/path/to/cfn-python-lint/src/cfnlint/transforms/__init__.py", line 38, in add_resource
    'A resource with ID "%s" already exists within this template' % resource_name)
cfnlint.transforms.TransformError: 'A resource with ID "ServerlessRestApi" already exists within this template'
```
Fixed the typo and added some test data to validate this (tests break without the typo fix)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
