### PR TITLE
Make Parseable output really parseable

### DIFF
--- a/src/cfnlint/formatters/__init__.py
+++ b/src/cfnlint/formatters/__init__.py
@@ -46,7 +46,7 @@ class ParseableFormatter(object):
     """Parseable Formmatter"""
     def format(self, match):
         """Format output"""
-        formatstr = u'{0}:{1}:{2}:{3}:{4}: [{5}] {6}'
+        formatstr = u'{0}:{1}:{2}:{3}:{4}:{5}:{6}'
         return formatstr.format(
             match.filename,
             match.linenumber,


### PR DESCRIPTION
The `ParseableFormatter` is not really parseable at the moment since the Error ID is in the Error message.

Since it's not really used ATM (As far as I could find out) I changed the current one. This makes the output actually easy to parse...

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.