### PR TITLE
Improve SAM dependency by requiring at least 1.6.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     ]},
     packages=find_packages('src'),
     zip_safe=False,
-    install_requires=['pyyaml', 'six', 'requests', 'aws-sam-translator'],
+    install_requires=['pyyaml', 'six', 'requests', 'aws-sam-translator>=1.6.0'],
     entry_points={
         'console_scripts': [
             'cfn-lint = cfnlint.__main__:main'

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ commands = discover
 deps =
   discover
   requests
-  aws-sam-translator
+  aws-sam-translator>=1.6.0
 setenv =
   LANG=en_US.UTF-8
   AWS_DEFAULT_REGION=us-east-1


### PR DESCRIPTION
*Issue https://github.com/awslabs/cfn-python-lint/issues/81*

Improve the SAM dependency. We need the new SAM version (1.6.0) to work properly with the transforms. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
