### PR TITLE
Add linting of Route53 recordsets

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -27,7 +27,7 @@ Rule `E3012` is used to check the types for value of a resource property.  A num
 
 
 ## Rules
-The following **69** rules are applied by this linter:
+The following **70** rules are applied by this linter:
 
 | Rule ID  | Title | Description | Tags |
 | -------- | ----- | ----------- |----- |
@@ -77,6 +77,7 @@ The following **69** rules are applied by this linter:
 | E3006 | Resources have appropriate names | Check if Resources are properly named (A-Za-z0-9) | `base`,`resources` |
 | E3010 | Resource limit not exceeded | Check the number of Resources in the template is lessthan the upper limit | `base`,`resources`,`limits` |
 | E3012 | Check resource properties values | Checks resource property values with Primitive Types for values that match those types. | `base`,`resources` |
+| E3020 | Validate Route53 RecordSets | Check if all RecordSets are correctly configured | `base`,`resources`,`route53`,`record_set` |
 | E4001 | Metadata Interface have appropriate properties | Metadata Interface properties are properly configured | `base`,`metadata` |
 | E6001 | Outputs have appropriate properties | Making sure the outputs are properly configured | `base`,`outputs` |
 | E6002 | Outputs have required properties | Making sure the outputs have required properties | `base`,`outputs` |

--- a/src/cfnlint/rules/resources/route53/RecordSet.py
+++ b/src/cfnlint/rules/resources/route53/RecordSet.py
@@ -49,10 +49,14 @@ class RecordSet(CloudFormationLintRule):
 
         for index, record in enumerate(resource_records):
             tree = path[:] + ['ResourceRecords', index]
+            full_path = ('/'.join(str(x) for x in tree))
+
             if not record.startswith('"') or not record.endswith('"'):
                 message = 'TXT record has to be enclosed in double quotation marks (") at {0}'
-                full_path = ('/'.join(str(x) for x in tree))
                 matches.append(RuleMatch(tree, message.format(full_path)))
+            elif len(record) > 255:
+                message = 'The length of the TXT record ({0}) exceeds the limit (255) as {1}'
+                matches.append(RuleMatch(tree, message.format(len(record), full_path)))
 
         return matches
 
@@ -65,7 +69,7 @@ class RecordSet(CloudFormationLintRule):
         if recordset_type not in self.VALID_RECORD_TYPES:
             message = 'Invalid record type "{0}" specified at {1}'
             full_path = ('/'.join(str(x) for x in path))
-            matches.append(RuleMatch(path, message.format(type, full_path)))
+            matches.append(RuleMatch(path, message.format(recordset_type, full_path)))
         elif recordset_type == 'TXT':
             matches.extend(self.check_txt_record(path, recordset))
 

--- a/src/cfnlint/rules/resources/route53/RecordSet.py
+++ b/src/cfnlint/rules/resources/route53/RecordSet.py
@@ -1,0 +1,100 @@
+"""
+  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this
+  software and associated documentation files (the "Software"), to deal in the Software
+  without restriction, including without limitation the rights to use, copy, modify,
+  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+from cfnlint import CloudFormationLintRule
+from cfnlint import RuleMatch
+
+class RecordSet(CloudFormationLintRule):
+    """Check Route53 Recordset Configuration"""
+    id = 'E3020'
+    shortdesc = 'Validate Route53 RecordSets'
+    description = 'Check if all RecordSets are correctly configured'
+    tags = ['base', 'resources', 'route53', 'record_set']
+
+    # https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/ResourceRecordTypes.html
+    VALID_RECORD_TYPES = [
+        'A',
+        'AAAA',
+        'CAA',
+        'CNAME',
+        'MX',
+        'NAPTR',
+        'NS',
+        'PTR',
+        'SOA'
+        'SPF',
+        'SRV',
+        'TXT'
+    ]
+
+    def check_txt_record(self, path, recordset):
+        """Check TXT record Configuration"""
+        matches = list()
+
+        # Check quotation of the records
+        resource_records = recordset.get('ResourceRecords')
+
+        for index, record in enumerate(resource_records):
+            tree = path[:] + ['ResourceRecords', index]
+            if not record.startswith('"') or not record.endswith('"'):
+                message = 'TXT record has to be enclosed in double quotation marks (") at {0}'
+                full_path = ('/'.join(str(x) for x in tree))
+                matches.append(RuleMatch(tree, message.format(full_path)))
+
+        return matches
+
+    def check_recordset(self, path, recordset):
+        """Check record configuration"""
+
+        matches = list()
+        recordset_type = recordset.get('Type')
+
+        if recordset_type not in self.VALID_RECORD_TYPES:
+            message = 'Invalid record type "{0}" specified at {1}'
+            full_path = ('/'.join(str(x) for x in path))
+            matches.append(RuleMatch(path, message.format(type, full_path)))
+        elif recordset_type == 'TXT':
+            matches.extend(self.check_txt_record(path, recordset))
+
+        return matches
+
+
+    def match(self, cfn):
+        """Check RecordSets and RecordSetGroups Properties"""
+
+        matches = list()
+
+        recordsets = cfn.get_resources(['AWS::Route53::RecordSet'])
+
+        for name, recordset in recordsets.items():
+            path = ['Resources', name, 'Properties']
+
+            if isinstance(recordset, dict):
+                props = recordset.get('Properties')
+                if props:
+                    matches.extend(self.check_recordset(path, props))
+
+        recordsetgroups = cfn.get_resource_properties(['AWS::Route53::RecordSetGroup', 'RecordSets'])
+
+        for recordsetgroup in recordsetgroups:
+            path = recordsetgroup['Path']
+            value = recordsetgroup['Value']
+            if isinstance(value, list):
+                for index, recordset in enumerate(value):
+                    tree = path[:] + [index]
+                    matches.extend(self.check_recordset(tree, recordset))
+
+        return matches

--- a/src/cfnlint/rules/resources/route53/__init__.py
+++ b/src/cfnlint/rules/resources/route53/__init__.py
@@ -1,0 +1,16 @@
+"""
+  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this
+  software and associated documentation files (the "Software"), to deal in the Software
+  without restriction, including without limitation the rights to use, copy, modify,
+  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""

--- a/test/rules/resources/route53/__init__.py
+++ b/test/rules/resources/route53/__init__.py
@@ -1,0 +1,16 @@
+"""
+  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this
+  software and associated documentation files (the "Software"), to deal in the Software
+  without restriction, including without limitation the rights to use, copy, modify,
+  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""

--- a/test/rules/resources/route53/test_recordsets.py
+++ b/test/rules/resources/route53/test_recordsets.py
@@ -1,0 +1,34 @@
+"""
+  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this
+  software and associated documentation files (the "Software"), to deal in the Software
+  without restriction, including without limitation the rights to use, copy, modify,
+  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+from cfnlint.rules.resources.route53.RecordSet import RecordSet  # pylint: disable=E0401
+from ... import BaseRuleTestCase
+
+
+class TestRoute53RecordSets(BaseRuleTestCase):
+    """Test CloudFront Aliases Configuration"""
+    def setUp(self):
+        """Setup"""
+        super(TestRoute53RecordSets, self).setUp()
+        self.collection.register(RecordSet())
+
+    def test_file_positive(self):
+        """Test Positive"""
+        self.helper_file_positive()
+
+    def test_file_negative_alias(self):
+        """Test failure"""
+        self.helper_file_negative('templates/bad/route53.yaml', 4)

--- a/test/templates/bad/route53.yaml
+++ b/test/templates/bad/route53.yaml
@@ -21,7 +21,8 @@ Resources:
       Type: "TXT"
       TTL: "300"
       ResourceRecords:
-        - "\"test1\""
+        - "\"google-site-verification=asdfasdfasdfasdfasdfasdfasd123123123786123871623876128376128736123f This is way too longasdfasdfasdfasdfasdfasdfasd123123123786123871623876128376128736123f This is way too longasdfasdfasdfasdfasdfasdfasd123123123786123871623876128376128736123f This is way too long\"" # Too long
+        - "\"MS=ms123123\""
         - "test2" # No quotation
   MyARecordSet:
     Type: "AWS::Route53::RecordSet"
@@ -42,7 +43,6 @@ Resources:
           Type: "TXT"
           TTL: "300"
           ResourceRecords:
-            - "test3" # No quotation
             - "test4" # No quotation
         - Name: "www.example.com"
           Type: "A"

--- a/test/templates/bad/route53.yaml
+++ b/test/templates/bad/route53.yaml
@@ -1,0 +1,61 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: "Route53 resources"
+Parameters:
+  DomainName:
+    Type: String
+    Default: "www.example.com"
+Resources:
+  MyHostedZone:
+    Type: "AWS::Route53::HostedZone"
+    Properties:
+      Name: !Ref "DomainName"
+      VPCs:
+        - VPCId: !ImportValue "infrastructure-vpc"
+          VPCRegion: AWS::Region
+  MyTXTRecordSet:
+    Type: "AWS::Route53::RecordSet"
+    Properties:
+      Comment: "Record to point to the on-prem COOL.BLUE domain controller 00"
+      HostedZoneId: !Ref "MyHostedZone"
+      Name: "x.example.com"
+      Type: "TXT"
+      TTL: "300"
+      ResourceRecords:
+        - "\"test1\""
+        - "test2" # No quotation
+  MyARecordSet:
+    Type: "AWS::Route53::RecordSet"
+    Properties:
+      Comment: "Record to point to the on-prem COOL.BLUE domain controller 00"
+      HostedZoneId: !Ref "MyHostedZone"
+      Name: "www.example.com"
+      Type: "X" # Invalid record type
+      TTL: "300"
+      ResourceRecords:
+        - "127.0.0.1"
+  MyRecordSetGroup:
+    Type: "AWS::Route53::RecordSetGroup"
+    Properties:
+      HostedZoneId: !Ref "MyHostedZone"
+      RecordSets:
+        - Name: "y.example.com"
+          Type: "TXT"
+          TTL: "300"
+          ResourceRecords:
+            - "test3" # No quotation
+            - "test4" # No quotation
+        - Name: "www.example.com"
+          Type: "A"
+          TTL: "300"
+          ResourceRecords:
+            - "127.0.0.1"
+  MySecondRecordSetGroup:
+    Type: "AWS::Route53::RecordSetGroup"
+    Properties:
+      HostedZoneId: !Ref "MyHostedZone"
+      RecordSets:
+        - Name: "z.example.com"
+          Type: "TXT"
+          TTL: "300"
+          ResourceRecords:
+            - "\"henk\""


### PR DESCRIPTION
*Issue https://github.com/awslabs/cfn-python-lint/issues/94*

Added a Rule to test Route53 recordsets. Both `AWS::Route53::RecordSet` and `AWS::Route53::RecordSetGroup` are processed.

There are a LOT of requirements on the recordsets (https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/ResourceRecordTypes.html) that should be covered.

This first version currently just checks 2 things:

- Checks if the recordset is of a valid type  (e.g. `A` or `TXT`)
- Added a check on TXT records to make sure they're in double quotations (https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/ResourceRecordTypes.html#TXTFormat)

Rule is set up in an extendable way so it's easy to add checks on all the other recordset types, so maybe this can/needs to be split up in separate rules. 



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
