### PR TITLE
Add support for wildcards

### DIFF
--- a/test/rules/resources/cloudfront/test_aliases.py
+++ b/test/rules/resources/cloudfront/test_aliases.py
@@ -31,4 +31,4 @@ class TestCloudFrontAliases(BaseRuleTestCase):
 
     def test_file_negative_alias(self):
         """Test failure"""
-        self.helper_file_negative('templates/bad/resources_cloudfront_invalid_aliases.yaml', 7)
+        self.helper_file_negative('templates/bad/resources_cloudfront_invalid_aliases.yaml', 8)

--- a/test/templates/bad/resources_cloudfront_invalid_aliases.yaml
+++ b/test/templates/bad/resources_cloudfront_invalid_aliases.yaml
@@ -17,6 +17,8 @@ Resources:
           - "e-mail.internal.ex-ample.eu"
           - "www.example.google"
           - "1111111111.ex--ample.nl"
+          - "*.example.com"
+          - "email.*.example.com" # invalid
           - "WWW.EXAMPLE.COM" # invalid
           - "-example.com" # invalid
           - "example.c" # invalid


### PR DESCRIPTION
*Description of changes:*
The recently release version with the Alias validation failed due to missing support for wildcards and was unable to "validate" CloudFormation functions.

I added wildcard support in the RegEx but that matches on wildcards in every subdomain and domain of the domain name. 

Only wildcards are valid on the first subdomain of a domain [rfc-4592](http://www.ietf.org/rfc/rfc4592.txt)

I'm fine if someone with more RegEx Fu is able to move it all back to 1 RegEx,.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
