### PR TITLE
Add support for Nodejs 8.10 to Lambda runtimes

### DIFF
--- a/src/cfnlint/rules/parameters/LambdaRuntime.py
+++ b/src/cfnlint/rules/parameters/LambdaRuntime.py
@@ -40,8 +40,8 @@ class LambdaRuntime(CloudFormationLintRule):
         """Check ref for VPC"""
         matches = list()
         runtimes = [
-            'nodejs', 'nodejs4.3', 'nodejs6.10', 'java8', 'python2.7', 'python3.6',
-            'dotnetcore1.0', 'dotnetcore2.0', 'nodejs4.3-edge', 'go1.x'
+            'nodejs', 'nodejs4.3', 'nodejs6.10', 'nodejs8.10', 'java8', 'python2.7',
+            'python3.6', 'dotnetcore1.0', 'dotnetcore2.0', 'nodejs4.3-edge', 'go1.x'
         ]
 
         if value in parameters:

--- a/src/cfnlint/rules/resources/lmbd/FunctionRuntime.py
+++ b/src/cfnlint/rules/resources/lmbd/FunctionRuntime.py
@@ -26,8 +26,8 @@ class FunctionRuntime(CloudFormationLintRule):
     tags = ['base', 'resources', 'lambda']
 
     runtimes = [
-        'nodejs', 'nodejs4.3', 'nodejs6.10', 'java8', 'python2.7', 'python3.6',
-        'dotnetcore1.0', 'dotnetcore2.0', 'nodejs4.3-edge', 'go1.x'
+        'nodejs', 'nodejs4.3', 'nodejs6.10', 'nodejs8.10', 'java8', 'python2.7',
+        'python3.6', 'dotnetcore1.0', 'dotnetcore2.0', 'nodejs4.3-edge', 'go1.x'
     ]
 
     def check_value(self, value, path):


### PR DESCRIPTION
*Issue: https://github.com/awslabs/cfn-python-lint/issues/50*

Add support for Nodejs 8.10 to Lambda runtimes. Apparantly it supported now:

https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html#SSS-CreateFunction-request-Runtime


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
