### PR TITLE
Add VIM plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ may need to manually remove the cfn-lint binary.
 There are IDE plugins available to get direct linter feedback from you favorite editor:
 
 * [Atom](https://atom.io/packages/atom-cfn-lint)
+* [NeoVim 0.2.0+/Vim 8](https://github.com/w0rp/ale#supported-languages)
 * [Sublime](https://packagecontrol.io/packages/SublimeLinter-contrib-cloudformation)
 * [Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=kddejong.vscode-cfn-lint)
 


### PR DESCRIPTION
Found out that there is a VIM linter available, Add it to the list.

*FYI*
There might be an issue with the latest version of the toolkit with that linter due to the change in the `parseable` output. We're working on a fix PR in that repo for that. Besides that we're trying to add the same configuration settings  like the other plugins (ignore_rules, append_rules, override_spec)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
