### PR TITLE
Fix/properties conditions check

### DIFF
--- a/src/cfnlint/rules/resources/properties/Properties.py
+++ b/src/cfnlint/rules/resources/properties/Properties.py
@@ -42,10 +42,10 @@ class Properties(CloudFormationLintRule):
             if len(value) == 1:
                 for sub_key, sub_value in value.items():
                     if sub_key in cfnlint.helpers.CONDITION_FUNCTIONS:
-                        cond_values = self.cfn.get_condition_values(sub_value)
-                        for cond_value in cond_values:
-                            matches.extend(self.primitivetypecheck(
-                                cond_value['Value'], primtype, proppath + cond_value['Path']))
+                        matches.extend(self.primitivetypecheck(
+                            sub_value[1], primtype, proppath + ['Fn::If', 1]))
+                        matches.extend(self.primitivetypecheck(
+                            sub_value[2], primtype, proppath + ['Fn::If', 2]))
                     elif sub_key not in ['Fn::Base64', 'Fn::GetAtt', 'Fn::GetAZs', 'Fn::ImportValue',
                                          'Fn::Join', 'Fn::Split', 'Fn::FindInMap', 'Fn::Select', 'Ref',
                                          'Fn::If', 'Fn::Contains', 'Fn::Sub', 'Fn::Cidr']:

--- a/src/cfnlint/rules/resources/properties/Properties.py
+++ b/src/cfnlint/rules/resources/properties/Properties.py
@@ -42,10 +42,14 @@ class Properties(CloudFormationLintRule):
             if len(value) == 1:
                 for sub_key, sub_value in value.items():
                     if sub_key in cfnlint.helpers.CONDITION_FUNCTIONS:
-                        matches.extend(self.primitivetypecheck(
-                            sub_value[1], primtype, proppath + ['Fn::If', 1]))
-                        matches.extend(self.primitivetypecheck(
-                            sub_value[2], primtype, proppath + ['Fn::If', 2]))
+                        # not erroring on bad Ifs but not need to account for it
+                        # so the rule doesn't error out
+                        if isinstance(sub_value, list):
+                            if len(sub_value) == 3:
+                                matches.extend(self.primitivetypecheck(
+                                    sub_value[1], primtype, proppath + ['Fn::If', 1]))
+                                matches.extend(self.primitivetypecheck(
+                                    sub_value[2], primtype, proppath + ['Fn::If', 2]))
                     elif sub_key not in ['Fn::Base64', 'Fn::GetAtt', 'Fn::GetAZs', 'Fn::ImportValue',
                                          'Fn::Join', 'Fn::Split', 'Fn::FindInMap', 'Fn::Select', 'Ref',
                                          'Fn::If', 'Fn::Contains', 'Fn::Sub', 'Fn::Cidr']:

--- a/test/module/test_template.py
+++ b/test/module/test_template.py
@@ -55,7 +55,7 @@ class TestTemplate(BaseTestCase):
     def test_get_parameters(self):
         """ Test Get Parameters"""
         parameters = self.template.get_parameters()
-        assert len(parameters) == 4
+        assert len(parameters) == 7
 
     def test_get_parameter_names(self):
         """Test Get Parameter Names"""
@@ -65,7 +65,7 @@ class TestTemplate(BaseTestCase):
     def test_get_valid_refs(self):
         """ Get Valid REFs"""
         refs = self.template.get_valid_refs()
-        assert len(refs) == 21
+        assert len(refs) == 24
 
     def test_conditions_return_object_success(self):
         """Test condition object response and nested IFs"""

--- a/test/templates/good/generic.yaml
+++ b/test/templates/good/generic.yaml
@@ -16,6 +16,17 @@ Parameters:
   pIops:
     Type: Number
     Default: 60
+  pEnvironment:
+    Type: String
+    Default: Prod
+  pProdVolumeSize:
+    Type: Number
+    Default: 50
+  pDevVolumeSize:
+    Type: Number
+    Default: 25
+Conditions:
+  ProdVolumeSize: !Equals [!Ref pEnvironment, 'Prod']
 Resources:
   RootRole:
     Type: "AWS::IAM::Role"
@@ -96,7 +107,7 @@ Resources:
             VolumeType: io1
             Iops: !Ref pIops
             DeleteOnTermination: false
-            VolumeSize: 20
+            VolumeSize: !If [ ProdVolumeSize, !Ref pProdVolumeSize, !Ref pDevVolumeSize ]
       NetworkInterfaces:
       -
         DeviceIndex: "1"


### PR DESCRIPTION
*Issue #, if available:*
#86

*Description of changes:*
- Fixes how conditions are handled in Properties checks.  We pass the entire condition result path objects back to the primitive check.  The helper function went down a few layers and logic wasn't built to handle it.  Plus this checks purpose is better served for this logic as we are testing basic structure.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
