### PR TITLE
Fix circular dependency in certain scenarios with a sub function

### DIFF
--- a/src/cfnlint/rules/resources/CircularDependency.py
+++ b/src/cfnlint/rules/resources/CircularDependency.py
@@ -128,6 +128,8 @@ class CircularDependency(CloudFormationLintRule):
                 sub_parameters = self.searchstring(value[0])
             elif isinstance(value, (six.text_type, six.string_types)):
                 sub_parameters = self.searchstring(value)
+            else:
+                sub_parameters = list()
 
             if res_type == 'Resources':
                 for sub_parameter in sub_parameters:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Ran into an issue with circular dependencies when sub functions are configured in a particular method.  This is a catch all to prevent crashing.

Trying to find a good test scenario for this again.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
