### PR TITLE
Update version check to be string based per the spec

### DIFF
--- a/src/cfnlint/rules/resources/codepipeline/CodepipelineStageActions.py
+++ b/src/cfnlint/rules/resources/codepipeline/CodepipelineStageActions.py
@@ -174,8 +174,8 @@ class CodepipelineStageActions(CloudFormationLintRule):
         """Check that action type version is valid."""
         matches = []
 
-        if action.get('ActionTypeId').get('Version') != 1:
-            message = 'For all currently supported action types, the only valid version is 1.'
+        if action.get('ActionTypeId').get('Version') != '1':
+            message = 'For all currently supported action types, the only valid version is "1".'
             matches.append(RuleMatch(
                 path + ['ActionTypeId', 'Version'],
                 message

--- a/src/cfnlint/rules/resources/codepipeline/CodepipelineStageActions.py
+++ b/src/cfnlint/rules/resources/codepipeline/CodepipelineStageActions.py
@@ -175,7 +175,7 @@ class CodepipelineStageActions(CloudFormationLintRule):
         matches = []
 
         if action.get('ActionTypeId').get('Version') != '1':
-            message = 'For all currently supported action types, the only valid version is "1".'
+            message = 'For all currently supported action types, the only valid version string is "1".'
             matches.append(RuleMatch(
                 path + ['ActionTypeId', 'Version'],
                 message

--- a/test/templates/bad/resources_codepipeline_action_artifact_counts.yaml
+++ b/test/templates/bad/resources_codepipeline_action_artifact_counts.yaml
@@ -16,7 +16,7 @@ Resources:
                 Category: Source
                 Owner: ThirdParty
                 Provider: GitHub
-                Version: 1
+                Version: "1"
               OutputArtifacts:
                 - Name: MyApp
               Configuration:
@@ -31,7 +31,7 @@ Resources:
               ActionTypeId:
                 Category: Build
                 Owner: AWS
-                Version: 1
+                Version: "1"
                 Provider: CodeBuild
               Configuration:
                 ProjectName: cfn-python-lint

--- a/test/templates/bad/resources_codepipeline_action_invalid_owner.yaml
+++ b/test/templates/bad/resources_codepipeline_action_invalid_owner.yaml
@@ -16,7 +16,7 @@ Resources:
                 Category: Source
                 Owner: Jenkins
                 Provider: GitHub
-                Version: 1
+                Version: "1"
               OutputArtifacts:
                 - Name: MyApp
               Configuration:
@@ -31,7 +31,7 @@ Resources:
               ActionTypeId:
                 Category: Build
                 Owner: AWS
-                Version: 1
+                Version: "1"
                 Provider: CodeBuild
               Configuration:
                 ProjectName: cfn-python-lint

--- a/test/templates/bad/resources_codepipeline_action_invalid_version.yaml
+++ b/test/templates/bad/resources_codepipeline_action_invalid_version.yaml
@@ -16,7 +16,7 @@ Resources:
                 Category: Source
                 Owner: ThirdParty
                 Provider: GitHub
-                Version: 2
+                Version: "2"
               OutputArtifacts:
                 - Name: MyApp
               Configuration:
@@ -31,7 +31,7 @@ Resources:
               ActionTypeId:
                 Category: Build
                 Owner: AWS
-                Version: 1
+                Version: "1"
                 Provider: CodeBuild
               Configuration:
                 ProjectName: cfn-python-lint

--- a/test/templates/bad/resources_codepipeline_action_non_unique.yaml
+++ b/test/templates/bad/resources_codepipeline_action_non_unique.yaml
@@ -16,7 +16,7 @@ Resources:
                 Category: Source
                 Owner: ThirdParty
                 Provider: GitHub
-                Version: 1
+                Version: "1"
               OutputArtifacts:
                 - Name: MyApp
               Configuration:
@@ -31,7 +31,7 @@ Resources:
               ActionTypeId:
                 Category: Build
                 Owner: AWS
-                Version: 1
+                Version: "1"
                 Provider: CodeBuild
               Configuration:
                 ProjectName: cfn-python-lint
@@ -41,7 +41,7 @@ Resources:
               ActionTypeId:
                 Category: Build
                 Owner: AWS
-                Version: 1
+                Version: "1"
                 Provider: CodeBuild
               Configuration:
                 ProjectName: cfn-python-lint

--- a/test/templates/bad/resources_codepipeline_stages_no_source.yaml
+++ b/test/templates/bad/resources_codepipeline_stages_no_source.yaml
@@ -17,7 +17,7 @@ Resources:
               ActionTypeId:
                 Category: Build
                 Owner: AWS
-                Version: 1
+                Version: "1"
                 Provider: CodeBuild
               Configuration:
                 ProjectName: cfn-python-lint
@@ -29,7 +29,7 @@ Resources:
               ActionTypeId:
                 Category: Build
                 Owner: AWS
-                Version: 1
+                Version: "1"
                 Provider: CodeBuild
               Configuration:
                 ProjectName: cfn-python-lint

--- a/test/templates/bad/resources_codepipeline_stages_non_unique.yaml
+++ b/test/templates/bad/resources_codepipeline_stages_non_unique.yaml
@@ -18,7 +18,7 @@ Resources:
                 Category: Source
                 Owner: ThirdParty
                 Provider: GitHub
-                Version: 1
+                Version: "1"
               OutputArtifacts:
                 - Name: MyApp
               Configuration:
@@ -33,7 +33,7 @@ Resources:
               ActionTypeId:
                 Category: Build
                 Owner: AWS
-                Version: 1
+                Version: "1"
                 Provider: CodeBuild
               Configuration:
                 ProjectName: cfn-python-lint

--- a/test/templates/bad/resources_codepipeline_stages_one_stage.yaml
+++ b/test/templates/bad/resources_codepipeline_stages_one_stage.yaml
@@ -18,7 +18,7 @@ Resources:
                 Category: Source
                 Owner: ThirdParty
                 Provider: GitHub
-                Version: 1
+                Version: "1"
               OutputArtifacts:
                 - Name: MyApp
               Configuration:
@@ -31,7 +31,7 @@ Resources:
               ActionTypeId:
                 Category: Build
                 Owner: AWS
-                Version: 1
+                Version: "1"
                 Provider: CodeBuild
               Configuration:
                 ProjectName: cfn-python-lint

--- a/test/templates/bad/resources_codepipeline_stages_second_stage.yaml
+++ b/test/templates/bad/resources_codepipeline_stages_second_stage.yaml
@@ -18,7 +18,7 @@ Resources:
                 Category: Source
                 Owner: ThirdParty
                 Provider: GitHub
-                Version: 1
+                Version: "1"
               OutputArtifacts:
                 - Name: MyApp
               Configuration:
@@ -34,7 +34,7 @@ Resources:
                 Category: Source
                 Owner: ThirdParty
                 Provider: GitHub
-                Version: 1
+                Version: "1"
               OutputArtifacts:
                 - Name: MyApp2
               Configuration:
@@ -47,7 +47,7 @@ Resources:
               ActionTypeId:
                 Category: Build
                 Owner: AWS
-                Version: 1
+                Version: "1"
                 Provider: CodeBuild
               Configuration:
                 ProjectName: cfn-python-lint

--- a/test/templates/good/resources_codepipeline.yaml
+++ b/test/templates/good/resources_codepipeline.yaml
@@ -16,7 +16,7 @@ Resources:
                 Category: Source
                 Owner: ThirdParty
                 Provider: GitHub
-                Version: 1
+                Version: "1"
               OutputArtifacts:
                 - Name: MyApp
               Configuration:
@@ -31,7 +31,7 @@ Resources:
               ActionTypeId:
                 Category: Build
                 Owner: AWS
-                Version: 1
+                Version: "1"
                 Provider: CodeBuild
               Configuration:
                 ProjectName: cfn-python-lint


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Change the version to be a string as stated in documentation and the CloudFormation spec.

https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-actions-actiontypeid.html
https://docs.aws.amazon.com/codepipeline/latest/APIReference/API_ActionTypeId.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
