### PR TITLE
Handle empty yaml files

### DIFF
--- a/src/cfnlint/core.py
+++ b/src/cfnlint/core.py
@@ -204,6 +204,9 @@ def get_template_args_rules(cli_args):
             loader = cfnlint.cfn_yaml.MarkedLoader(fp.read())
             loader.add_multi_constructor('!', cfnlint.cfn_yaml.multi_constructor)
             template = loader.get_single_data()
+            # Convert an empty file to an empty dict
+            if template is None:
+                template = {}
             defaults = get_default_args(template)
         except IOError as e:
             if e.errno == 2:


### PR DESCRIPTION
Already handled correctly for json files

Issue https://github.com/awslabs/cfn-python-lint/issues/104

yaml loader loads empty string as `None`, convert these to an empty dict so it's handled correctly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
