### PR TITLE
Support multiple functions without RestApiId

### DIFF
--- a/test/templates/good/transform_serverless_function.yaml
+++ b/test/templates/good/transform_serverless_function.yaml
@@ -21,6 +21,11 @@ Resources:
           Properties:
             Path: /original
             Method: GET
+        DoubleApi:
+          Type: Api
+          Properties:
+            Path: /double
+            Method: GET
         ThumbnailApi:
           Type: Api
           Properties:


### PR DESCRIPTION
If there are multiple events without `RestApiId` specified, the Transform generates an error:

```
E0001 While Performing a Transform got error: A resource with ID "ServerlessRestApi" already exists within this template
test/templates/good/transform_serverless_function.yaml:4:1
``` 
From the documentation (https://github.com/awslabs/serverless-application-model/blob/develop/versions/2016-10-31.md#api):

```
If not defined, a default AWS::Serverless::Api resource is created using a generated Swagger document contains a union of all paths and methods defined by Api events defined in this template that do not specify a RestApiId.
```

Added a check to create only 1 RestApi resource

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
