### PR TITLE
Simplify ignore rules logic instead of passing it all over

### DIFF
--- a/src/cfnlint/__main__.py
+++ b/src/cfnlint/__main__.py
@@ -29,7 +29,7 @@ def main():
     return(
         cfnlint.core.run_cli(
             vars(args)['template'], template, rules, fmt,
-            vars(args)['ignore_checks'], vars(args)['regions'],
+            vars(args)['regions'],
             vars(args)['override_spec'], formatter))
 
 

--- a/src/cfnlint/core.py
+++ b/src/cfnlint/core.py
@@ -44,7 +44,7 @@ class ArgumentParser(argparse.ArgumentParser):
         self.exit(32, '%s: error: %s\n' % (self.prog, message))
 
 
-def run_cli(filename, template, rules, fmt, ignore_checks, regions, override_spec, formatter):
+def run_cli(filename, template, rules, fmt, regions, override_spec, formatter):
     """Process args and run"""
 
     if override_spec:
@@ -52,8 +52,7 @@ def run_cli(filename, template, rules, fmt, ignore_checks, regions, override_spe
 
     transforms = get_transforms()
     matches = run_checks(
-        filename, template, rules, transforms, ignore_checks,
-        regions)
+        filename, template, rules, transforms, regions)
 
     print_matches(matches, fmt, formatter)
 
@@ -125,9 +124,9 @@ def get_formatter(fmt):
     return formatter
 
 
-def get_rules(rulesdir):
+def get_rules(rulesdir, ignore_rules):
     """Get rules"""
-    rules = RulesCollection()
+    rules = RulesCollection(ignore_rules)
     rules_dirs = [DEFAULT_RULESDIR] + rulesdir
     for rules_dir in rules_dirs:
         rules.extend(
@@ -255,7 +254,7 @@ def get_template_args_rules(cli_args):
         cfnlint.helpers.update_resource_specs()
         exit(0)
 
-    rules = cfnlint.core.get_rules(vars(args)['append_rules'])
+    rules = cfnlint.core.get_rules(vars(args)['append_rules'], vars(args)['ignore_checks'])
 
     if vars(args)['listrules']:
         print(rules)
@@ -298,7 +297,7 @@ def get_default_args(template):
     return defaults
 
 
-def run_checks(filename, template, rules, transforms, ignore_checks, regions):
+def run_checks(filename, template, rules, transforms, regions):
     """Run Checks against the template"""
     if regions:
 
@@ -310,8 +309,7 @@ def run_checks(filename, template, rules, transforms, ignore_checks, regions):
     matches = list()
 
     runner = cfnlint.Runner(
-        rules, transforms, filename, template,
-        ignore_checks, regions)
+        rules, transforms, filename, template, regions)
     matches.extend(runner.transform())
     # Only do rule analysis if Transform was successful
     if not matches:

--- a/test/module/core/test_run_checks.py
+++ b/test/module/core/test_run_checks.py
@@ -31,7 +31,7 @@ class TestRunChecks(BaseTestCase):
             '--template', filename])
 
         results = cfnlint.core.run_checks(
-            vars(args)['template'], template, rules, {}, {}, ['us-east-1'])
+            vars(args)['template'], template, rules, {}, ['us-east-1'])
 
         assert(results == [])
 
@@ -43,7 +43,7 @@ class TestRunChecks(BaseTestCase):
             '--template', filename])
 
         results = cfnlint.core.run_checks(
-            vars(args)['template'], template, rules, {}, {}, ['us-east-1'])
+            vars(args)['template'], template, rules, {}, ['us-east-1'])
 
         assert(results[0].rule.id == 'W2506')
         assert(results[1].rule.id == 'W2001')

--- a/test/module/override/test_complete.py
+++ b/test/module/override/test_complete.py
@@ -43,7 +43,7 @@ class TestComplete(BaseTestCase):
 
         cfnlint.helpers.set_specs(custom_spec)
 
-        good_runner = Runner(self.collection, [], filename, template, [], ['us-east-1'], [])
+        good_runner = Runner(self.collection, [], filename, template, ['us-east-1'], [])
         self.assertEqual([], good_runner.run())
 
     def test_fail_run(self):
@@ -54,6 +54,6 @@ class TestComplete(BaseTestCase):
         custom_spec = json.load(open('templates/override_spec/complete.json'))
         cfnlint.helpers.set_specs(custom_spec)
 
-        bad_runner = Runner(self.collection, [], filename, template, [], ['us-east-1'], [])
+        bad_runner = Runner(self.collection, [], filename, template, ['us-east-1'], [])
         errs = bad_runner.run()
         self.assertEqual(3, len(errs))

--- a/test/module/override/test_exclude.py
+++ b/test/module/override/test_exclude.py
@@ -41,7 +41,7 @@ class TestExclude(BaseTestCase):
 
         cfnlint.helpers.set_specs(custom_spec)
 
-        good_runner = Runner(self.collection, [], filename, template, [], ['us-east-1'], [])
+        good_runner = Runner(self.collection, [], filename, template, ['us-east-1'], [])
         self.assertEqual([], good_runner.run())
 
     def test_fail_run(self):
@@ -52,6 +52,6 @@ class TestExclude(BaseTestCase):
         custom_spec = json.load(open('templates/override_spec/exclude.json'))
         cfnlint.helpers.set_specs(custom_spec)
 
-        bad_runner = Runner(self.collection, [], filename, template, [], ['us-east-1'], [])
+        bad_runner = Runner(self.collection, [], filename, template, ['us-east-1'], [])
         errs = bad_runner.run()
         self.assertEqual(2, len(errs))

--- a/test/module/override/test_include.py
+++ b/test/module/override/test_include.py
@@ -41,6 +41,6 @@ class TestInclude(BaseTestCase):
         custom_spec = json.load(open('templates/override_spec/include.json'))
         cfnlint.helpers.set_specs(custom_spec)
 
-        bad_runner = Runner(self.collection, [], filename, template, [], ['us-east-1'], [])
+        bad_runner = Runner(self.collection, [], filename, template, ['us-east-1'], [])
         errs = bad_runner.run()
         self.assertEqual(2, len(errs))

--- a/test/module/override/test_required.py
+++ b/test/module/override/test_required.py
@@ -41,7 +41,7 @@ class TestOverrideRequired(BaseTestCase):
 
         cfnlint.helpers.set_specs(custom_spec)
 
-        good_runner = Runner(self.collection, [], filename, template, [], ['us-east-1'], [])
+        good_runner = Runner(self.collection, [], filename, template, ['us-east-1'], [])
         self.assertEqual([], good_runner.run())
 
     def test_fail_run(self):
@@ -52,6 +52,6 @@ class TestOverrideRequired(BaseTestCase):
 
         cfnlint.helpers.set_specs(custom_spec)
 
-        bad_runner = Runner(self.collection, [], filename, template, [], ['us-east-1'], [])
+        bad_runner = Runner(self.collection, [], filename, template, ['us-east-1'], [])
         errs = bad_runner.run()
         self.assertEqual(1, len(errs))

--- a/test/module/test_cfn_json.py
+++ b/test/module/test_cfn_json.py
@@ -63,7 +63,7 @@ class TestCfnJson(BaseTestCase):
             cfn = Template(template, ['us-east-1'])
 
             matches = list()
-            matches.extend(self.rules.run(filename, cfn, []))
+            matches.extend(self.rules.run(filename, cfn))
             assert len(matches) == failures, 'Expected {} failures, got {} on {}'.format(failures, len(matches), filename)
 
     def test_fail_run(self):

--- a/test/module/test_rules_collections.py
+++ b/test/module/test_rules_collections.py
@@ -44,7 +44,7 @@ class TestTemplate(BaseTestCase):
         cfn = Template(template, ['us-east-1'])
 
         matches = list()
-        matches.extend(self.rules.run(filename, cfn, []))
+        matches.extend(self.rules.run(filename, cfn))
         assert(matches == [])
 
     def test_fail_run(self):
@@ -54,7 +54,7 @@ class TestTemplate(BaseTestCase):
         cfn = Template(template, ['us-east-1'])
 
         matches = list()
-        matches.extend(self.rules.run(filename, cfn, []))
+        matches.extend(self.rules.run(filename, cfn))
         assert len(matches) == 27, 'Expected {} failures, got {}'.format(27, len(matches))
 
     def test_fail_sub_properties_run(self):
@@ -64,5 +64,5 @@ class TestTemplate(BaseTestCase):
         cfn = Template(template, ['us-east-1'])
 
         matches = list()
-        matches.extend(self.rules.run(filename, cfn, []))
+        matches.extend(self.rules.run(filename, cfn))
         assert len(matches) == 3, 'Expected {} failures, got {}'.format(2, len(matches))

--- a/test/rules/__init__.py
+++ b/test/rules/__init__.py
@@ -59,7 +59,7 @@ class BaseRuleTestCase(BaseTestCase):
         """Success test"""
         for filename in self.success_templates:
             template = self.load_template(filename)
-            good_runner = Runner(self.collection, self.transforms, filename, template, [], ['us-east-1'], [])
+            good_runner = Runner(self.collection, self.transforms, filename, template, ['us-east-1'], [])
             good_runner.transform()
             failures = good_runner.run()
             assert [] == failures, 'Got failures {} on {}'.format(failures, filename)
@@ -67,14 +67,14 @@ class BaseRuleTestCase(BaseTestCase):
     def helper_file_positive_template(self, filename):
         """Success test with template parameter"""
         template = self.load_template(filename)
-        good_runner = Runner(self.collection, self.transforms, filename, template, [], ['us-east-1'], [])
+        good_runner = Runner(self.collection, self.transforms, filename, template, ['us-east-1'], [])
         good_runner.transform()
         self.assertEqual([], good_runner.run())
 
     def helper_file_negative(self, filename, err_count):
         """Failure test"""
         template = self.load_template(filename)
-        bad_runner = Runner(self.collection, self.transforms, filename, template, [], ['us-east-1'], [])
+        bad_runner = Runner(self.collection, self.transforms, filename, template, ['us-east-1'], [])
         bad_runner.transform()
         errs = bad_runner.run()
         self.assertEqual(err_count, len(errs))

--- a/test/transforms/__init__.py
+++ b/test/transforms/__init__.py
@@ -29,12 +29,12 @@ class BaseTransformTestCase(BaseTestCase):
 
     def helper_transform_template(self, template, test_function):
         """Success test with template parameter"""
-        good_runner = Runner([], self.transforms, 'test', template, [], ['us-east-1'], [])
+        good_runner = Runner([], self.transforms, 'test', template, ['us-east-1'], [])
         good_runner.transform()
         self.assertTrue(test_function(good_runner.cfn.template))
 
     def helper_transform_cfn(self, template, test_function):
         """Test the bigger CFN template"""
-        good_runner = Runner([], self.transforms, 'test', template, [], ['us-east-1'], [])
+        good_runner = Runner([], self.transforms, 'test', template, ['us-east-1'], [])
         good_runner.transform()
         self.assertTrue(test_function(good_runner.cfn))


### PR DESCRIPTION
*Issue #, if available:*
#114 - As a result of investigating this issue I wanted to make the ignore rules/checks functionality simpler.  
*Description of changes:*
- Instead of passing ignore checks through to the Rules runner filter the rules collection on init so all future rules are automatically filtered.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
