### PR TITLE
Support Conditional to be used for lists

### DIFF
--- a/test/rules/resources/properties/test_properties.py
+++ b/test/rules/resources/properties/test_properties.py
@@ -39,7 +39,7 @@ class TestResourceProperties(BaseRuleTestCase):
 
     def test_file_negative_2(self):
         """Failure test"""
-        self.helper_file_negative('templates/bad/object_should_be_list.yaml', 2)
+        self.helper_file_negative('templates/bad/object_should_be_list.yaml', 4)
 
     def test_file_negative_3(self):
         """Failure test"""

--- a/test/templates/bad/object_should_be_list.yaml
+++ b/test/templates/bad/object_should_be_list.yaml
@@ -651,3 +651,23 @@ Resources:
       Cooldown: '60'
       ScalingAdjustment: '1'
     Type: AWS::AutoScaling::ScalingPolicy
+  Table:
+    Type: 'AWS::DynamoDB::Table'
+    Properties:
+      TableName: !If [HasTableName, !Ref TableName, !Ref 'AWS::NoValue']
+      AttributeDefinitions: !If
+      - HasSortKey
+      - - AttributeName: !Ref PartitionKeyName
+          AttributeType: !Ref PartitionKeyType
+        - AttributeName: !Ref SortKeyName
+          AttributeType: !Ref SortKeyType
+      - "String"
+      KeySchema: !If
+      - HasSortKey
+      - - AttributeName: !Ref PartitionKeyName
+          KeyType: HASH
+        - AttributeName: !Ref SortKeyName
+          KeyType: RANGE
+      - - AttributeName: !Ref PartitionKeyName
+          KeyType: HASH
+        - "String2"

--- a/test/templates/good/resource_properties.yaml
+++ b/test/templates/good/resource_properties.yaml
@@ -561,3 +561,25 @@ Resources:
       Parameters:
         sql_mode: "NO_AUTO_CREATE_USER"
         another_param: "ANOTHER_PARAMETER"
+  Table:
+    Type: 'AWS::DynamoDB::Table'
+    Properties:
+      TableName: !If [HasTableName, !Ref TableName, !Ref 'AWS::NoValue']
+      AttributeDefinitions: !If
+      - HasSortKey
+      - - AttributeName: !Ref PartitionKeyName
+          AttributeType: !Ref PartitionKeyType
+        - AttributeName: !Ref SortKeyName
+          AttributeType: !Ref SortKeyType
+      - - AttributeName: !Ref PartitionKeyName
+          AttributeType: !Ref PartitionKeyType
+      KeySchema: !If
+      - HasSortKey
+      - - AttributeName: !Ref PartitionKeyName
+          KeyType: HASH
+        - AttributeName: !Ref SortKeyName
+          KeyType: RANGE
+      - - AttributeName: !Ref PartitionKeyName
+          KeyType: HASH
+        - AttributeName: !Ref SortKeyName
+          KeyType: RANGE


### PR DESCRIPTION
*Issue https://github.com/awslabs/cfn-python-lint/issues/140*
Fixes #140 

A list has to be a list ATM. Within the lists Conditionals are supported, but not when the condition is wrapping the list itself. Add support for this by checking for Conditionals and check each outcome.

Code is just getting a bit messy now, need to tweak that (pylint does not approved my 😂 )

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
