### PR TITLE
Feature/standard parse errors

### DIFF
--- a/src/cfnlint/__init__.py
+++ b/src/cfnlint/__init__.py
@@ -833,3 +833,11 @@ class Runner(object):
             if not any(match == u for u in return_matches):
                 return_matches.append(match)
         return return_matches
+
+
+class ParseError(cfnlint.CloudFormationLintRule):
+    """Parse Lint Rule"""
+    id = 'E0000'
+    shortdesc = 'Parsing error found when parsing the template'
+    description = 'Checks for Null values and Duplicat values in resources'
+    tags = ['base']

--- a/src/cfnlint/__init__.py
+++ b/src/cfnlint/__init__.py
@@ -839,5 +839,5 @@ class ParseError(cfnlint.CloudFormationLintRule):
     """Parse Lint Rule"""
     id = 'E0000'
     shortdesc = 'Parsing error found when parsing the template'
-    description = 'Checks for Null values and Duplicat values in resources'
+    description = 'Checks for Null values and Duplicate values in resources'
     tags = ['base']

--- a/src/cfnlint/__main__.py
+++ b/src/cfnlint/__main__.py
@@ -24,13 +24,13 @@ LOGGER = logging.getLogger('cfnlint')
 
 def main():
     """Main function"""
-    (args, template, rules) = cfnlint.core.get_template_args_rules(sys.argv[1:])
+    (args, template, rules, fmt, formatter) = cfnlint.core.get_template_args_rules(sys.argv[1:])
 
     return(
         cfnlint.core.run_cli(
-            vars(args)['template'], template, rules, vars(args)['format'],
+            vars(args)['template'], template, rules, fmt,
             vars(args)['ignore_checks'], vars(args)['regions'],
-            vars(args)['override_spec']))
+            vars(args)['override_spec'], formatter))
 
 
 if __name__ == '__main__':

--- a/src/cfnlint/cfn_yaml.py
+++ b/src/cfnlint/cfn_yaml.py
@@ -26,6 +26,7 @@ from yaml import SequenceNode
 from yaml import MappingNode
 from yaml.constructor import SafeConstructor
 from yaml.constructor import ConstructorError
+import cfnlint
 
 UNCONVERTED_SUFFIXES = ['Ref', 'Condition']
 FN_PREFIX = 'Fn::'
@@ -33,18 +34,22 @@ FN_PREFIX = 'Fn::'
 LOGGER = logging.getLogger(__name__)
 
 
-class DuplicateError(ConstructorError):
+class CfnParseError(ConstructorError):
     """
-    Error thrown when the template contains duplicates
+    Error thrown when the template contains Cfn Error
     """
-    pass
+    def __init__(self, message, line_number, column_number, key=' '):
 
+        # Call the base class constructor with the parameters it needs
+        super(CfnParseError, self).__init__(message)
 
-class NullError(ConstructorError):
-    """
-    Error thrown when the template contains Nulls
-    """
-    pass
+        # Now for your custom code...
+        self.line_number = line_number
+        self.column_number = column_number
+        self.message = message
+        self.match = cfnlint.Match(
+            line_number + 1, column_number + 1, line_number + 1,
+            column_number + 1 + len(key), '', cfnlint.ParseError(), message=message)
 
 
 def create_node_class(cls):
@@ -93,7 +98,9 @@ class NodeConstructor(SafeConstructor):
             value = self.construct_object(value_node, False)
 
             if key in mapping:
-                raise DuplicateError('"{}" (line {})'.format(key, key_node.start_mark.line + 1))
+                raise CfnParseError(
+                    'Duplicate resource found "{}" (line {})'.format(key, key_node.start_mark.line + 1),
+                    key_node.start_mark.line, key_node.start_mark.column, key)
             mapping[key] = value
 
         obj, = SafeConstructor.construct_yaml_map(self, node)
@@ -110,7 +117,9 @@ class NodeConstructor(SafeConstructor):
 
     def construct_yaml_null_error(self, node):
         """Throw a null error"""
-        raise NullError('Null value at line {0} column {1}'.format(node.start_mark.line, node.start_mark.column))
+        raise CfnParseError(
+            'Null value at line {0} column {1}'.format(node.start_mark.line, node.start_mark.column),
+            node.start_mark.line, node.start_mark.column, ' ')
 
 
 NodeConstructor.add_constructor(

--- a/src/cfnlint/core.py
+++ b/src/cfnlint/core.py
@@ -18,6 +18,10 @@ import logging
 import sys
 import os
 import json
+try:
+    from json.decoder import JSONDecodeError
+except ImportError:
+    JSONDecodeError = ValueError
 import argparse
 import six
 from yaml.parser import ParserError, ScannerError
@@ -27,11 +31,6 @@ import cfnlint.cfn_yaml
 import cfnlint.cfn_json
 from cfnlint.version import __version__
 from cfnlint.helpers import REGIONS
-
-try:
-    from json.decoder import JSONDecodeError
-except ImportError:
-    JSONDecodeError = ValueError
 
 LOGGER = logging.getLogger('cfnlint')
 DEFAULT_RULESDIR = os.path.join(os.path.dirname(__file__), 'rules')
@@ -56,11 +55,7 @@ def run_cli(filename, template, rules, fmt, ignore_checks, regions, override_spe
         filename, template, rules, transforms, ignore_checks,
         regions)
 
-    if fmt == 'json':
-        print(json.dumps(matches, indent=4, cls=CustomEncoder))
-    else:
-        for match in matches:
-            print(formatter.format(match))
+    print_matches(matches, fmt, formatter)
 
     return get_exit_code(matches)
 

--- a/test/module/core/test_run_checks.py
+++ b/test/module/core/test_run_checks.py
@@ -27,7 +27,7 @@ class TestRunChecks(BaseTestCase):
         """Test success run"""
 
         filename = 'templates/good/generic.yaml'
-        (args, template, rules) = cfnlint.core.get_template_args_rules([
+        (args, template, rules, _, _) = cfnlint.core.get_template_args_rules([
             '--template', filename])
 
         results = cfnlint.core.run_checks(
@@ -39,7 +39,7 @@ class TestRunChecks(BaseTestCase):
         """Test bad template"""
 
         filename = 'templates/quickstart/nat-instance.json'
-        (args, template, rules) = cfnlint.core.get_template_args_rules([
+        (args, template, rules, _, _) = cfnlint.core.get_template_args_rules([
             '--template', filename])
 
         results = cfnlint.core.run_checks(

--- a/test/module/core/test_run_cli.py
+++ b/test/module/core/test_run_cli.py
@@ -47,7 +47,7 @@ class TestCli(BaseTestCase):
             cfnlint.core.get_template_args_rules([
                 '--template', filename])
 
-        self.assertEqual(exit_code.exception.code, 1)
+        self.assertEqual(exit_code.exception.code, 2)
 
     def test_template_invalid_json(self):
         """Test template not found"""
@@ -57,44 +57,27 @@ class TestCli(BaseTestCase):
             cfnlint.core.get_template_args_rules([
                 '--template', filename])
 
-        self.assertEqual(exit_code.exception.code, 1)
+        self.assertEqual(exit_code.exception.code, 2)
 
     def test_template_invalid_yaml_ignore(self):
         """Test template not found"""
         filename = 'templates/bad/core/config_invalid_yaml.yaml'
 
-        (args, _, _, _, _) = cfnlint.core.get_template_args_rules([
-            '--template', filename, '--ignore-bad-template'])
+        with self.assertRaises(SystemExit) as exit_code:
+            cfnlint.core.get_template_args_rules([
+                '--template', filename, '--ignore-bad-template'])
 
-        self.assertEqual(vars(args), {
-            'append_rules': [],
-            'format': None,
-            'ignore_bad_template': True,
-            'ignore_checks': [],
-            'listrules': False,
-            'log_level': None,
-            'override_spec': None,
-            'regions': ['us-east-1'],
-            'template': 'templates/bad/core/config_invalid_yaml.yaml',
-            'update_specs': False})
+        self.assertEqual(exit_code.exception.code, 2)
 
     def test_template_invalid_json_ignore(self):
         """Test template not found"""
         filename = 'templates/bad/core/config_invalid_json.json'
-        (args, _, _, _, _) = cfnlint.core.get_template_args_rules([
-            '--template', filename, '--ignore-bad-template'])
 
-        self.assertEqual(vars(args), {
-            'append_rules': [],
-            'format': None,
-            'ignore_bad_template': True,
-            'ignore_checks': [],
-            'listrules': False,
-            'log_level': None,
-            'override_spec': None,
-            'regions': ['us-east-1'],
-            'template': 'templates/bad/core/config_invalid_json.json',
-            'update_specs': False})
+        with self.assertRaises(SystemExit) as exit_code:
+            cfnlint.core.get_template_args_rules([
+                '--template', filename, '--ignore-bad-template'])
+
+        self.assertEqual(exit_code.exception.code, 2)
 
     def test_template_config(self):
         """Test template config"""

--- a/test/module/core/test_run_cli.py
+++ b/test/module/core/test_run_cli.py
@@ -63,7 +63,7 @@ class TestCli(BaseTestCase):
         """Test template not found"""
         filename = 'templates/bad/core/config_invalid_yaml.yaml'
 
-        (args, _, _) = cfnlint.core.get_template_args_rules([
+        (args, _, _, _, _) = cfnlint.core.get_template_args_rules([
             '--template', filename, '--ignore-bad-template'])
 
         self.assertEqual(vars(args), {
@@ -81,7 +81,7 @@ class TestCli(BaseTestCase):
     def test_template_invalid_json_ignore(self):
         """Test template not found"""
         filename = 'templates/bad/core/config_invalid_json.json'
-        (args, _, _) = cfnlint.core.get_template_args_rules([
+        (args, _, _, _, _) = cfnlint.core.get_template_args_rules([
             '--template', filename, '--ignore-bad-template'])
 
         self.assertEqual(vars(args), {
@@ -99,7 +99,7 @@ class TestCli(BaseTestCase):
     def test_template_config(self):
         """Test template config"""
         filename = 'templates/good/core/config_parameters.yaml'
-        (args, _, _) = cfnlint.core.get_template_args_rules([
+        (args, _, _, _, _) = cfnlint.core.get_template_args_rules([
             '--template', filename, '--ignore-bad-template'])
 
         self.assertEqual(vars(args), {
@@ -117,7 +117,7 @@ class TestCli(BaseTestCase):
     def test_override_parameters(self):
         """Test overriding parameters"""
         filename = 'templates/good/core/config_parameters.yaml'
-        (args, _, _) = cfnlint.core.get_template_args_rules([
+        (args, _, _, _, _) = cfnlint.core.get_template_args_rules([
             '--template', filename, '--ignore-bad-template',
             '--ignore-checks', 'E0000'])
 
@@ -137,7 +137,7 @@ class TestCli(BaseTestCase):
         """ Test bad formatting in config"""
 
         filename = 'templates/bad/core/config_parameters.yaml'
-        (args, _, _) = cfnlint.core.get_template_args_rules([
+        (args, _, _, _, _) = cfnlint.core.get_template_args_rules([
             '--template', filename, '--ignore-bad-template'])
 
         self.assertEqual(vars(args), {

--- a/test/module/test_duplicate.py
+++ b/test/module/test_duplicate.py
@@ -42,7 +42,7 @@ class TestDuplicate(BaseTestCase):
             loader = cfnlint.cfn_yaml.MarkedLoader(fp.read())
             loader.add_multi_constructor('!', cfnlint.cfn_yaml.multi_constructor)
             loader.get_single_data()
-        except cfnlint.cfn_yaml.DuplicateError:
+        except cfnlint.cfn_yaml.CfnParseError:
             assert(False)
             return
 
@@ -74,7 +74,7 @@ class TestDuplicate(BaseTestCase):
             loader = cfnlint.cfn_yaml.MarkedLoader(fp.read())
             loader.add_multi_constructor('!', cfnlint.cfn_yaml.multi_constructor)
             loader.get_single_data()
-        except cfnlint.cfn_yaml.DuplicateError:
+        except cfnlint.cfn_yaml.CfnParseError:
             assert(True)
             return
 

--- a/test/module/test_null_values.py
+++ b/test/module/test_null_values.py
@@ -42,7 +42,7 @@ class TestNulls(BaseTestCase):
             loader = cfnlint.cfn_yaml.MarkedLoader(fp.read())
             loader.add_multi_constructor('!', cfnlint.cfn_yaml.multi_constructor)
             loader.get_single_data()
-        except cfnlint.cfn_yaml.NullError:
+        except cfnlint.cfn_yaml.CfnParseError:
             assert(False)
             return
 
@@ -74,7 +74,7 @@ class TestNulls(BaseTestCase):
             loader = cfnlint.cfn_yaml.MarkedLoader(fp.read())
             loader.add_multi_constructor('!', cfnlint.cfn_yaml.multi_constructor)
             loader.get_single_data()
-        except cfnlint.cfn_yaml.NullError:
+        except cfnlint.cfn_yaml.CfnParseError:
             assert(True)
             return
 


### PR DESCRIPTION
*Issue #, if available:*
Fixes https://github.com/awslabs/aws-cfn-lint-atom/issues/3
Fixes #86

*Description of changes:*
- Responding with cfn-lint standard responses when running into duplicate, null, and parse errors.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
