### PR TITLE
Conditions can be used by other conditions

### DIFF
--- a/test/module/cfn_json/test_cfn_json.py
+++ b/test/module/cfn_json/test_cfn_json.py
@@ -50,7 +50,7 @@ class TestCfnJson(BaseTestCase):
             },
             "vpc": {
                 "filename": 'templates/quickstart/vpc.json',
-                "failures": 41
+                "failures": 40
             },
             "poller": {
                 "filename": 'templates/public/lambda-poller.json',


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Fix an issue where conditions are reported as not being used but may be being used by other conditions.

Covered by the vpc.json test in which the GovCloud condition was being used but was being reported as not.  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
