### PR TITLE
Fix getting config like ignore_checks from the template

### DIFF
--- a/src/cfnlint/__main__.py
+++ b/src/cfnlint/__main__.py
@@ -74,7 +74,7 @@ def main():
             loader = cfnlint.parser.MarkedLoader(fp.read())
             loader.add_multi_constructor('!', cfnlint.parser.multi_constructor)
             template = loader.get_single_data()
-            if template is dict:
+            if isinstance(template, dict):
                 defaults = template.get('Metadata', {}).get('cfn-lint', {}).get('config', {})
         except IOError as e:
             if e.errno == 2:


### PR DESCRIPTION
Signed-off-by: Irving Popovetsky <irving@chef.io>

*Description of changes:*
I noticed that setting configuration in my templates (such as `ignore_checks`) wasn't working.  digging around, I noticed this if statement was never evaluating to `True`: https://github.com/awslabs/cfn-python-lint/blob/master/src/cfnlint/__main__.py#L77

because:
```python
>>> template is dict
False
>>> template.__class__
<class 'cfnlint.parser.dict_node'>
```

this is a more reliable check:
```python
>>> isinstance(template, dict)
True
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
