### PR TITLE
Test for naming standards of resources, parameters, outputs, mappings

### DIFF
--- a/src/cfnlint/helpers.py
+++ b/src/cfnlint/helpers.py
@@ -39,6 +39,8 @@ REGIONS = ['us-east-1', 'us-east-2', 'us-west-1', 'us-west-2', 'ca-central-1',
            'ap-northeast-2', 'ap-southeast-1', 'ap-southeast-2', 'ap-south-1',
            'sa-east-1']
 
+REGEX_ALPHANUMERIC = re.compile('^[a-zA-Z0-9_]*$')
+
 AVAILABILITY_ZONES = [
     'us-east-1a', 'us-east-1b', 'us-east-1c', 'us-east-1d', 'us-east-1e', 'us-east-1f',
     'us-east-2a' 'us-east-2b' 'us-east-2c',

--- a/src/cfnlint/rules/mappings/Name.py
+++ b/src/cfnlint/rules/mappings/Name.py
@@ -1,0 +1,44 @@
+"""
+  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this
+  software and associated documentation files (the "Software"), to deal in the Software
+  without restriction, including without limitation the rights to use, copy, modify,
+  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+import re
+from cfnlint import CloudFormationLintRule
+from cfnlint import RuleMatch
+from cfnlint.helpers import REGEX_ALPHANUMERIC
+
+
+class Name(CloudFormationLintRule):
+    """Check if Mappings are named correctly"""
+    id = 'E7002'
+    shortdesc = 'Mappings have appropriate names'
+    description = 'Check if Mappings are properly named (A-Za-z0-9)'
+    tags = ['base', 'mapping']
+
+    def match(self, cfn):
+        """Check CloudFormation Mapping"""
+
+        matches = list()
+
+        mappings = cfn.template.get('Mappings', {})
+        for mapping_name, _ in mappings.items():
+            if not re.match(REGEX_ALPHANUMERIC, mapping_name):
+                message = 'Mapping {0} has invalid name.  Name has to be alphanumeric.'
+                matches.append(RuleMatch(
+                    ['Mappings', mapping_name],
+                    message.format(mapping_name)
+                ))
+
+        return matches

--- a/src/cfnlint/rules/outputs/Name.py
+++ b/src/cfnlint/rules/outputs/Name.py
@@ -1,0 +1,44 @@
+"""
+  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this
+  software and associated documentation files (the "Software"), to deal in the Software
+  without restriction, including without limitation the rights to use, copy, modify,
+  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+import re
+from cfnlint import CloudFormationLintRule
+from cfnlint import RuleMatch
+from cfnlint.helpers import REGEX_ALPHANUMERIC
+
+
+class Name(CloudFormationLintRule):
+    """Check if Outputs are named correctly"""
+    id = 'E6004'
+    shortdesc = 'Outputs have appropriate names'
+    description = 'Check if Outputs are properly named (A-Za-z0-9)'
+    tags = ['base', 'outputs']
+
+    def match(self, cfn):
+        """Check CloudFormation Mapping"""
+
+        matches = list()
+
+        outputs = cfn.template.get('Outputs', {})
+        for output_name, _ in outputs.items():
+            if not re.match(REGEX_ALPHANUMERIC, output_name):
+                message = 'Mapping {0} has invalid name.  Name has to be alphanumeric.'
+                matches.append(RuleMatch(
+                    ['Outputs', output_name],
+                    message.format(output_name)
+                ))
+
+        return matches

--- a/src/cfnlint/rules/outputs/Name.py
+++ b/src/cfnlint/rules/outputs/Name.py
@@ -35,7 +35,7 @@ class Name(CloudFormationLintRule):
         outputs = cfn.template.get('Outputs', {})
         for output_name, _ in outputs.items():
             if not re.match(REGEX_ALPHANUMERIC, output_name):
-                message = 'Mapping {0} has invalid name.  Name has to be alphanumeric.'
+                message = 'Output {0} has invalid name.  Name has to be alphanumeric.'
                 matches.append(RuleMatch(
                     ['Outputs', output_name],
                     message.format(output_name)

--- a/src/cfnlint/rules/parameters/Name.py
+++ b/src/cfnlint/rules/parameters/Name.py
@@ -1,0 +1,44 @@
+"""
+  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this
+  software and associated documentation files (the "Software"), to deal in the Software
+  without restriction, including without limitation the rights to use, copy, modify,
+  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+import re
+from cfnlint import CloudFormationLintRule
+from cfnlint import RuleMatch
+from cfnlint.helpers import REGEX_ALPHANUMERIC
+
+
+class Name(CloudFormationLintRule):
+    """Check if Parameters are named correctly"""
+    id = 'E2003'
+    shortdesc = 'Parameters have appropriate names'
+    description = 'Check if Parameters are properly named (A-Za-z0-9)'
+    tags = ['base', 'parameters']
+
+    def match(self, cfn):
+        """Check CloudFormation Mapping"""
+
+        matches = list()
+
+        parameters = cfn.template.get('Parameters', {})
+        for parameter_name, _ in parameters.items():
+            if not re.match(REGEX_ALPHANUMERIC, parameter_name):
+                message = 'Mapping {0} has invalid name.  Name has to be alphanumeric.'
+                matches.append(RuleMatch(
+                    ['Parameters', parameter_name],
+                    message.format(parameter_name)
+                ))
+
+        return matches

--- a/src/cfnlint/rules/parameters/Name.py
+++ b/src/cfnlint/rules/parameters/Name.py
@@ -35,7 +35,7 @@ class Name(CloudFormationLintRule):
         parameters = cfn.template.get('Parameters', {})
         for parameter_name, _ in parameters.items():
             if not re.match(REGEX_ALPHANUMERIC, parameter_name):
-                message = 'Mapping {0} has invalid name.  Name has to be alphanumeric.'
+                message = 'Parameter {0} has invalid name.  Name has to be alphanumeric.'
                 matches.append(RuleMatch(
                     ['Parameters', parameter_name],
                     message.format(parameter_name)

--- a/src/cfnlint/rules/resources/Name.py
+++ b/src/cfnlint/rules/resources/Name.py
@@ -1,0 +1,44 @@
+"""
+  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this
+  software and associated documentation files (the "Software"), to deal in the Software
+  without restriction, including without limitation the rights to use, copy, modify,
+  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+import re
+from cfnlint import CloudFormationLintRule
+from cfnlint import RuleMatch
+from cfnlint.helpers import REGEX_ALPHANUMERIC
+
+
+class Name(CloudFormationLintRule):
+    """Check if Resources are named correctly"""
+    id = 'E3006'
+    shortdesc = 'Resources have appropriate names'
+    description = 'Check if Resources are properly named (A-Za-z0-9)'
+    tags = ['base', 'resources']
+
+    def match(self, cfn):
+        """Check CloudFormation Mapping"""
+
+        matches = list()
+
+        resources = cfn.template.get('Resources', {})
+        for resource_name, _ in resources.items():
+            if not re.match(REGEX_ALPHANUMERIC, resource_name):
+                message = 'Mapping {0} has invalid name.  Name has to be alphanumeric.'
+                matches.append(RuleMatch(
+                    ['Resources', resource_name],
+                    message.format(resource_name)
+                ))
+
+        return matches

--- a/test/rules/mappings/test_name.py
+++ b/test/rules/mappings/test_name.py
@@ -1,0 +1,38 @@
+"""
+  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this
+  software and associated documentation files (the "Software"), to deal in the Software
+  without restriction, including without limitation the rights to use, copy, modify,
+  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+from cfnlint.rules.mappings.Name import Name  # pylint: disable=E0401
+from .. import BaseRuleTestCase
+
+
+class TestName(BaseRuleTestCase):
+    """Test template Condition Names"""
+    def setUp(self):
+        """Setup"""
+        super(TestName, self).setUp()
+        self.collection.register(Name())
+
+    def test_file_positive(self):
+        """Test Positive"""
+        self.helper_file_positive()
+
+    def test_file_success(self):
+        """Test success"""
+        self.helper_file_positive_template('templates/good/mappings/name.yaml')
+
+    def test_file_negative(self):
+        """Test failure"""
+        self.helper_file_negative('templates/bad/mappings/name.yaml', 1)

--- a/test/rules/outputs/test_name.py
+++ b/test/rules/outputs/test_name.py
@@ -1,0 +1,38 @@
+"""
+  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this
+  software and associated documentation files (the "Software"), to deal in the Software
+  without restriction, including without limitation the rights to use, copy, modify,
+  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+from cfnlint.rules.outputs.Name import Name  # pylint: disable=E0401
+from .. import BaseRuleTestCase
+
+
+class TestName(BaseRuleTestCase):
+    """Test template outputs Names"""
+    def setUp(self):
+        """Setup"""
+        super(TestName, self).setUp()
+        self.collection.register(Name())
+
+    def test_file_positive(self):
+        """Test Positive"""
+        self.helper_file_positive()
+
+    def test_file_success(self):
+        """Test success"""
+        self.helper_file_positive_template('templates/good/outputs/name.yaml')
+
+    def test_file_negative(self):
+        """Test failure"""
+        self.helper_file_negative('templates/bad/outputs/name.yaml', 1)

--- a/test/rules/parameters/test_name.py
+++ b/test/rules/parameters/test_name.py
@@ -1,0 +1,38 @@
+"""
+  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this
+  software and associated documentation files (the "Software"), to deal in the Software
+  without restriction, including without limitation the rights to use, copy, modify,
+  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+from cfnlint.rules.parameters.Name import Name  # pylint: disable=E0401
+from .. import BaseRuleTestCase
+
+
+class TestName(BaseRuleTestCase):
+    """Test template parameters Names"""
+    def setUp(self):
+        """Setup"""
+        super(TestName, self).setUp()
+        self.collection.register(Name())
+
+    def test_file_positive(self):
+        """Test Positive"""
+        self.helper_file_positive()
+
+    def test_file_success(self):
+        """Test success"""
+        self.helper_file_positive_template('templates/good/parameters/name.yaml')
+
+    def test_file_negative(self):
+        """Test failure"""
+        self.helper_file_negative('templates/bad/parameters/name.yaml', 1)

--- a/test/rules/resources/test_name.py
+++ b/test/rules/resources/test_name.py
@@ -14,31 +14,25 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-import re
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
-from cfnlint.helpers import REGEX_ALPHANUMERIC
+from cfnlint.rules.resources.Name import Name  # pylint: disable=E0401
+from .. import BaseRuleTestCase
 
 
-class Name(CloudFormationLintRule):
-    """Check if Resources are named correctly"""
-    id = 'E3006'
-    shortdesc = 'Resources have appropriate names'
-    description = 'Check if Resources are properly named (A-Za-z0-9)'
-    tags = ['base', 'resources']
+class TestName(BaseRuleTestCase):
+    """Test template resources Names"""
+    def setUp(self):
+        """Setup"""
+        super(TestName, self).setUp()
+        self.collection.register(Name())
 
-    def match(self, cfn):
-        """Check CloudFormation Mapping"""
+    def test_file_positive(self):
+        """Test Positive"""
+        self.helper_file_positive()
 
-        matches = list()
+    def test_file_success(self):
+        """Test success"""
+        self.helper_file_positive_template('templates/good/resources/name.yaml')
 
-        resources = cfn.template.get('Resources', {})
-        for resource_name, _ in resources.items():
-            if not re.match(REGEX_ALPHANUMERIC, resource_name):
-                message = 'Resources {0} has invalid name.  Name has to be alphanumeric.'
-                matches.append(RuleMatch(
-                    ['Resources', resource_name],
-                    message.format(resource_name)
-                ))
-
-        return matches
+    def test_file_negative(self):
+        """Test failure"""
+        self.helper_file_negative('templates/bad/resources/name.yaml', 1)

--- a/test/templates/bad/mappings/name.yaml
+++ b/test/templates/bad/mappings/name.yaml
@@ -1,0 +1,10 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Mappings:
+  Bad.Name:
+    us-east-1:
+      AMI: "ami-7f418316"
+      TestAz: "us-east-1a"
+    us-west-1:
+      AMI: "ami-951945d0"
+      TestAz: "us-west-1a"
+Resources: {}

--- a/test/templates/bad/outputs/name.yaml
+++ b/test/templates/bad/outputs/name.yaml
@@ -1,0 +1,9 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  myInstance:
+    Type: AWS::EC2::Instance
+    Properties:
+      ImageId: ami-123456
+Outputs:
+  dns.Name:
+    Value: !GetAtt myInstance.PrivateDnsName

--- a/test/templates/bad/parameters/name.yaml
+++ b/test/templates/bad/parameters/name.yaml
@@ -1,0 +1,9 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Parameters:
+  image.Id:
+    Type: AWS::EC2::Image::Id
+Resources:
+  myInstance:
+    Type: AWS::EC2::Instance
+    Properties:
+      ImageId: !Ref image.Id

--- a/test/templates/bad/resources/name.yaml
+++ b/test/templates/bad/resources/name.yaml
@@ -1,0 +1,6 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  my.Instance:
+    Type: AWS::EC2::Instance
+    Properties:
+      ImageId: ami-123456

--- a/test/templates/good/mappings/name.yaml
+++ b/test/templates/good/mappings/name.yaml
@@ -1,0 +1,10 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Mappings:
+  RegionMap:
+    us-east-1:
+      AMI: "ami-7f418316"
+      TestAz: "us-east-1a"
+    us-west-1:
+      AMI: "ami-951945d0"
+      TestAz: "us-west-1a"
+Resources: {}

--- a/test/templates/good/outputs/name.yaml
+++ b/test/templates/good/outputs/name.yaml
@@ -1,0 +1,9 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  myInstance:
+    Type: AWS::EC2::Instance
+    Properties:
+      ImageId: ami-123456
+Outputs:
+  dnsName:
+    Value: !GetAtt myInstance.PrivateDnsName

--- a/test/templates/good/parameters/name.yaml
+++ b/test/templates/good/parameters/name.yaml
@@ -1,0 +1,9 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Parameters:
+  imageId:
+    Type: AWS::EC2::Image::Id
+Resources:
+  myInstance:
+    Type: AWS::EC2::Instance
+    Properties:
+      ImageId: !Ref imageId

--- a/test/templates/good/properties_ec2_vpc.yaml
+++ b/test/templates/good/properties_ec2_vpc.yaml
@@ -22,7 +22,7 @@ Resources:
     Properties:
       InstanceTenancy: !Ref vpcTenancy
       CidrBlock: !Ref cidrBlock
-  mySubnet2-1:
+  mySubnet21:
     Type: AWS::EC2::Subnet
     Properties:
       CidrBlock:
@@ -30,7 +30,7 @@ Resources:
         - 0
         - !Cidr [!Ref cidrBlock, 3, 16]
       VpcId: vpc-1234567
-  mySubnet2-2:
+  mySubnet22:
     Type: AWS::EC2::Subnet
     Properties:
       CidrBlock: !Ref cidrBlock

--- a/test/templates/good/resources/name.yaml
+++ b/test/templates/good/resources/name.yaml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Resources:
-  my.Instance:
+  myInstance:
     Type: AWS::EC2::Instance
     Properties:
       ImageId: ami-123456

--- a/test/templates/good/resources/name.yaml
+++ b/test/templates/good/resources/name.yaml
@@ -1,0 +1,6 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  my.Instance:
+    Type: AWS::EC2::Instance
+    Properties:
+      ImageId: ami-123456


### PR DESCRIPTION
*Issue #, if available:*
Fixes #76 

*Description of changes:*
- Adds naming standard checks for Resources, mappings, parameters, and outputs.
- Conditions are not included cause they don't have a documented naming standard.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
