### PR TITLE
Add overview of all rules to the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ cfn-lint applies the configuration from the CloudFormation Metadata first and th
 ## Rules
 This linter checks the CloudFormation by processing a collection of Rules, where every rules handles a specific function check or validation of the template.
 
-This collection of rules can be extended with custom rules using the `--apopend-rules` argument.
+This collection of rules can be extended with custom rules using the `--append-rules` argument.
 
 More information describing how rules are set up and an overview of all the Rules that are applied by this linter are documented [here](docs/rules.md)
 
@@ -87,7 +87,7 @@ More information describing how rules are set up and an overview of all the Rule
 ## Customize specifications
 The linter follows the [CloudFormation specifications](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-resource-specification.html) by default. However, for your use case specific requirements might exist. For example, within your organisation it might be mandatory to use [Tagging](https://aws.amazon.com/answers/account-management/aws-tagging-strategies/).
 
-The linter provides the possibility to implement these customzsed specifications using the `--override-spec` argument.
+The linter provides the possibility to implement these customized specifications using the `--override-spec` argument.
 
 More information about how this feature works is documented [here](docs/customize_specifications.md)
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ There are IDE plugins available to get direct linter feedback from you favorite 
 | --ignore-checks | ignore_checks | [IGNORE_CHECKS [IGNORE_CHECKS ...]] | Only check rules whose ID do not match or prefix these values.  Examples: <br />- A value of `W` will disable all warnings<br />- `W2` disables all Warnings for Parameter rules.<br />- `W2001` will disable rule `W2001` |
 | --log-level | log_level | {info, debug} | Log Level |
 | --update-specs | | | Update the CloudFormation Specs.  You may need sudo to run this.  You will need internet access when running this command |
-| --override-spec | | filename | Spec-style file containing custom definitions. Can be used to override CloudFormation specifications. More info [here](#customise-specifications) |
+| --override-spec | | filename | Spec-style file containing custom definitions. Can be used to override CloudFormation specifications. |
 | --version | | | Version of cfn-lint |
 
 ### Command Line
@@ -76,80 +76,20 @@ cfn-lint applies the configuration from the CloudFormation Metadata first and th
 > E3001 Invalid Type AWS::Batch::ComputeEnvironment for resource testBatch in ap-south-1
 
 
-## Rule IDs
+## Rules
+This linter checks the CloudFormation by processing a collection of Rules, where every rules handles a specific function check or validation of the template.
 
-### Errors
-Errors will start with the letter E.  Errors should result in a hard failure of the template being run.
+This collection of rules can be extended with custom rules using the `--apopend-rules` argument.
 
-### Warnings
-Warnings start with the letter W.  Warnings alert you when the template doesn't follow best practices but should still function.  *Example: If you use a parameter for a RDS master password you should have the parameter property NoEcho set to true.*
+More information describing how rules are set up and an overview of all the Rules that are applied by this linter are documented [here](docs/rules.md)
 
-### Categories
 
-| Rule Numbers    | Category |
-| --------------- | ------------- |
-| (E&#124;W)0XXX  | Basic Template Errors. Examples: Not parseable, main sections (Outputs, Resources, etc.)  |
-| (E&#124;W)1XXX  | Functions (Ref, GetAtt, etc.)  |
-| (E&#124;W)2XXX  | Parameters |
-| (E&#124;W)3XXX  | Resources |
-| (E&#124;W)4XXX  | Metadata |
-| (E&#124;W)6xxx  | Outputs |
-| (E&#124;W)7xxx  | Mappings |
-| (E&#124;W)8xxx  | Conditions |
-| (E&#124;W)9xxx  | Reserved for users rules |
-
-*Warning* <br />
-Rule `E3012` is used to check the types for value of a resource property.  A number is a number, string is a string, etc.  There are occasions where this could be just a warning and other times it could be an error.  cfn-lint didn't build an exception process so all instances of this issue is considered an error.  
-
-## Customise specifications
+## Customize specifications
 The linter follows the [CloudFormation specifications](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-resource-specification.html) by default. However, for your use case specific requirements might exist. For example, within your organisation it might be mandatory to use [Tagging](https://aws.amazon.com/answers/account-management/aws-tagging-strategies/).
 
-The linter provides the possibility to implement these customised specifications using the `--override-spec` parameter. This parameter should pass a (JSON) file in the same format as the [Specification](/src/cfnlint/data) files, this file is then merged into the Regional specification files that are used to process all the linting rules.
+The linter provides the possibility to implement these customzsed specifications using the `--override-spec` argument.
 
-This makes it easy to apply your our rules on top of the CloudFormation rules without having to write your own checks in Python and use the power of the linter itself with a single file!
-
-### Features
-The `--override-spec` functionality currently supports the following features:
-
-#### Whitelist/Blacklist resources
-If you want to block the use of specific resources, you can easily disable them by using the Whitelist/Blacklist features. This can be done by specifying a list of `IncludedResourceTypes` and/or `ExcludedResourceTypes`.
-
-* `IncludedResourceTypes`: List of resources that are supported. If specified, all resources that are not in this list are not allowed.
-* `ExcludedResourceTypes`: List of resources that are not supported. Resources in this list are not allowed.
-
-Wildcards (`*`) are supported in these lists, so `AWS::EC2::*` allows ALL EC2 ResourceTypes. Both lists can work in conjunction with each other.
-
-The following example only allows the usage of all `EC2` resources, except for `AWS::EC2::SpotFleet`:
-```
-{
-  "IncludeResourceTypes": [
-    "AWS::EC2::*"
-  ],
-  "ExcludeResourceTypes": [
-    "AWS::EC2::SpotFleet"
-  ]
-}
-```
-
-#### Alter Resource/Parameter specifications
-The spec file overwrites values from the Regional spec files which give you the possible to alter the specifications for your own needs. A good example is making optional Parameters Required.
-
-For example, to enforce tagging on an S3 bucket, the override file looks like this:
-```
-{
-  "ResourceTypes": {
-    "AWS::S3::Bucket": {
-      "Properties": {
-        "Tags": {
-          "Required": true
-        }
-      }
-    }
-  }
-}
-```
-**WARNING**
-The file is checked for valid JSON syntax, but does not check the contents of the file before merging it into the Specifications. Be careful with your changes because it can possibly corrupt the Specifications and break the linting process.
+More information about how this feature works is documented [here](docs/customize_specifications.md)
 
 ## Credit
 Will Thames and ansible-lint at https://github.com/willthames/ansible-lint

--- a/README.md
+++ b/README.md
@@ -43,9 +43,8 @@ There are IDE plugins available to get direct linter feedback from you favorite 
 | --append-rules | append_rules | [RULESDIR [RULESDIR ...]] | Specify one or more rules directories using one or more --append-rules arguments. |
 | --ignore-checks | ignore_checks | [IGNORE_CHECKS [IGNORE_CHECKS ...]] | Only check rules whose ID do not match or prefix these values.  Examples: <br />- A value of `W` will disable all warnings<br />- `W2` disables all Warnings for Parameter rules.<br />- `W2001` will disable rule `W2001` |
 | --log-level | log_level | {info, debug} | Log Level |
-| --update-specs | | | Update the CloudFormation Specs.  You may need sudo to run this.  You will need internet access when running this command |
 | --override-spec | | filename | Spec-style file containing custom definitions. Can be used to override CloudFormation specifications. |
-| --version | | | Version of cfn-lint |
+| --update-specs | | | Update the CloudFormation Specs.  You may need sudo to run this.  You will need internet access when running this command || --version | | | Version of cfn-lint |
 
 ### Command Line
 From a command prompt run `cfn-lint --template <path to yaml template>`

--- a/docs/customize_specifications.md
+++ b/docs/customize_specifications.md
@@ -1,7 +1,7 @@
 ## Customize specifications
 The linter follows the [CloudFormation specifications](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-resource-specification.html) by default. However, for your use case specific requirements might exist. For example, within your organisation it might be mandatory to use [Tagging](https://aws.amazon.com/answers/account-management/aws-tagging-strategies/).
 
-The linter provides the possibility to implement these customzsed specifications using the `--override-spec` argument. This argument should pass a (JSON) file in the same format as the [Specification](/src/cfnlint/data) files, this file is then merged into the Regional specification files that are used to process all the linting rules.
+The linter provides the possibility to implement these customized specifications using the `--override-spec` argument. This argument should pass a (JSON) file in the same format as the [Specification](/src/cfnlint/data) files, this file is then merged into the Regional specification files that are used to process all the linting rules.
 
 This makes it easy to apply your our rules on top of the CloudFormation rules without having to write your own checks in Python and use the power of the linter itself with a single file!
 
@@ -29,7 +29,7 @@ The following example only allows the usage of all `EC2` resources, except for `
 ```
 
 #### Alter Resource/Parameter specifications
-The spec file overwrites values from the Regional spec files which give you the possible to alter the specifications for your own needs. A good example is making optional Parameters Required.
+The spec file overwrites values from the Regional spec files which give you the possible to alter the specifications for your own needs. A good example is making optional Parameters required.
 
 For example, to enforce tagging on an S3 bucket, the override file looks like this:
 ```

--- a/docs/customize_specifications.md
+++ b/docs/customize_specifications.md
@@ -1,0 +1,49 @@
+## Customize specifications
+The linter follows the [CloudFormation specifications](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-resource-specification.html) by default. However, for your use case specific requirements might exist. For example, within your organisation it might be mandatory to use [Tagging](https://aws.amazon.com/answers/account-management/aws-tagging-strategies/).
+
+The linter provides the possibility to implement these customzsed specifications using the `--override-spec` argument. This argument should pass a (JSON) file in the same format as the [Specification](/src/cfnlint/data) files, this file is then merged into the Regional specification files that are used to process all the linting rules.
+
+This makes it easy to apply your our rules on top of the CloudFormation rules without having to write your own checks in Python and use the power of the linter itself with a single file!
+
+### Features
+The `--override-spec` functionality currently supports the following features:
+
+#### Whitelist/Blacklist resources
+If you want to block the use of specific resources, you can easily disable them by using the Whitelist/Blacklist features. This can be done by specifying a list of `IncludedResourceTypes` and/or `ExcludedResourceTypes`.
+
+* `IncludedResourceTypes`: List of resources that are supported. If specified, all resources that are not in this list are not allowed.
+* `ExcludedResourceTypes`: List of resources that are not supported. Resources in this list are not allowed.
+
+Wildcards (`*`) are supported in these lists, so `AWS::EC2::*` allows ALL EC2 ResourceTypes. Both lists can work in conjunction with each other.
+
+The following example only allows the usage of all `EC2` resources, except for `AWS::EC2::SpotFleet`:
+```
+{
+  "IncludeResourceTypes": [
+    "AWS::EC2::*"
+  ],
+  "ExcludeResourceTypes": [
+    "AWS::EC2::SpotFleet"
+  ]
+}
+```
+
+#### Alter Resource/Parameter specifications
+The spec file overwrites values from the Regional spec files which give you the possible to alter the specifications for your own needs. A good example is making optional Parameters Required.
+
+For example, to enforce tagging on an S3 bucket, the override file looks like this:
+```
+{
+  "ResourceTypes": {
+    "AWS::S3::Bucket": {
+      "Properties": {
+        "Tags": {
+          "Required": true
+        }
+      }
+    }
+  }
+}
+```
+**WARNING**
+The file is checked for valid JSON syntax, but does not check the contents of the file before merging it into the Specifications. Be careful with your changes because it can possibly corrupt the Specifications and break the linting process.

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -1,0 +1,101 @@
+# Rules
+
+### Errors
+Errors will start with the letter `E`. Errors should result in a hard failure of the template being run.
+
+### Warnings
+Warnings start with the letter `W`. Warnings alert you when the template doesnt follow best practices but should still function.  *Example: If you use a parameter for a RDS master password you should have the parameter property NoEcho set to true.*
+
+
+## Categories
+
+| Rule Numbers    | Category |
+| --------------- | ------------- |
+| (E&#124;W)0XXX  | Basic Template Errors. Examples: Not parseable, main sections (Outputs, Resources, etc.)  |
+| (E&#124;W)1XXX  | Functions (Ref, GetAtt, etc.)  |
+| (E&#124;W)2XXX  | Parameters |
+| (E&#124;W)3XXX  | Resources |
+| (E&#124;W)4XXX  | Metadata |
+| (E&#124;W)6xxx  | Outputs |
+| (E&#124;W)7xxx  | Mappings |
+| (E&#124;W)8xxx  | Conditions |
+| (E&#124;W)9xxx  | Reserved for users rules |
+
+
+*Warning*
+Rule `E3012` is used to check the types for value of a resource property.  A number is a number, string is a string, etc.  There are occasions where this could be just a warning and other times it could be an error.  cfn-lint didnt build an exception process so all instances of this issue is considered an error.
+
+
+
+## Rules
+THe following **67** rules are applied by this linter:
+
+| Rule ID  | Title | Description | Tags |
+| -------- | ----- | ----------- |----- |
+| E1001 | Basic CloudFormation Template Configuration | Making sure the basic CloudFormation template componets are propery configured | `base` |
+| E1010 | GetAtt validation of parameters | Making sure the function GetAtt is of list | `base`,`functions`,`getatt` |
+| E1011 | FindInMap validation of configuration | Making sure the function is a list of appropriate config | `base`,`functions`,`getatt` |
+| E1012 | Check if Refs exist | Making sure the refs exist | `base`,`functions`,`ref` |
+| E1015 | GetAz validation of parameters | Making sure the function not is of list | `base`,`functions`,`getaz` |
+| E1016 | ImportValue validation of parameters | Making sure the function not is of list | `base`,`functions`,`importvalue` |
+| E1017 | Select validation of parameters | Making sure the function not is of list | `base`,`functions`,`select` |
+| E1018 | Split validation of parameters | Making sure the split function is properly configured | `base`,`functions`,`split` |
+| E1019 | Sub validation of parameters | Making sure the split function is properly configured | `base`,`functions`,`sub` |
+| E1020 | Ref validation of value | Making the Ref has a value of String (no other functions are supported) | `base`,`functions`,`ref` |
+| E1021 | Base64 validation of parameters | Making sure the function not is of list | `base`,`functions`,`base64` |
+| E1022 | Join validation of parameters | Making sure the join function is properly configured | `base`,`functions`,`join` |
+| E1023 | Validation NOT function configuration | Making sure that NOT functions are list | `base`,`functions`,`not` |
+| E1024 | Cidr validation of parameters | Making sure the function CIDR is a list with valid values | `base`,`functions`,`cidr` |
+| E1025 | Check if Conditions exist | Making sure the Conditions used in Fn:If functions exist | `base`,`functions`,`if` |
+| E1026 | Cannot reference resources in the Conditions block of the template | Check that any Refs in the Conditions block uses no resources | `base`,`functions`,`ref` |
+| E2001 | Parameters have appropriate properties | Making sure the parameters are properly configured | `base`,`parameters` |
+| E2002 | Parameters have appropriate type | Making sure the parameters have a correct type | `base`,`parameters` |
+| E2003 | Parameters have appropriate names | Check if Parameters are properly named (A-Za-z0-9) | `base`,`parameters` |
+| E2004 | CIDR Allowed Values should be a Cidr Range | Check if a parameter is being used as a CIDR. If it is make sure allowed values are proper CIDRs | `base`,`parameters`,`cidr` |
+| E2010 | Parameter limit not exceeded | Check the number of Parameters in the template is lessthan the upper limit | `base`,`parameters`,`limits` |
+| E2502 | Check if IamInstanceProfile are using the name and not ARN | See if there are any properties IamInstanceProfileare using name and not ARN | `base`,`properties` |
+| E2503 | Resource ELB Properties | See if Elb Resource Properties are set correctly HTTPS has certificate HTTP has no certificate | `base`,`properties`,`elb` |
+| E2504 | Check Ec2 Ebs Properties | See if Ec2 Eb2 Properties are valid | `base`,`properties`,`ec2`,`ebs` |
+| E2505 | Resource EC2 VPC Properties | See if EC2 VPC Properties are set correctly | `base`,`properties`,`vpc` |
+| E2506 | Resource EC2 Security Group Ingress Properties | See if EC2 Security Group Ingress Properties are set correctly. Check that "SourceSecurityGroupId" or "SourceSecurityGroupName" are  are exclusive and using the type of Ref or GetAtt  | `base`,`resources`,`securitygroup` |
+| E2507 | Check if IAM Policies are properly configured | See if there elements inside an IAM policy are correct | `base`,`properties`,`iam` |
+| E2510 | Resource EC2 PropertiesEc2Subnet Properties | See if EC2 Subnet Properties are set correctly | `base`,`properties`,`subnet` |
+| E2520 | Check Properties that are mutually exclusive | Making sure CloudFormation properties that are exclusive are not defined | `base`,`resources` |
+| E2521 | Check Properties that are required together | Make sure CloudFormation resource properties are included together when required | `base`,`resources` |
+| E2522 | Check Properties that need at least one of a list of properties | Making sure CloudFormation properties that require at least one property from a list. More than one can be included. | `base`,`resources` |
+| E2523 | Check Properties that need only one of a list of properties | Making sure CloudFormation properties that require only one property from a list. One has to be specified. | `base`,`resources` |
+| E2530 | Check Lambda Memory Size Properties | See if Lambda Memory Size is valid | `base`,`resources`,`lambda` |
+| E2531 | Check Lambda Runtime Properties | See if Lambda Runtime is in valid | `base`,`resources`,`lambda` |
+| E2540 | CodePipeline Stages | See if CodePipeline stages are set correctly | `base`,`properties`,`codepipeline` |
+| E2541 | CodePipeline Stage Actions | See if CodePipeline stage actions are set correctly | `base`,`resources`,`codepipeline` |
+| E3001 | Basic CloudFormation Resource Check | Making sure the basic CloudFormation resources are propery configured | `base`,`resources` |
+| E3002 | Resource properties are valid | Making sure that resources properties are propery configured | `base`,`resources` |
+| E3003 | Required Resource Parameters are missing | Making sure that Resources properties that are required exist | `base`,`resources` |
+| E3004 | Resource dependencies are not circular | Check that Resources are not circularly dependent by Ref, Sub, or GetAtt | `base`,`resources`,`circularly` |
+| E3005 | Check DependsOn values for Resources | Check that the DependsOn values are valid | `base`,`resources`,`dependson` |
+| E3006 | Resources have appropriate names | Check if Resources are properly named (A-Za-z0-9) | `base`,`resources` |
+| E3010 | Resource limit not exceeded | Check the number of Resources in the template is lessthan the upper limit | `base`,`resources`,`limits` |
+| E3012 | Check resource properties values | Checks resource property values with Primitive Types for values that match those types. | `base`,`resources` |
+| E4001 | Metadata Interface have appropriate properties | Metadata Interface properties are properly configured | `base`,`metadata` |
+| E6001 | Outputs have appropriate properties | Making sure the outputs are properly configured | `base`,`outputs` |
+| E6002 | Outputs have required properties | Making sure the outputs have required properties | `base`,`outputs` |
+| E6003 | Outputs have values of strings | Making sure the outputs have strings as values | `base`,`outputs` |
+| E6004 | Outputs have appropriate names | Check if Outputs are properly named (A-Za-z0-9) | `base`,`outputs` |
+| E6010 | Output limit not exceeded | Check the number of Outputs in the template is lessthan the upper limit | `base`,`outputs`,`limits` |
+| E7001 | Mappings are appropriately configured | Check if Mappings are properly configured | `base`,`mappings` |
+| E7002 | Mappings have appropriate names | Check if Mappings are properly named (A-Za-z0-9) | `base`,`mapping` |
+| E7010 | Mapping limit not exceeded | Check the number of Mappings in the template is lessthan the upper limit | `base`,`mappings`,`limits` |
+| E8001 | Conditions have appropriate properties | Check if Conditions are properly configured | `base`,`conditions` |
+| W2001 | Check if Parameters are Used | Making sure the parameters defined are used | `base`,`parameters` |
+| W2501 | Check if Password Properties are correctly configured | Password properties should be strings and if parameter using NoEcho | `base`,`parameters`,`passwords` |
+| W2505 | Check if VpcID Parameters have the correct type | See if there are any refs for VpcId to a parameter of innapropriate type.  Appropriate Types are [AWS::EC2::VPC::Id, AWS::SSM::Parameter::Value<AWS::EC2::VPC::Id>] | `base`,`parameters`,`vpcid` |
+| W2506 | Check if ImageId Parameters have the correct type | See if there are any refs for ImageId to a parameter of innapropriate type. Appropriate Types are [AWS::EC2::Image::Id, AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>] | `base`,`parameters`,`imageid` |
+| W2507 | Security Group Parameters are of correct type AWS::EC2::SecurityGroup::Id | Check if a parameter is being used in a resource for Security Group.  If it is make sure it is of type AWS::EC2::SecurityGroup::Id | `base`,`parameters`,`securitygroup` |
+| W2508 | Availability Zone Parameters are of correct type AWS::EC2::AvailabilityZone::Name | Check if a parameter is being used in a resource for Security Group.  If it is make sure it is of type AWS::EC2::AvailabilityZone::Name | `base`,`parameters`,`availabilityzone` |
+| W2509 | CIDR Parameters have allowed values | Check if a parameter is being used as a CIDR. If it is make sure it has allowed values regex comparisons | `base`,`parameters`,`availabilityzone` |
+| W2510 | Parameter Memory Size attributes should have max and min | Check if a parameter that is used for Lambda memory size  should have a min and max size that matches Lambda constraints | `base`,`parameters`,`lambda` |
+| W2512 | Parameter Lambda Runtime has allowed values set | Check if a parameter that is used for Lambda runtime  has allowed values constraint defined | `base`,`parameters`,`lambda` |
+| W3010 | Availability Zone Parameters should not be hardcoded | Check if an Availability Zone property is hardcoded. | `base`,`parameters`,`availabilityzone` |
+| W4001 | Metadata Interface parameters exist | Metadata Interface parameters actually exist | `base`,`metadata` |
+| W7001 | Check if Mappings are Used | Making sure the mappings defined are used | `base`,`conditions` |
+| W8001 | Check if Conditions are Used | Making sure the conditions defined are used | `base`,`conditions` |

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -1,7 +1,7 @@
 # Rules
 
 ### Errors
-Errors will start with the letter `E`. Errors should result in a hard failure of the template being run.
+Errors will start with the letter `E`. Errors will result in a hard failure for the template being validated.
 
 ### Warnings
 Warnings start with the letter `W`. Warnings alert you when the template doesnt follow best practices but should still function.  *Example: If you use a parameter for a RDS master password you should have the parameter property NoEcho set to true.*
@@ -23,8 +23,7 @@ Warnings start with the letter `W`. Warnings alert you when the template doesnt 
 
 
 *Warning*
-Rule `E3012` is used to check the types for value of a resource property.  A number is a number, string is a string, etc.  There are occasions where this could be just a warning and other times it could be an error.  cfn-lint didnt build an exception process so all instances of this issue is considered an error.
-
+Rule `E3012` is used to check the types for value of a resource property.  A number is a number, string is a string, etc.  There are occasions where this could be just a warning and other times it could be an error.  cfn-lint doesn't have an exception process so all instances of this issue are considered errors. You can disable this rule using `--ignore-checks` if it is not required for your internal best practices.
 
 
 ## Rules

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -27,7 +27,7 @@ Rule `E3012` is used to check the types for value of a resource property.  A num
 
 
 ## Rules
-THe following **67** rules are applied by this linter:
+The following **67** rules are applied by this linter:
 
 | Rule ID  | Title | Description | Tags |
 | -------- | ----- | ----------- |----- |

--- a/src/cfnlint/core.py
+++ b/src/cfnlint/core.py
@@ -29,6 +29,7 @@ from cfnlint import RulesCollection, TransformsCollection, Match
 import cfnlint.formatters as formatters
 import cfnlint.cfn_yaml
 import cfnlint.cfn_json
+import cfnlint.maintenance
 from cfnlint.version import __version__
 from cfnlint.helpers import REGIONS
 
@@ -179,6 +180,10 @@ def append_parser(parser, defaults):
         '--update-specs', help='Update the CloudFormation Specs',
         action='store_true'
     )
+    parser.add_argument(
+        '--update-documentation', help=argparse.SUPPRESS,
+        action='store_true'
+    )
 
     parser.set_defaults(**defaults)
 
@@ -250,11 +255,16 @@ def get_template_args_rules(cli_args):
     append_parser(parser, defaults)
     args = parser.parse_args(cli_args)
 
+
     if vars(args)['update_specs']:
-        cfnlint.helpers.update_resource_specs()
+        cfnlint.maintenance.update_resource_specs()
         exit(0)
 
     rules = cfnlint.core.get_rules(vars(args)['append_rules'], vars(args)['ignore_checks'])
+
+    if vars(args)['update_documentation']:
+        cfnlint.maintenance.update_documentation(rules)
+        exit(0)
 
     if vars(args)['listrules']:
         print(rules)

--- a/src/cfnlint/helpers.py
+++ b/src/cfnlint/helpers.py
@@ -21,7 +21,6 @@ import os
 import imp
 import logging
 import re
-import requests
 import pkg_resources
 
 
@@ -173,37 +172,6 @@ def initialize_specs():
 
 
 initialize_specs()
-
-
-def update_resource_specs():
-    """ Update Resource Specs """
-
-    # pylint: disable=C0301
-    regions = {
-        'ap-south-1': 'https://d2senuesg1djtx.cloudfront.net/latest/gzip/CloudFormationResourceSpecification.json',
-        'ap-northeast-2': 'https://d1ane3fvebulky.cloudfront.net/latest/gzip/CloudFormationResourceSpecification.json',
-        'ap-southeast-2': 'https://d2stg8d246z9di.cloudfront.net/latest/gzip/CloudFormationResourceSpecification.json',
-        'ap-southeast-1': 'https://doigdx0kgq9el.cloudfront.net/latest/gzip/CloudFormationResourceSpecification.json',
-        'ap-northeast-1': 'https://d33vqc0rt9ld30.cloudfront.net/latest/gzip/CloudFormationResourceSpecification.json',
-        'ca-central-1': 'https://d2s8ygphhesbe7.cloudfront.net/latest/gzip/CloudFormationResourceSpecification.json',
-        'eu-central-1': 'https://d1mta8qj7i28i2.cloudfront.net/latest/gzip/CloudFormationResourceSpecification.json',
-        'eu-west-2': 'https://d1742qcu2c1ncx.cloudfront.net/latest/gzip/CloudFormationResourceSpecification.json',
-        'eu-west-1': 'https://d3teyb21fexa9r.cloudfront.net/latest/gzip/CloudFormationResourceSpecification.json',
-        'sa-east-1': 'https://d3c9jyj3w509b0.cloudfront.net/latest/gzip/CloudFormationResourceSpecification.json',
-        'us-east-1': 'https://d1uauaxba7bl26.cloudfront.net/latest/gzip/CloudFormationResourceSpecification.json',
-        'us-east-2': 'https://dnwj8swjjbsbt.cloudfront.net/latest/gzip/CloudFormationResourceSpecification.json',
-        'us-west-1': 'https://d68hl49wbnanq.cloudfront.net/latest/gzip/CloudFormationResourceSpecification.json',
-        'us-west-2': 'https://d201a2mn26r7lk.cloudfront.net/latest/gzip/CloudFormationResourceSpecification.json',
-    }
-    for region, url in regions.items():
-        filename = pkg_resources.resource_filename(
-            __name__,
-            '/data/CloudSpecs/%s.json' % region,
-        )
-        LOGGER.debug('Downloading template %s into %s', url, filename)
-        req = requests.get(url)
-        with open(filename, 'wb') as f:
-            f.write(req.content)
 
 
 def load_plugins(directory):

--- a/src/cfnlint/maintenance.py
+++ b/src/cfnlint/maintenance.py
@@ -1,0 +1,94 @@
+"""
+  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this
+  software and associated documentation files (the "Software"), to deal in the Software
+  without restriction, including without limitation the rights to use, copy, modify,
+  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+import logging
+import pkg_resources
+import requests
+
+LOGGER = logging.getLogger('cfnlint')
+
+
+def update_resource_specs():
+    """ Update Resource Specs """
+
+    # pylint: disable=C0301
+    regions = {
+        'ap-south-1': 'https://d2senuesg1djtx.cloudfront.net/latest/gzip/CloudFormationResourceSpecification.json',
+        'ap-northeast-2': 'https://d1ane3fvebulky.cloudfront.net/latest/gzip/CloudFormationResourceSpecification.json',
+        'ap-southeast-2': 'https://d2stg8d246z9di.cloudfront.net/latest/gzip/CloudFormationResourceSpecification.json',
+        'ap-southeast-1': 'https://doigdx0kgq9el.cloudfront.net/latest/gzip/CloudFormationResourceSpecification.json',
+        'ap-northeast-1': 'https://d33vqc0rt9ld30.cloudfront.net/latest/gzip/CloudFormationResourceSpecification.json',
+        'ca-central-1': 'https://d2s8ygphhesbe7.cloudfront.net/latest/gzip/CloudFormationResourceSpecification.json',
+        'eu-central-1': 'https://d1mta8qj7i28i2.cloudfront.net/latest/gzip/CloudFormationResourceSpecification.json',
+        'eu-west-2': 'https://d1742qcu2c1ncx.cloudfront.net/latest/gzip/CloudFormationResourceSpecification.json',
+        'eu-west-1': 'https://d3teyb21fexa9r.cloudfront.net/latest/gzip/CloudFormationResourceSpecification.json',
+        'sa-east-1': 'https://d3c9jyj3w509b0.cloudfront.net/latest/gzip/CloudFormationResourceSpecification.json',
+        'us-east-1': 'https://d1uauaxba7bl26.cloudfront.net/latest/gzip/CloudFormationResourceSpecification.json',
+        'us-east-2': 'https://dnwj8swjjbsbt.cloudfront.net/latest/gzip/CloudFormationResourceSpecification.json',
+        'us-west-1': 'https://d68hl49wbnanq.cloudfront.net/latest/gzip/CloudFormationResourceSpecification.json',
+        'us-west-2': 'https://d201a2mn26r7lk.cloudfront.net/latest/gzip/CloudFormationResourceSpecification.json',
+    }
+    for region, url in regions.items():
+        filename = pkg_resources.resource_filename(
+            __name__,
+            '/data/CloudSpecs/%s.json' % region,
+        )
+        LOGGER.debug('Downloading template %s into %s', url, filename)
+        req = requests.get(url)
+        with open(filename, 'wb') as f:
+            f.write(req.content)
+
+
+def update_documentation(rules):
+    """Generate documentation"""
+
+    # Update the overview of all rules in the linter
+    filename = 'docs/rules.md'
+
+    # Sort rules by the Rule ID
+    sorted_rules = sorted(rules, key=lambda obj: obj.id)
+
+    data = []
+
+    # Read current file up to the Rules part, everything up to that point is
+    # static documentation.
+    with open(filename, 'r') as origial_file:
+
+        line = origial_file.readline()
+        while line:
+            data.append(line)
+
+            if line == '## Rules\n':
+                break
+
+            line = origial_file.readline()
+
+    # Rebuild the file content
+    with open(filename, 'w') as new_file:
+
+        # Rewrite the static documentation
+        for line in data:
+            new_file.write(line)
+
+        # Add the rules
+        new_file.write('The following **{}** rules are applied by this linter:\n\n'.format(len(sorted_rules)))
+        new_file.write('| Rule ID  | Title | Description | Tags |\n')
+        new_file.write('| -------- | ----- | ----------- |----- |\n')
+
+        rule_output = '| {0} | {1} | {2} | {3} |\n'
+        for rule in sorted_rules:
+            tags = ','.join('`{0}`'.format(tag) for tag in rule.tags)
+            new_file.write(rule_output.format(rule.id, rule.shortdesc, rule.description, tags))

--- a/test/module/core/test_run_cli.py
+++ b/test/module/core/test_run_cli.py
@@ -95,6 +95,7 @@ class TestCli(BaseTestCase):
             'override_spec': None,
             'regions': ['us-east-1'],
             'template': 'templates/good/core/config_parameters.yaml',
+            'update_documentation': False,
             'update_specs': False})
 
     def test_override_parameters(self):
@@ -114,6 +115,7 @@ class TestCli(BaseTestCase):
             'override_spec': None,
             'regions': ['us-east-1'],
             'template': 'templates/good/core/config_parameters.yaml',
+            'update_documentation': False,
             'update_specs': False})
 
     def test_bad_config(self):
@@ -133,4 +135,5 @@ class TestCli(BaseTestCase):
             'override_spec': None,
             'regions': ['us-east-1'],
             'template': filename,
+            'update_documentation': False,
             'update_specs': False})


### PR DESCRIPTION
Added/generated al list of all the rules present in the toolkit. Cleaned up the Readme a bit by moving some of the extended documentation to a separate `docs` folder

Also added an `--update-documentation` to generate the rules documentation (Kept the argument a bit more "general" in case there is other documentation we can generate in the future. 
Hiding it from the help (`-h`).



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
