### PR TITLE
Fix sub missing Pseudo Parameters

### DIFF
--- a/src/cfnlint/rules/functions/Sub.py
+++ b/src/cfnlint/rules/functions/Sub.py
@@ -31,7 +31,7 @@ class Sub(CloudFormationLintRule):
         """Test if a string has appropriate parameters"""
 
         matches = list()
-        regex = re.compile(r'\${[^!][a-zA-Z0-9.:]+}')
+        regex = re.compile(r'\${[^!].*?}')
         string_params = regex.findall(sub_string)
         get_atts = cfn.get_valid_getatts()
 

--- a/src/cfnlint/rules/functions/Sub.py
+++ b/src/cfnlint/rules/functions/Sub.py
@@ -31,7 +31,7 @@ class Sub(CloudFormationLintRule):
         """Test if a string has appropriate parameters"""
 
         matches = list()
-        regex = re.compile(r'\${[^!][a-zA-Z0-9.]+}')
+        regex = re.compile(r'\${[^!][a-zA-Z0-9.:]+}')
         string_params = regex.findall(sub_string)
         get_atts = cfn.get_valid_getatts()
 

--- a/test/rules/functions/test_sub.py
+++ b/test/rules/functions/test_sub.py
@@ -31,4 +31,4 @@ class TestRulesSub(BaseRuleTestCase):
 
     def test_file_negative(self):
         """Test failure"""
-        self.helper_file_negative('templates/bad/functions_sub.yaml', 7)
+        self.helper_file_negative('templates/bad/functions_sub.yaml', 8)

--- a/test/rules/functions/test_sub.py
+++ b/test/rules/functions/test_sub.py
@@ -31,4 +31,4 @@ class TestRulesSub(BaseRuleTestCase):
 
     def test_file_negative(self):
         """Test failure"""
-        self.helper_file_negative('templates/bad/functions_sub.yaml', 8)
+        self.helper_file_negative('templates/bad/functions_sub.yaml', 9)

--- a/test/templates/bad/functions_sub.yaml
+++ b/test/templates/bad/functions_sub.yaml
@@ -14,7 +14,7 @@ Resources:
                 listen-address: 127.0.0.1
                 port: 9200
                 target: https://${mySubStack.Outputs.DomainEndpoint}
-                region: ${AWS::Region}
+                region: ${AWS::BadRegion}
                 loadbalancer: ${myInstance3.PublicDnsName1}
                 badresource: ${myInstance5.PublicDnsName}
     Properties:

--- a/test/templates/bad/functions_sub.yaml
+++ b/test/templates/bad/functions_sub.yaml
@@ -15,6 +15,8 @@ Resources:
                 port: 9200
                 target: https://${mySubStack.Outputs.DomainEndpoint}
                 region: ${AWS::BadRegion}
+                failover-region: ${AWS AnotherRegion}
+                literal: ${!Literal}
                 loadbalancer: ${myInstance3.PublicDnsName1}
                 badresource: ${myInstance5.PublicDnsName}
     Properties:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Missing Pseudo Parameters in Sub ref checks which resulted in Bad Pseudo Parameters not being caught.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
