### PR TITLE
Don't add role if there's one existing already

### DIFF
--- a/src/cfnlint/transforms/Serverless/Functions.py
+++ b/src/cfnlint/transforms/Serverless/Functions.py
@@ -28,24 +28,25 @@ class Functions(CloudFormationTransform):
         """
         for resource_name, resource_values in cfn.get_resources(resource_type='AWS::Serverless::Function').items():
             resource_properties = resource_values.get('Properties', {})
-            transforms.add_resource(
-                cfn, '%sRole' % resource_name,
-                {
-                    'Type': 'AWS::IAM::Role',
-                    'Properties': {
-                        'AssumeRolePolicyDocument': {
-                            'Version': '2012-10-17',
-                            'Statement': [{
-                                'Effect': 'Allow',
-                                'Principal': {
-                                    'Service': ['lambda.amazonaws.com']
-                                },
-                                'Action': ['sts:AssumeRole']
-                            }]
+            if not resource_properties.get('Role'):
+                transforms.add_resource(
+                    cfn, '%sRole' % resource_name,
+                    {
+                        'Type': 'AWS::IAM::Role',
+                        'Properties': {
+                            'AssumeRolePolicyDocument': {
+                                'Version': '2012-10-17',
+                                'Statement': [{
+                                    'Effect': 'Allow',
+                                    'Principal': {
+                                        'Service': ['lambda.amazonaws.com']
+                                    },
+                                    'Action': ['sts:AssumeRole']
+                                }]
+                            }
                         }
                     }
-                }
-            )
+                )
             if resource_properties:
                 key_value = resource_properties.get('AutoPublishAlias')
                 if key_value:

--- a/test/transforms/test_serverless_functions.py
+++ b/test/transforms/test_serverless_functions.py
@@ -62,6 +62,34 @@ class TestServerlessFunction(BaseTransformTestCase):
 
         self.helper_transform_template(self.template, test_success)
 
+    def test_function_role_exists_positive(self):
+        """Test converstion of serverless function to not include Role if there's existing role"""
+
+        def test_success(template):
+            """Test success"""
+            resource = template.get('Resources', {}).get('myFunctionRole')
+            if resource:
+                return False
+            return True
+
+        self.helper_transform_template({
+            "AWSTemplateFormatVersion": "2010-09-09",
+            "Transform": "AWS::Serverless-2016-10-31",
+            "Resources": {
+                "myFunction": {
+                    "Type": "AWS::Serverless::Function",
+                    "Properties": {
+                        "Handler": "index.handler",
+                        "Runtime": "nodejs4.3",
+                        "CodeUri": "s3://testBucket/mySourceCode.zip",
+                        "Role": {
+                            "Ref": "myFunctionRole",
+                        },
+                    }
+                }
+            }
+        }, test_success)
+
     def test_function_event_api_positive(self):
         """Test converstion of serverless function to API Event"""
 


### PR DESCRIPTION
This PR fixes an issue with a function (`FunctionName`) that has explicitly defined role in the format of: `FunctionNameRole`. Trying to lint that will fail with message: 

> A resource with ID "FunctionNameRole" already exists within this template

The issue is fixed by not creating a new Role resource if serverless function has an existing reference to a role.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
