### PR TITLE
Fix GetAtts in SubStrings that go to custom and CloudFormation stacks

### DIFF
--- a/src/cfnlint/__init__.py
+++ b/src/cfnlint/__init__.py
@@ -482,10 +482,15 @@ class Template(object):
         resourcetypes = cfnlint.helpers.RESOURCE_SPECS['us-east-1'].get('ResourceTypes')
         results = {}
         resources = self.template.get('Resources', {})
+
+        astrik_types = (
+            'Custom::', 'AWS::CloudFormation::Stack',
+            'AWS::Serverless::', 'AWS::CloudFormation::CustomResource'
+        )
         for name, value in resources.items():
             if 'Type' in value:
                 valtype = value['Type']
-                if valtype.startswith(('Custom::', 'AWS::CloudFormation::Stack', 'AWS::Serverless::')):
+                if valtype.startswith(astrik_types):
                     LOGGER.debug('Cant build an appropriate getatt list from %s', valtype)
                     results[name] = {'*': {'PrimitiveItemType': 'String'}}
                 else:

--- a/src/cfnlint/rules/functions/Sub.py
+++ b/src/cfnlint/rules/functions/Sub.py
@@ -51,19 +51,18 @@ class Sub(CloudFormationLintRule):
         valid_params.extend(cfn.get_resource_names())
         for key, _ in parameters.items():
             valid_params.append(key)
-        for resource, attributes in get_atts.items():
-            for attribute_name, _ in attributes.items():
-                valid_params.append('%s.%s' % (resource, attribute_name))
 
         for string_param in string_params:
             string_param = string_param[2:-1]
             if isinstance(string_param, (six.string_types, six.text_type)):
                 if string_param not in valid_params:
                     found = False
-                    for valid_param in valid_params:
-                        if len(valid_param.split('.')) > 1:
-                            if (string_param.split('.')[0] == valid_param.split('.')[0] and
-                                    valid_param.split('.')[1] == '*'):
+                    for resource, attributes in get_atts.items():
+                        for attribute_name, _ in attributes.items():
+                            if resource == string_param.split('.')[0] and attribute_name == '*':
+                                found = True
+                            elif (resource == string_param.split('.')[0] and
+                                  attribute_name == string_param.split('.')[1:]):
                                 found = True
                     if not found:
                         message = 'String parameter {0} not found in string for {1}'

--- a/src/cfnlint/rules/functions/Sub.py
+++ b/src/cfnlint/rules/functions/Sub.py
@@ -62,7 +62,7 @@ class Sub(CloudFormationLintRule):
                             if resource == string_param.split('.')[0] and attribute_name == '*':
                                 found = True
                             elif (resource == string_param.split('.')[0] and
-                                  attribute_name == string_param.split('.')[1:]):
+                                  attribute_name == '.'.join(string_param.split('.')[1:])):
                                 found = True
                     if not found:
                         message = 'String parameter {0} not found in string for {1}'

--- a/src/cfnlint/rules/functions/Sub.py
+++ b/src/cfnlint/rules/functions/Sub.py
@@ -57,11 +57,18 @@ class Sub(CloudFormationLintRule):
 
         for string_param in string_params:
             string_param = string_param[2:-1]
-            if isinstance(string_param, six.string_types):
+            if isinstance(string_param, (six.string_types, six.text_type)):
                 if string_param not in valid_params:
-                    message = 'String parameter {0} not found in string for {1}'
-                    matches.append(RuleMatch(
-                        tree, message.format(string_param, '/'.join(map(str, tree)))))
+                    found = False
+                    for valid_param in valid_params:
+                        if len(valid_param.split('.')) > 1:
+                            if (string_param.split('.')[0] == valid_param.split('.')[0] and
+                                    valid_param.split('.')[1] == '*'):
+                                found = True
+                    if not found:
+                        message = 'String parameter {0} not found in string for {1}'
+                        matches.append(RuleMatch(
+                            tree, message.format(string_param, '/'.join(map(str, tree)))))
 
         return matches
 

--- a/test/rules/functions/test_sub.py
+++ b/test/rules/functions/test_sub.py
@@ -31,4 +31,4 @@ class TestRulesSub(BaseRuleTestCase):
 
     def test_file_negative(self):
         """Test failure"""
-        self.helper_file_negative('templates/bad/functions_sub.yaml', 4)
+        self.helper_file_negative('templates/bad/functions_sub.yaml', 7)

--- a/test/templates/bad/functions_sub.yaml
+++ b/test/templates/bad/functions_sub.yaml
@@ -5,6 +5,18 @@ Description: >
 Resources:
   myInstance:
     Type: AWS::EC2::Instance
+    Metadata:
+      AWS::CloudFormation::Init:
+        config:
+          files:
+            /etc/aws-signing-proxy.yml:
+              content: !Sub |
+                listen-address: 127.0.0.1
+                port: 9200
+                target: https://${mySubStack.Outputs.DomainEndpoint}
+                region: ${AWS::Region}
+                loadbalancer: ${myInstance3.PublicDnsName1}
+                badresource: ${myInstance5.PublicDnsName}
     Properties:
       ImageId: ami-asdfef
       UserData:

--- a/test/templates/good/functions_sub.yaml
+++ b/test/templates/good/functions_sub.yaml
@@ -14,6 +14,16 @@ Parameters:
 Resources:
   myInstance:
     Type: AWS::EC2::Instance
+    Metadata:
+      AWS::CloudFormation::Init:
+        config:
+          files:
+            /etc/aws-signing-proxy.yml:
+              content: !Sub |
+                listen-address: 127.0.0.1
+                port: 9200
+                target: https://${mySubStack.Outputs.DomainEndpoint}
+                region: ${AWS::Region}
     Properties:
       ImageId: String
       UserData:
@@ -21,4 +31,13 @@ Resources:
           Fn::Sub:
           - yum install ${myPackage}
             yum install ${package}
+            yum install ${myCustomResource.Package}
           - package: !Ref myAppPackage
+  mySubStack:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: String
+  myCustomResource:
+    Type: Custom::Test
+    Properties:
+      ServiceToken: Arn

--- a/test/templates/good/functions_sub.yaml
+++ b/test/templates/good/functions_sub.yaml
@@ -11,6 +11,8 @@ Parameters:
     Type: String
     Default: java
     Description: App Package
+  mySubnets:
+    Type: List<AWS::EC2::Subnet::Id>
 Resources:
   myInstance:
     Type: AWS::EC2::Instance
@@ -24,6 +26,7 @@ Resources:
                 port: 9200
                 target: https://${mySubStack.Outputs.DomainEndpoint}
                 region: ${AWS::Region}
+                loadbalancer: ${myAlb.DNSName}
     Properties:
       ImageId: String
       UserData:
@@ -41,3 +44,9 @@ Resources:
     Type: Custom::Test
     Properties:
       ServiceToken: Arn
+
+  myAlb:
+    Type: "AWS::ElasticLoadBalancingV2::LoadBalancer"
+    Properties:
+      Name: !Sub ${AWS::StackName}-lb
+      Subnets: !Ref mySubnets


### PR DESCRIPTION
*Issue #, if available:*
Fixes #66 

*Description of changes:*
- Fixes sub string validating getatt requests to custom and cloudformation stack resources.  Technically getatts of those resource types come back as resourcename.* and this wasn't handled when doing the 'in' based search.  Had to some more string tests to handle these resource types.  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
