### PR TITLE
Add some IAM limits checks

### DIFF
--- a/src/cfnlint/rules/resources/iam/Limits.py
+++ b/src/cfnlint/rules/resources/iam/Limits.py
@@ -23,7 +23,7 @@ from cfnlint import RuleMatch
 
 class Limits(CloudFormationLintRule):
     """Check if IAM limits are not breached"""
-    id = '2508'
+    id = 'E2508'
     shortdesc = 'Check IAM resource limits'
     description = 'See if IAM resources do not breach limits'
     tags = ['base', 'resources', 'iam']

--- a/src/cfnlint/rules/resources/iam/Limits.py
+++ b/src/cfnlint/rules/resources/iam/Limits.py
@@ -1,0 +1,132 @@
+"""
+  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this
+  software and associated documentation files (the "Software"), to deal in the Software
+  without restriction, including without limitation the rights to use, copy, modify,
+  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+import datetime
+import json
+
+from cfnlint import CloudFormationLintRule
+from cfnlint import RuleMatch
+
+
+class Limits(CloudFormationLintRule):
+    """Check if IAM limits are not breached"""
+    id = '2508'
+    shortdesc = 'Check IAM resource limits'
+    description = 'See if IAM resources do not breach limits'
+    tags = ['base', 'resources', 'iam']
+
+    def _serialize_date(self, obj):
+        if isinstance(obj, datetime.date):
+            return obj.isoformat()
+        raise TypeError('Object of type {} is not JSON serializable'.format(obj.__class__.__name__))
+
+    def check_managed_policy_arns(self, properties, path):
+        """Check ManagedPolicyArns is within limits"""
+        matches = list()
+
+        if 'ManagedPolicyArns' not in properties:
+            return matches
+
+        if len(properties['ManagedPolicyArns']) > 10:
+            matches.append(
+                RuleMatch(
+                    path + ['ManagedPolicyArns'],
+                    'IAM resources cannot have more than 10 ManagedPolicyArns',
+                )
+            )
+
+        return matches
+
+    def check_instance_profile_roles(self, properties, path):
+        """Check InstanceProfile.Roles is within limits"""
+        matches = list()
+
+        if 'Roles' not in properties:
+            return matches
+
+        if len(properties['Roles']) > 1:
+            matches.append(
+                RuleMatch(
+                    path + ['Roles'],
+                    'InstanceProfile can only have one role attached'
+                )
+            )
+
+        return matches
+
+    def check_user_groups(self, properties, path):
+        """Check User.Groups is within limits"""
+        matches = list()
+
+        if 'Groups' not in properties:
+            return matches
+
+        if len(properties['Groups']) > 10:
+            matches.append(
+                RuleMatch(
+                    path + ['Groups'],
+                    'User can be a member of maximum 10 groups',
+                )
+            )
+
+        return matches
+
+    def check_role_assume_role_policy_document(self, properties, path):
+        """Check Role.AssumeRolePolicyDocument is within limits"""
+        matches = list()
+
+        if 'AssumeRolePolicyDocument' not in properties:
+            return matches
+
+        if len(json.dumps(properties['AssumeRolePolicyDocument'], default=self._serialize_date)) > 2048:
+            matches.append(
+                RuleMatch(
+                    path + ['AssumeRolePolicyDocument'],
+                    'Role trust policy JSON text cannot be longer than 2048 characters',
+                )
+            )
+
+        return matches
+
+    def match(self, cfn):
+        """Check that IAM resources are below limits"""
+        matches = list()
+        types = {
+            'AWS::IAM::User': [
+                self.check_managed_policy_arns,
+                self.check_user_groups,
+            ],
+            'AWS::IAM::Group': [
+                self.check_managed_policy_arns,
+            ],
+            'AWS::IAM::Role': [
+                self.check_managed_policy_arns,
+                self.check_role_assume_role_policy_document,
+            ],
+            'AWS::IAM::InstanceProfile': [
+                self.check_instance_profile_roles,
+            ],
+        }
+
+        for resource_type, check_list in types.items():
+            resources = cfn.get_resources(resource_type=resource_type)
+            for resource_name, resource_object in resources.items():
+                path = ['Resources', resource_name, 'Properties']
+                properties = resource_object.get('Properties', {})
+                for check in check_list:
+                    matches.extend(check(properties, path))
+
+        return matches

--- a/test/rules/resources/iam/test_iam_limits.py
+++ b/test/rules/resources/iam/test_iam_limits.py
@@ -1,0 +1,46 @@
+"""
+  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this
+  software and associated documentation files (the "Software"), to deal in the Software
+  without restriction, including without limitation the rights to use, copy, modify,
+  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+from cfnlint.rules.resources.iam.Limits import Limits  # pylint: disable=E0401
+from ... import BaseRuleTestCase
+
+
+class TestPropertyIamLimits(BaseRuleTestCase):
+    """Test IAM Limits"""
+    def setUp(self):
+        """Setup"""
+        super(TestPropertyIamLimits, self).setUp()
+        self.collection.register(Limits())
+
+    def test_file_positive(self):
+        """Test Positive"""
+        self.helper_file_positive()
+
+    def test_managedpolicyarns(self):
+        """Test failure"""
+        self.helper_file_negative('templates/bad/resources_iam_managedpolicyarns.yaml', 3)
+
+    def test_user_groups(self):
+        """Test failure"""
+        self.helper_file_negative('templates/bad/resources_iam_user_groups.yaml', 1)
+
+    def test_instance_profile_roles(self):
+        """Test failure"""
+        self.helper_file_negative('templates/bad/resources_iam_instanceprofile_roles.yaml', 1)
+
+    def test_role_assume_role_policy_document(self):
+        """Test failure"""
+        self.helper_file_negative('templates/bad/resources_iam_role_assume_role_policy_document.yaml', 1)

--- a/test/templates/bad/resources_iam_instanceprofile_roles.yaml
+++ b/test/templates/bad/resources_iam_instanceprofile_roles.yaml
@@ -1,0 +1,9 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Test bad InstanceProfile roles setup
+Resources:
+  IamUser:
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+      Roles:
+      - arn:aws:iam::012345678901:role/R01
+      - arn:aws:iam::012345678901:role/R02

--- a/test/templates/bad/resources_iam_managedpolicyarns.yaml
+++ b/test/templates/bad/resources_iam_managedpolicyarns.yaml
@@ -1,0 +1,49 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Test bad ManagedPolicyArns setup
+Resources:
+  IamRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument: {}
+      ManagedPolicyArns:
+      - arn:aws:iam::aws:policy/AdministratorAccess
+      - arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess
+      - arn:aws:iam::aws:policy/AmazonElastiCacheReadOnlyAccess
+      - arn:aws:iam::aws:policy/AmazonKinesisReadOnlyAccess
+      - arn:aws:iam::aws:policy/AmazonRDSReadOnlyAccess
+      - arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess
+      - arn:aws:iam::aws:policy/AutoScalingConsoleReadOnlyAccess
+      - arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+      - arn:aws:iam::aws:policy/AWSCodeBuildReadOnlyAccess
+      - arn:aws:iam::aws:policy/AWSCodePipelineReadOnlyAccess
+      - arn:aws:iam::aws:policy/IAMReadOnlyAccess
+  IamGroup:
+    Type: AWS::IAM::Group
+    Properties:
+      ManagedPolicyArns:
+      - arn:aws:iam::aws:policy/AdministratorAccess
+      - arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess
+      - arn:aws:iam::aws:policy/AmazonElastiCacheReadOnlyAccess
+      - arn:aws:iam::aws:policy/AmazonKinesisReadOnlyAccess
+      - arn:aws:iam::aws:policy/AmazonRDSReadOnlyAccess
+      - arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess
+      - arn:aws:iam::aws:policy/AutoScalingConsoleReadOnlyAccess
+      - arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+      - arn:aws:iam::aws:policy/AWSCodeBuildReadOnlyAccess
+      - arn:aws:iam::aws:policy/AWSCodePipelineReadOnlyAccess
+      - arn:aws:iam::aws:policy/IAMReadOnlyAccess
+  IamUser:
+    Type: AWS::IAM::User
+    Properties:
+      ManagedPolicyArns:
+      - arn:aws:iam::aws:policy/AdministratorAccess
+      - arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess
+      - arn:aws:iam::aws:policy/AmazonElastiCacheReadOnlyAccess
+      - arn:aws:iam::aws:policy/AmazonKinesisReadOnlyAccess
+      - arn:aws:iam::aws:policy/AmazonRDSReadOnlyAccess
+      - arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess
+      - arn:aws:iam::aws:policy/AutoScalingConsoleReadOnlyAccess
+      - arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+      - arn:aws:iam::aws:policy/AWSCodeBuildReadOnlyAccess
+      - arn:aws:iam::aws:policy/AWSCodePipelineReadOnlyAccess
+      - arn:aws:iam::aws:policy/IAMReadOnlyAccess

--- a/test/templates/bad/resources_iam_role_assume_role_policy_document.yaml
+++ b/test/templates/bad/resources_iam_role_assume_role_policy_document.yaml
@@ -1,0 +1,64 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Test bad ManagedPolicyArns setup
+Resources:
+  IamRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Sid: VeryLongTextVeryLongTextVeryLongTextVeryLongTextVeryLongTextVeryLongText
+          Effect: Allow
+          Principal:
+            Service: cloudformation.amazonaws.com
+          Action: sts:AssumeRole
+        - Sid: VeryLongTextVeryLongTextVeryLongTextVeryLongTextVeryLongTextVeryLongText
+          Effect: Allow
+          Principal:
+            Service: cloudformation.amazonaws.com
+          Action: sts:AssumeRole
+        - Sid: VeryLongTextVeryLongTextVeryLongTextVeryLongTextVeryLongTextVeryLongText
+          Effect: Allow
+          Principal:
+            Service: cloudformation.amazonaws.com
+          Action: sts:AssumeRole
+        - Sid: VeryLongTextVeryLongTextVeryLongTextVeryLongTextVeryLongTextVeryLongText
+          Effect: Allow
+          Principal:
+            Service: cloudformation.amazonaws.com
+          Action: sts:AssumeRole
+        - Sid: VeryLongTextVeryLongTextVeryLongTextVeryLongTextVeryLongTextVeryLongText
+          Effect: Allow
+          Principal:
+            Service: cloudformation.amazonaws.com
+          Action: sts:AssumeRole
+        - Sid: VeryLongTextVeryLongTextVeryLongTextVeryLongTextVeryLongTextVeryLongText
+          Effect: Allow
+          Principal:
+            Service: cloudformation.amazonaws.com
+          Action: sts:AssumeRole
+        - Sid: VeryLongTextVeryLongTextVeryLongTextVeryLongTextVeryLongTextVeryLongText
+          Effect: Allow
+          Principal:
+            Service: cloudformation.amazonaws.com
+          Action: sts:AssumeRole
+        - Sid: VeryLongTextVeryLongTextVeryLongTextVeryLongTextVeryLongTextVeryLongText
+          Effect: Allow
+          Principal:
+            Service: cloudformation.amazonaws.com
+          Action: sts:AssumeRole
+        - Sid: VeryLongTextVeryLongTextVeryLongTextVeryLongTextVeryLongTextVeryLongText
+          Effect: Allow
+          Principal:
+            Service: cloudformation.amazonaws.com
+          Action: sts:AssumeRole
+        - Sid: VeryLongTextVeryLongTextVeryLongTextVeryLongTextVeryLongTextVeryLongText
+          Effect: Allow
+          Principal:
+            Service: cloudformation.amazonaws.com
+          Action: sts:AssumeRole
+        - Sid: VeryLongTextVeryLongTextVeryLongTextVeryLongTextVeryLongTextVeryLongText
+          Effect: Allow
+          Principal:
+            Service: cloudformation.amazonaws.com
+          Action: sts:AssumeRole

--- a/test/templates/bad/resources_iam_user_groups.yaml
+++ b/test/templates/bad/resources_iam_user_groups.yaml
@@ -1,0 +1,18 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Test bad User groups setup
+Resources:
+  IamUser:
+    Type: AWS::IAM::User
+    Properties:
+      Groups:
+      - arn:aws:iam::012345678901:group/G01
+      - arn:aws:iam::012345678901:group/G02
+      - arn:aws:iam::012345678901:group/G03
+      - arn:aws:iam::012345678901:group/G04
+      - arn:aws:iam::012345678901:group/G05
+      - arn:aws:iam::012345678901:group/G06
+      - arn:aws:iam::012345678901:group/G07
+      - arn:aws:iam::012345678901:group/G08
+      - arn:aws:iam::012345678901:group/G09
+      - arn:aws:iam::012345678901:group/G10
+      - arn:aws:iam::012345678901:group/G11


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Add checks for _some_ of IAM limits, as defined in [documentation](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-limits.html). Mainly those, which can be determined by looking at an individual templates:

- managed policies attached to IAM user, group or role - 10
- groups IAM user can be a member of - 10
- roles in an instance profile - 1
- `AssumeRolePolicyDocument` size - <2048 characters

The ID `2508` was picked semi-arbitrarily. It is close to `2507` - another IAM related check.

Associated tests are also added and pass. Locally I get linter errors:

```
Using config file /home/julius/code/cfn-python-lint/pylintrc
************* Module cfnlint.transform
E: 19, 0: Unable to import 'samtranslator.parser' (import-error)
E: 20, 0: Unable to import 'samtranslator.translator.translator' (import-error)
E: 21, 0: Unable to import 'samtranslator.public.exceptions' (import-error)

-----------------------------------
Your code has been rated at 9.96/10
```

but since they are not related to files I changed I presume it is part of `master` branch or my local setup.

The motivation for this change is that it comes from learning the managed policies limit the hard-way - a CloudFormation stack was stuck in `UPDATE_IN_PROGRESS` for about 40-odd minutes, before it timed out with message below and rolled back:

```
Cannot exceed quota for PoliciesPerGroup: 10 (Service: AmazonIdentityManagement; Status Code: 409; Error Code: LimitExceeded
```

Having this check would have saved some time for me and hopefully can save for someone else.

I hope you will consider this as improvement and I look forward to feedback and I will update this as you think appropriate to be merged into `master`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
