### PR TITLE
Test that Refs in Conditions don't map to resources

### DIFF
--- a/src/cfnlint/rules/functions/Ref.py
+++ b/src/cfnlint/rules/functions/Ref.py
@@ -35,7 +35,7 @@ class Ref(CloudFormationLintRule):
 
         for ref_obj in ref_objs:
             value = ref_obj[-1]
-            if not isinstance(value, (six.string_types, six.text_type, int)):
+            if not isinstance(value, (six.string_types, six.text_type)):
                 message = 'Ref can only be a string for {0}'
                 matches.append(RuleMatch(ref_obj[:-1], message.format('/'.join(map(str, ref_obj[:-1])))))
 

--- a/src/cfnlint/rules/functions/RefExist.py
+++ b/src/cfnlint/rules/functions/RefExist.py
@@ -65,11 +65,12 @@ class RefExist(CloudFormationLintRule):
         # start with the basic ref calls
         for reftree in reftrees:
             ref = reftree[-1]
-            if ref not in valid_refs:
-                message = 'Ref {0} not found as a resource or parameter'
-                matches.append(RuleMatch(
-                    reftree[:-2], message.format(ref)
-                ))
+            if isinstance(ref, (six.string_types, six.text_type, int)):
+                if ref not in valid_refs:
+                    message = 'Ref {0} not found as a resource or parameter'
+                    matches.append(RuleMatch(
+                        reftree[:-2], message.format(ref)
+                    ))
         for subtree in subtrees:
             sub = subtree[-1]
             parammatches = []

--- a/src/cfnlint/rules/resources/CircularDependency.py
+++ b/src/cfnlint/rules/resources/CircularDependency.py
@@ -93,12 +93,13 @@ class CircularDependency(CloudFormationLintRule):
         resources = {}
         for ref_obj in ref_objs:
             value = ref_obj[-1]
-            ref_type, ref_name = ref_obj[:2]
-            if ref_type == 'Resources':
-                if cfn.template.get('Resources', {}).get(value, {}):
-                    if not resources.get(ref_name):
-                        resources[ref_name] = []
-                    resources[ref_name].append(value)
+            if isinstance(value, (six.text_type, six.string_types, int)):
+                ref_type, ref_name = ref_obj[:2]
+                if ref_type == 'Resources':
+                    if cfn.template.get('Resources', {}).get(value, {}):
+                        if not resources.get(ref_name):
+                            resources[ref_name] = []
+                        resources[ref_name].append(value)
 
         getatt_objs = cfn.search_deep_keys('Fn::GetAtt')
         for getatt_obj in getatt_objs:

--- a/test/rules/functions/test_ref.py
+++ b/test/rules/functions/test_ref.py
@@ -14,29 +14,21 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-import six
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules.functions.Ref import Ref  # pylint: disable=E0401
+from .. import BaseRuleTestCase
 
 
-class Ref(CloudFormationLintRule):
-    """Check if Ref value is a string"""
-    id = 'E1020'
-    shortdesc = 'Ref validation of value'
-    description = 'Making the Ref has a value of String (no other functions are supported)'
-    tags = ['base', 'functions', 'ref']
+class TestRulesRef(BaseRuleTestCase):
+    """Test Rules Ref exists """
+    def setUp(self):
+        """Setup"""
+        super(TestRulesRef, self).setUp()
+        self.collection.register(Ref())
 
-    def match(self, cfn):
-        """Check CloudFormation Ref"""
+    def test_file_positive(self):
+        """Test Positive"""
+        self.helper_file_positive()
 
-        matches = list()
-
-        ref_objs = cfn.search_deep_keys('Ref')
-
-        for ref_obj in ref_objs:
-            value = ref_obj[-1]
-            if not isinstance(value, (six.string_types, six.text_type, int)):
-                message = 'Ref can only be a string for {0}'
-                matches.append(RuleMatch(ref_obj[:-1], message.format('/'.join(map(str, ref_obj[:-1])))))
-
-        return matches
+    def test_file_negative(self):
+        """Test failure"""
+        self.helper_file_negative('templates/bad/functions/ref.yaml', 1)

--- a/test/rules/functions/test_ref_exist.py
+++ b/test/rules/functions/test_ref_exist.py
@@ -31,4 +31,4 @@ class TestRulesRefExist(BaseRuleTestCase):
 
     def test_file_negative(self):
         """Test failure"""
-        self.helper_file_negative('templates/bad/functions_ref.yaml', 5)
+        self.helper_file_negative('templates/bad/functions/ref.yaml', 5)

--- a/test/rules/functions/test_ref_in_condition.py
+++ b/test/rules/functions/test_ref_in_condition.py
@@ -14,29 +14,21 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-import six
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules.functions.RefInCondition import RefInCondition  # pylint: disable=E0401
+from .. import BaseRuleTestCase
 
 
-class Ref(CloudFormationLintRule):
-    """Check if Ref value is a string"""
-    id = 'E1020'
-    shortdesc = 'Ref validation of value'
-    description = 'Making the Ref has a value of String (no other functions are supported)'
-    tags = ['base', 'functions', 'ref']
+class TestRulesRefInCondition(BaseRuleTestCase):
+    """Test Rules Ref exists """
+    def setUp(self):
+        """Setup"""
+        super(TestRulesRefInCondition, self).setUp()
+        self.collection.register(RefInCondition())
 
-    def match(self, cfn):
-        """Check CloudFormation Ref"""
+    def test_file_positive(self):
+        """Test Positive"""
+        self.helper_file_positive()
 
-        matches = list()
-
-        ref_objs = cfn.search_deep_keys('Ref')
-
-        for ref_obj in ref_objs:
-            value = ref_obj[-1]
-            if not isinstance(value, (six.string_types, six.text_type, int)):
-                message = 'Ref can only be a string for {0}'
-                matches.append(RuleMatch(ref_obj[:-1], message.format('/'.join(map(str, ref_obj[:-1])))))
-
-        return matches
+    def test_file_negative(self):
+        """Test failure"""
+        self.helper_file_negative('templates/bad/functions/ref.yaml', 1)

--- a/test/templates/bad/functions/ref.yaml
+++ b/test/templates/bad/functions/ref.yaml
@@ -1,0 +1,71 @@
+---
+AWSTemplateFormatVersion: "2010-09-09"
+Parameters:
+  myVpcId:
+    Description: MyVpc Id
+    Type: AWS::EC2::VPC::Id
+Conditions:
+  cVpc: !Equals [!Ref mySecurityGroupVpc1, 'VpcId']
+Resources:
+  mySecurityGroupVpc1:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: !Ref [ 1 ]
+      VpcId: !Ref myVpcId
+      SecurityGroupIngress:
+      -
+        IpProtocol: 1
+        SourceSecurityGroupId: 'sg-1234567'
+      -
+        IpProtocol: 1
+        SourceSecurityGroupId: !Ref mySecurityGroupVpc2
+  mySecurityGroupVpc2:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: 'Security Group Vpc 2'
+      VpcId: !Ref myVpcId
+      SecurityGroupIngress:
+      -
+        IpProtocol: 1
+        SourceSecurityGroupId: !Ref mySecurityGroupVpc1
+  MyEC2Instance:
+    Type: "AWS::EC2::Instance"
+    Properties:
+      ImageId: "ami-2f726546"
+      InstanceType: t1.micro
+      KeyName: testkey
+      BlockDeviceMappings:
+        -
+          DeviceName: /dev/sdm
+          Ebs:
+            VolumeType: io1
+            Iops: !Ref pIops
+            DeleteOnTermination: false
+            VolumeSize: 20
+      NetworkInterfaces:
+        - DeviceIndex: "1"
+      # Package doesn't exist as parameter
+      UserData: !Sub |
+        yum install ${Package}
+  AnotherInstance:
+    Type: "AWS::EC2::Instance"
+    Properties:
+      ImageId: "ami-2f726546"
+      InstanceType: t1.micro
+      KeyName: testkey
+      BlockDeviceMappings:
+        -
+          DeviceName: /dev/sdm
+          Ebs:
+            VolumeType: io1
+            Iops: !Ref pIops
+            DeleteOnTermination: false
+            VolumeSize: 20
+      NetworkInterfaces:
+        - DeviceIndex: "1"
+      # Package doesn't exist as parameter
+      UserData:
+        Fn::Sub:
+        - "yum install ${myPackage} ${Package}"
+        -
+          myPackage: !Ref httpdPackage


### PR DESCRIPTION
*Issue #, if available:*
Fixes #99 

*Description of changes:*
- Fix issues in which rules fail if a Ref isn't a string or int.
- Validate that Refs on Conditions don't Ref to Resources.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
