### PR TITLE
Allow AllowedValues parameter property when using CIDR

### DIFF
--- a/src/cfnlint/rules/parameters/Cidr.py
+++ b/src/cfnlint/rules/parameters/Cidr.py
@@ -19,7 +19,7 @@ from cfnlint import RuleMatch
 
 
 class Cidr(CloudFormationLintRule):
-    """Check Availibility Zone parameter checks """
+    """Check Availability Zone parameter checks """
     id = 'W2509'
     shortdesc = 'CIDR Parameters have allowed values'
     description = 'Check if a parameter is being used as a CIDR. ' \
@@ -49,8 +49,8 @@ class Cidr(CloudFormationLintRule):
             'AWS::EC2::SecurityGroup.Ingress',
         ]
 
-        for resoruce_type_spec in resource_type_specs:
-            self.resource_property_types.append(resoruce_type_spec)
+        for resource_type_spec in resource_type_specs:
+            self.resource_property_types.append(resource_type_spec)
         for property_type_spec in property_type_specs:
             self.resource_sub_property_types.append(property_type_spec)
 

--- a/test/rules/parameters/test_cidr_allowed_values.py
+++ b/test/rules/parameters/test_cidr_allowed_values.py
@@ -1,0 +1,38 @@
+"""
+  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this
+  software and associated documentation files (the "Software"), to deal in the Software
+  without restriction, including without limitation the rights to use, copy, modify,
+  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+from cfnlint.rules.parameters.CidrAllowedValues import CidrAllowedValues  # pylint: disable=E0401
+from .. import BaseRuleTestCase
+
+
+class TestParameterCidrAllowedValues(BaseRuleTestCase):
+    """Test template parameter configurations"""
+    def setUp(self):
+        """Setup"""
+        super(TestParameterCidrAllowedValues, self).setUp()
+        self.collection.register(CidrAllowedValues())
+
+    success_templates = [
+        'templates/good/properties_ec2_vpc.yaml',
+    ]
+
+    def test_file_positive(self):
+        """Test Positive"""
+        self.helper_file_positive()
+
+    def test_file_negative(self):
+        """Test failure"""
+        self.helper_file_negative('templates/bad/properties_ec2_network.yaml', 3)

--- a/test/templates/bad/properties_ec2_network.yaml
+++ b/test/templates/bad/properties_ec2_network.yaml
@@ -5,6 +5,12 @@ Description: >
 Parameters:
   cidrBlock:
     Type: Number
+  cidrBlockAllowedValues:
+    Type: String
+    AllowedValues:
+      - '127.0.0.1'
+      - '8.8.8.8'
+      - 'notacidr'
   vpcTenancy:
     Type: String
     AllowedValues:
@@ -23,6 +29,11 @@ Resources:
     Properties:
       InstanceTenancy: !Ref vpcTenancy
       CidrBlock: 10.0.0.3
+  myVpc3:
+    Type: AWS::EC2::VPC
+    Properties:
+      InstanceTenancy: !Ref vpcTenancy
+      CidrBlock: !Ref cidrBlockAllowedValues
   mySubnet2-1:
     Type: AWS::EC2::Subnet
     Properties:

--- a/test/templates/good/properties_ec2_vpc.yaml
+++ b/test/templates/good/properties_ec2_vpc.yaml
@@ -3,9 +3,20 @@ AWSTemplateFormatVersion: "2010-09-09"
 Description: >
   AWS EC2 Good Template
 Parameters:
-  cidrBlock:
+  cidrBlockAllowedPattern:
     Type: String
     AllowedPattern: '^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$'
+  cidrBlockAllowedValues:
+    Type: String
+    AllowedValues:
+      - '127.0.0.1/32'
+      - '8.8.8.8/32'
+  cidrBlockAllowedPatternValues:
+    Type: String
+    AllowedPattern: '^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$'
+    AllowedValues:
+      - '127.0.0.1/32'
+      - '8.8.8.8/32'
   vpcTenancy:
     Type: String
     AllowedValues:
@@ -15,23 +26,33 @@ Resources:
   myVpc1:
     Type: AWS::EC2::VPC
     Properties:
-      CidrBlock: !Ref cidrBlock
+      CidrBlock: !Ref cidrBlockAllowedPattern
       InstanceTenancy: default
   myVpc2:
     Type: AWS::EC2::VPC
     Properties:
       InstanceTenancy: !Ref vpcTenancy
-      CidrBlock: !Ref cidrBlock
+      CidrBlock: !Ref cidrBlockAllowedPattern
+  myVpc3:
+    Type: AWS::EC2::VPC
+    Properties:
+      InstanceTenancy: !Ref vpcTenancy
+      CidrBlock: !Ref cidrBlockAllowedValues
+  myVpc4:
+    Type: AWS::EC2::VPC
+    Properties:
+      InstanceTenancy: !Ref vpcTenancy
+      CidrBlock: !Ref cidrBlockAllowedPatternValues
   mySubnet21:
     Type: AWS::EC2::Subnet
     Properties:
       CidrBlock:
         Fn::Select:
         - 0
-        - !Cidr [!Ref cidrBlock, 3, 16]
+        - !Cidr [!Ref cidrBlockAllowedPattern, 3, 16]
       VpcId: vpc-1234567
   mySubnet22:
     Type: AWS::EC2::Subnet
     Properties:
-      CidrBlock: !Ref cidrBlock
+      CidrBlock: !Ref cidrBlockAllowedPattern
       VpcId: vpc-1234567


### PR DESCRIPTION
*Issue #, if available:*
Fixes #93

*Description of changes:*
When using a parameter as a CIDR, this PR allows you to also use the AllowedValues property instead of only the AllowedPattern property.

In addition I added an extra check. If you are using AllowedValues as a CIDR, it goes through the values to see if they are proper CIDRs. If not it errors.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
