### PR TITLE
add alias validation for CloudFront distributions

### DIFF
--- a/src/cfnlint/rules/resources/cloudfront/Aliases.py
+++ b/src/cfnlint/rules/resources/cloudfront/Aliases.py
@@ -1,0 +1,47 @@
+"""
+  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this
+  software and associated documentation files (the "Software"), to deal in the Software
+  without restriction, including without limitation the rights to use, copy, modify,
+  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+import re
+from cfnlint import CloudFormationLintRule
+from cfnlint import RuleMatch
+
+
+class Aliases(CloudFormationLintRule):
+    """Check if CloudFront Aliases are valid domain names"""
+    id = 'E3013'
+    shortdesc = 'CloudFront Aliases'
+    description = 'CloudFront aliases should contain valid domain names'
+    tags = ['base', 'properties', 'cloudfront']
+
+    def match(self, cfn):
+        """Check cloudfront Resource Parameters"""
+
+        matches = list()
+
+        valid_domain = re.compile(r'^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9][a-z0-9-]{0,61}[a-z0-9]$')
+
+        results = cfn.get_resource_properties(['AWS::CloudFront::Distribution', 'DistributionConfig'])
+        for result in results:
+            aliases = result['Value'].get('Aliases')
+            if aliases:
+                for alias in aliases:
+                    if not isinstance(alias, dict):
+                        if not re.match(valid_domain, alias):
+                            message = 'Invalid alias found: {}'.format(alias)
+                            path = result['Path'] + ['Aliases']
+                            matches.append(RuleMatch(path, message.format(('/'.join(result['Path'])))))
+
+        return matches

--- a/src/cfnlint/rules/resources/cloudfront/__init__.py
+++ b/src/cfnlint/rules/resources/cloudfront/__init__.py
@@ -1,0 +1,16 @@
+"""
+  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this
+  software and associated documentation files (the "Software"), to deal in the Software
+  without restriction, including without limitation the rights to use, copy, modify,
+  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""

--- a/test/rules/resources/cloudfront/__init__.py
+++ b/test/rules/resources/cloudfront/__init__.py
@@ -1,0 +1,16 @@
+"""
+  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this
+  software and associated documentation files (the "Software"), to deal in the Software
+  without restriction, including without limitation the rights to use, copy, modify,
+  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""

--- a/test/rules/resources/cloudfront/test_aliases.py
+++ b/test/rules/resources/cloudfront/test_aliases.py
@@ -1,0 +1,34 @@
+"""
+  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this
+  software and associated documentation files (the "Software"), to deal in the Software
+  without restriction, including without limitation the rights to use, copy, modify,
+  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+from cfnlint.rules.resources.cloudfront.Aliases import Aliases  # pylint: disable=E0401
+from ... import BaseRuleTestCase
+
+
+class TestCloudFrontAliases(BaseRuleTestCase):
+    """Test CloudFront Aliases Configuration"""
+    def setUp(self):
+        """Setup"""
+        super(TestCloudFrontAliases, self).setUp()
+        self.collection.register(Aliases())
+
+    def test_file_positive(self):
+        """Test Positive"""
+        self.helper_file_positive()
+
+    def test_file_negative_alias(self):
+        """Test failure"""
+        self.helper_file_negative('templates/bad/resources_cloudfront_invalid_aliases.yaml', 7)

--- a/test/templates/bad/resources_cloudfront_invalid_aliases.yaml
+++ b/test/templates/bad/resources_cloudfront_invalid_aliases.yaml
@@ -1,0 +1,41 @@
+AWSTemplateFormatVersion: 2010-09-09
+Resources:
+  CloudFrontDistribution:
+    Type: "AWS::CloudFront::Distribution"
+    Properties:
+      DistributionConfig:
+        Aliases:
+          - "www.example.com"
+          - "example.com"
+          - "email.exa.ple.com"
+          - "mx1.example.eu"
+          - "e-mail.example.amsterdam"
+          - "xn-caf-dma.com"
+          - "www.example.eu"
+          - "111.example.com"
+          - "email.internal.example.eu"
+          - "e-mail.internal.ex-ample.eu"
+          - "www.example.google"
+          - "1111111111.ex--ample.nl"
+          - "WWW.EXAMPLE.COM" # invalid
+          - "-example.com" # invalid
+          - "example.c" # invalid
+          - "www.example.com " # invalid
+          - "www.-example.com" # invalid
+          - "-www.example.com" # invalid
+          - "www.example.com-" # invalid
+        DefaultCacheBehavior:
+          AllowedMethods:
+            - "GET"
+            - "HEAD"
+          CachedMethods:
+            - "GET"
+            - "HEAD"
+          ForwardedValues:
+            QueryString: true
+          TargetOriginId: "s3"
+          ViewerProtocolPolicy: "https-only"
+        Enabled: true
+        Origins:
+          - Id: "s3"
+            DomainName: www.example.com.s3.amazonaws.com"


### PR DESCRIPTION
*[96](https://github.com/awslabs/cfn-python-lint/issues/96)*

*Description of changes:*
This PR will add validation to check wether an CloudFront alias is a valid domain using RegEx. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
