### PR TITLE
Fix type checking of nested functions

### DIFF
--- a/src/cfnlint/rules/resources/properties/ValuePrimitiveType.py
+++ b/src/cfnlint/rules/resources/properties/ValuePrimitiveType.py
@@ -43,7 +43,8 @@ class ValuePrimitiveType(CloudFormationLintRule):
         """Check Value"""
         matches = list()
         primitive_type = kwargs.get('primitive_type', {})
-        if isinstance(value, dict) and primitive_type == 'Json':
+
+        if isinstance(value, dict):
             return matches
         if primitive_type in ['String']:
             if not isinstance(value, (str, six.text_type, six.string_types)):


### PR DESCRIPTION
Issue 42

Hotfix on the type checking. Got an error the following:

```
  ApplicationLoadBalancer:
    Type: "AWS::ElasticLoadBalancingV2::LoadBalancer"
    Properties:
      SecurityGroups:
        - !If [IsAcceptance, !ImportValue "import-something", !Ref "AWS::NoValue"]
```
The "!ImportValue" is not a string, which is true.

Not sure if it's fixable in the `check_values()` method, for now hotfixed it in the type checking. 

The reasons that there's 1 less failure in the test is here: https://github.com/awslabs/cfn-python-lint/blob/master/test/templates/quickstart/vpc.json#L489 (Which is valid but broke on the function)

(Also Validated against our codebase)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
