### PR TITLE
Moved YAML Template loading logic to the YAML loader

### DIFF
--- a/src/cfnlint/cfn_yaml.py
+++ b/src/cfnlint/cfn_yaml.py
@@ -188,3 +188,17 @@ def construct_getatt(node):
         return [s.value for s in node.value]
     else:
         raise ValueError('Unexpected node type: {}'.format(type(node.value)))
+
+def load(filename):
+    """
+    Load the give YAML file
+    """
+    fp = open(filename)
+    loader = MarkedLoader(fp.read())
+    loader.add_multi_constructor('!', multi_constructor)
+    template = loader.get_single_data()
+    # Convert an empty file to an empty dict
+    if template is None:
+        template = {}
+
+    return template

--- a/src/cfnlint/core.py
+++ b/src/cfnlint/core.py
@@ -200,14 +200,7 @@ def get_template_args_rules(cli_args):
         filename = vars(args[0])['template']
         ignore_bad_template = vars(args[0])['ignore_bad_template']
         try:
-            fp = open(filename)
-            loader = cfnlint.cfn_yaml.MarkedLoader(fp.read())
-            loader.add_multi_constructor('!', cfnlint.cfn_yaml.multi_constructor)
-            template = loader.get_single_data()
-            # Convert an empty file to an empty dict
-            if template is None:
-                template = {}
-            defaults = get_default_args(template)
+            template = cfnlint.cfn_yaml.load(filename)
         except IOError as e:
             if e.errno == 2:
                 LOGGER.error('Template file not found: %s', filename)
@@ -252,6 +245,8 @@ def get_template_args_rules(cli_args):
                 matches = [create_match_yaml_parser_error(err, filename)]
                 print_matches(matches, fmt, formatter)
                 sys.exit(get_exit_code(matches))
+
+    defaults = get_default_args(template)
 
     append_parser(parser, defaults)
     args = parser.parse_args(cli_args)

--- a/test/module/test_duplicate.py
+++ b/test/module/test_duplicate.py
@@ -38,10 +38,7 @@ class TestDuplicate(BaseTestCase):
         filename = 'templates/good/generic.yaml'
 
         try:
-            fp = open(filename)
-            loader = cfnlint.cfn_yaml.MarkedLoader(fp.read())
-            loader.add_multi_constructor('!', cfnlint.cfn_yaml.multi_constructor)
-            loader.get_single_data()
+            cfnlint.cfn_yaml.load(filename)
         except cfnlint.cfn_yaml.CfnParseError:
             assert(False)
             return
@@ -70,10 +67,7 @@ class TestDuplicate(BaseTestCase):
         filename = 'templates/bad/duplicate.yaml'
 
         try:
-            fp = open(filename)
-            loader = cfnlint.cfn_yaml.MarkedLoader(fp.read())
-            loader.add_multi_constructor('!', cfnlint.cfn_yaml.multi_constructor)
-            loader.get_single_data()
+            cfnlint.cfn_yaml.load(filename)
         except cfnlint.cfn_yaml.CfnParseError:
             assert(True)
             return

--- a/test/module/test_null_values.py
+++ b/test/module/test_null_values.py
@@ -38,10 +38,7 @@ class TestNulls(BaseTestCase):
         filename = 'templates/good/generic.yaml'
 
         try:
-            fp = open(filename)
-            loader = cfnlint.cfn_yaml.MarkedLoader(fp.read())
-            loader.add_multi_constructor('!', cfnlint.cfn_yaml.multi_constructor)
-            loader.get_single_data()
+            cfnlint.cfn_yaml.load(filename)
         except cfnlint.cfn_yaml.CfnParseError:
             assert(False)
             return
@@ -70,10 +67,7 @@ class TestNulls(BaseTestCase):
         filename = 'templates/bad/null_values.yaml'
 
         try:
-            fp = open(filename)
-            loader = cfnlint.cfn_yaml.MarkedLoader(fp.read())
-            loader.add_multi_constructor('!', cfnlint.cfn_yaml.multi_constructor)
-            loader.get_single_data()
+            cfnlint.cfn_yaml.load(filename)
         except cfnlint.cfn_yaml.CfnParseError:
             assert(True)
             return

--- a/test/module/test_rules_collections.py
+++ b/test/module/test_rules_collections.py
@@ -40,10 +40,7 @@ class TestTemplate(BaseTestCase):
     def test_success_run(self):
         """ Test Run Logic"""
         filename = 'templates/good/generic.yaml'
-        fp = open(filename)
-        loader = cfnlint.cfn_yaml.MarkedLoader(fp.read())
-        loader.add_multi_constructor("!", cfnlint.cfn_yaml.multi_constructor)
-        template = loader.get_single_data()
+        template = cfnlint.cfn_yaml.load(filename)
         cfn = Template(template, ['us-east-1'])
 
         matches = list()
@@ -53,10 +50,7 @@ class TestTemplate(BaseTestCase):
     def test_fail_run(self):
         """Test failure run"""
         filename = 'templates/bad/generic.yaml'
-        fp = open(filename)
-        loader = cfnlint.cfn_yaml.MarkedLoader(fp.read())
-        loader.add_multi_constructor("!", cfnlint.cfn_yaml.multi_constructor)
-        template = loader.get_single_data()
+        template = cfnlint.cfn_yaml.load(filename)
         cfn = Template(template, ['us-east-1'])
 
         matches = list()
@@ -66,10 +60,7 @@ class TestTemplate(BaseTestCase):
     def test_fail_sub_properties_run(self):
         """Test failure run"""
         filename = 'templates/bad/properties_onlyone.yaml'
-        fp = open(filename)
-        loader = cfnlint.cfn_yaml.MarkedLoader(fp.read())
-        loader.add_multi_constructor("!", cfnlint.cfn_yaml.multi_constructor)
-        template = loader.get_single_data()
+        template = cfnlint.cfn_yaml.load(filename)
         cfn = Template(template, ['us-east-1'])
 
         matches = list()

--- a/test/testlib/testcase.py
+++ b/test/testlib/testcase.py
@@ -15,7 +15,7 @@
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 from unittest import TestCase
-from cfnlint.cfn_yaml import MarkedLoader, multi_constructor
+import cfnlint.cfn_yaml
 
 
 class BaseTestCase(TestCase):
@@ -28,7 +28,4 @@ class BaseTestCase(TestCase):
 
     def load_template(self, filename):
         """Return teplate"""
-        fp = open(filename)
-        loader = MarkedLoader(fp.read())
-        loader.add_multi_constructor("!", multi_constructor)
-        return loader.get_single_data()
+        return cfnlint.cfn_yaml.load(filename)


### PR DESCRIPTION
Issue: https://github.com/awslabs/cfn-python-lint/issues/47

Move YAML template loading logic to `cfn_yaml` make remove duplicate code and make the code easier to re-use. Think the location is also better because the yaml loading responsibility is now in central place.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
