### PR TITLE
Add Sublime linter plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ may need to manually remove the cfn-lint binary.
 There are IDE plugins available to get direct linter feedback from you favorite editor:
 
 * [Atom](https://atom.io/packages/atom-cfn-lint)
+* [Sublime](https://packagecontrol.io/packages/SublimeLinter-contrib-cloudformation)
 * [Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=kddejong.vscode-cfn-lint)
 
 ## Configuration


### PR DESCRIPTION
Added the/a/my Sublime linter to the list of IDE plugins that work with cfn-lint

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
