### PR TITLE
Fix argument handling of "maintenance" and updated documentation

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -27,11 +27,12 @@ Rule `E3012` is used to check the types for value of a resource property.  A num
 
 
 ## Rules
-The following **67** rules are applied by this linter:
+The following **69** rules are applied by this linter:
 
 | Rule ID  | Title | Description | Tags |
 | -------- | ----- | ----------- |----- |
 | E1001 | Basic CloudFormation Template Configuration | Making sure the basic CloudFormation template componets are propery configured | `base` |
+| E1002 | Template size limit | Check the size of the template is less than the upper limit | `base`,`limits` |
 | E1010 | GetAtt validation of parameters | Making sure the function GetAtt is of list | `base`,`functions`,`getatt` |
 | E1011 | FindInMap validation of configuration | Making sure the function is a list of appropriate config | `base`,`functions`,`getatt` |
 | E1012 | Check if Refs exist | Making sure the refs exist | `base`,`functions`,`ref` |
@@ -58,6 +59,7 @@ The following **67** rules are applied by this linter:
 | E2505 | Resource EC2 VPC Properties | See if EC2 VPC Properties are set correctly | `base`,`properties`,`vpc` |
 | E2506 | Resource EC2 Security Group Ingress Properties | See if EC2 Security Group Ingress Properties are set correctly. Check that "SourceSecurityGroupId" or "SourceSecurityGroupName" are  are exclusive and using the type of Ref or GetAtt  | `base`,`resources`,`securitygroup` |
 | E2507 | Check if IAM Policies are properly configured | See if there elements inside an IAM policy are correct | `base`,`properties`,`iam` |
+| E2508 | Check IAM resource limits | See if IAM resources do not breach limits | `base`,`resources`,`iam` |
 | E2510 | Resource EC2 PropertiesEc2Subnet Properties | See if EC2 Subnet Properties are set correctly | `base`,`properties`,`subnet` |
 | E2520 | Check Properties that are mutually exclusive | Making sure CloudFormation properties that are exclusive are not defined | `base`,`resources` |
 | E2521 | Check Properties that are required together | Make sure CloudFormation resource properties are included together when required | `base`,`resources` |

--- a/src/cfnlint/__main__.py
+++ b/src/cfnlint/__main__.py
@@ -24,11 +24,11 @@ LOGGER = logging.getLogger('cfnlint')
 
 def main():
     """Main function"""
-    (args, template, rules, fmt, formatter) = cfnlint.core.get_template_args_rules(sys.argv[1:])
+    (args, filename, template, rules, fmt, formatter) = cfnlint.core.get_template_args_rules(sys.argv[1:])
 
     return(
         cfnlint.core.run_cli(
-            vars(args)['template'], template, rules, fmt,
+            filename, template, rules, fmt,
             vars(args)['regions'],
             vars(args)['override_spec'], formatter))
 

--- a/test/module/core/test_run_checks.py
+++ b/test/module/core/test_run_checks.py
@@ -27,11 +27,11 @@ class TestRunChecks(BaseTestCase):
         """Test success run"""
 
         filename = 'templates/good/generic.yaml'
-        (args, template, rules, _, _) = cfnlint.core.get_template_args_rules([
+        (args, filename, template, rules, _, _) = cfnlint.core.get_template_args_rules([
             '--template', filename])
 
         results = cfnlint.core.run_checks(
-            vars(args)['template'], template, rules, ['us-east-1'])
+            filename, template, rules, ['us-east-1'])
 
         assert(results == [])
 
@@ -39,11 +39,11 @@ class TestRunChecks(BaseTestCase):
         """Test bad template"""
 
         filename = 'templates/quickstart/nat-instance.json'
-        (args, template, rules, _, _) = cfnlint.core.get_template_args_rules([
+        (args, filename, template, rules, _, _) = cfnlint.core.get_template_args_rules([
             '--template', filename])
 
         results = cfnlint.core.run_checks(
-            vars(args)['template'], template, rules, ['us-east-1'])
+            filename, template, rules, ['us-east-1'])
 
         assert(results[0].rule.id == 'W2506')
         assert(results[1].rule.id == 'W2001')

--- a/test/module/core/test_run_cli.py
+++ b/test/module/core/test_run_cli.py
@@ -82,7 +82,7 @@ class TestCli(BaseTestCase):
     def test_template_config(self):
         """Test template config"""
         filename = 'templates/good/core/config_parameters.yaml'
-        (args, _, _, _, _) = cfnlint.core.get_template_args_rules([
+        (args, _, _, _, _, _) = cfnlint.core.get_template_args_rules([
             '--template', filename, '--ignore-bad-template'])
 
         self.assertEqual(vars(args), {
@@ -102,7 +102,7 @@ class TestCli(BaseTestCase):
     def test_positional_template_parameters(self):
         """Test overriding parameters"""
         filename = 'templates/good/core/config_parameters.yaml'
-        (args, _, _, _, _) = cfnlint.core.get_template_args_rules([
+        (args, _, _, _, _, _) = cfnlint.core.get_template_args_rules([
             filename, '--ignore-bad-template',
             '--ignore-checks', 'E0000'])
 
@@ -123,7 +123,7 @@ class TestCli(BaseTestCase):
     def test_override_parameters(self):
         """Test overriding parameters"""
         filename = 'templates/good/core/config_parameters.yaml'
-        (args, _, _, _, _) = cfnlint.core.get_template_args_rules([
+        (args, _, _, _, _, _) = cfnlint.core.get_template_args_rules([
             '--template', filename, '--ignore-bad-template',
             '--ignore-checks', 'E0000'])
 
@@ -145,7 +145,7 @@ class TestCli(BaseTestCase):
         """ Test bad formatting in config"""
 
         filename = 'templates/bad/core/config_parameters.yaml'
-        (args, _, _, _, _) = cfnlint.core.get_template_args_rules([
+        (args, _, _, _, _, _) = cfnlint.core.get_template_args_rules([
             '--template', filename, '--ignore-bad-template'])
 
         self.assertEqual(vars(args), {


### PR DESCRIPTION
Filename was "mandatory", so the "update" command did not trigger, fixed that. Discovered some errors flowing out the positional argument code for the template, also fixed that.

Also ran the `--update-documentation` command to add the 2 new rules to the documentation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
