### PR TITLE
Convert Lambda Warning to allow for AllowedValues

### DIFF
--- a/src/cfnlint/rules/parameters/LambdaMemorySize.py
+++ b/src/cfnlint/rules/parameters/LambdaMemorySize.py
@@ -26,9 +26,6 @@ class LambdaMemorySize(CloudFormationLintRule):
                   ' should have a min and max size that matches Lambda constraints'
     tags = ['base', 'parameters', 'lambda']
 
-    min_memory = 128
-    max_memory = 3008
-
     def __init__(self):
         """Init"""
         resource_type_specs = [
@@ -45,19 +42,17 @@ class LambdaMemorySize(CloudFormationLintRule):
 
         if value in parameters:
             parameter = parameters.get(value)
-            min_value = parameter.get('MinValue', 0)
-            max_value = parameter.get('MaxValue', 999999)
-            if min_value < self.min_memory or max_value > self.max_memory:
-                param_path = ['Parameters', value, 'Type']
-                message = 'Type for Parameter should be Integer, MinValue should be ' \
-                          'at least {0}, and MaxValue equal or less than {1} at {0}'
+            min_value = parameter.get('MinValue')
+            max_value = parameter.get('MaxValue')
+            allowed_values = parameter.get('AllowedValues')
+            if (not min_value or not max_value) and (not allowed_values):
+                param_path = ['Parameters', value]
+                message = 'Lambda Memory Size parameters should use MinValue, MaxValue ' \
+                          'or AllowedValues at {0}'
                 matches.append(
                     RuleMatch(
                         param_path,
-                        message.format(
-                            self.min_memory,
-                            self.max_memory,
-                            ('/'.join(param_path)))))
+                        message.format(('/'.join(param_path)))))
 
         return matches
 

--- a/test/rules/parameters/test_lambda_memory_size.py
+++ b/test/rules/parameters/test_lambda_memory_size.py
@@ -31,4 +31,4 @@ class TestParameterLambdaMemorySize(BaseRuleTestCase):
 
     def test_file_negative(self):
         """Test failure"""
-        self.helper_file_negative('templates/bad/resources_lambda.yaml', 1)
+        self.helper_file_negative('templates/bad/resources_lambda.yaml', 2)

--- a/test/rules/resources/lmbd/test_memory_size.py
+++ b/test/rules/resources/lmbd/test_memory_size.py
@@ -31,4 +31,4 @@ class TestFunctionMemorySize(BaseRuleTestCase):
 
     def test_file_negative(self):
         """Test failure"""
-        self.helper_file_negative('templates/bad/resources_lambda.yaml', 2)
+        self.helper_file_negative('templates/bad/resources_lambda.yaml', 3)

--- a/test/templates/bad/resources_lambda.yaml
+++ b/test/templates/bad/resources_lambda.yaml
@@ -6,6 +6,27 @@ Parameters:
   myParameterMemorySize:
     Type: Number
     Description: Memory Size
+  myMemorySize2:
+    Type: Number
+    AllowedValues:
+      - 1
+      - 384
+      - 512
+      - 640
+      - 768
+      - 896
+      - 1024
+      - 1152
+      - 1280
+      - 1408
+      - 3009
+    Default: 128
+    Description: Size of the Lambda function running the scheduler, increase size when
+      processing large numbers of instances
+  myMemorySize3:
+    Type: Number
+    Description: Size of the Lambda function running the scheduler, increase size when
+      processing large numbers of instances
   myParameterRuntime:
     Type: String
     Description: Runtime
@@ -42,3 +63,17 @@ Resources:
       Role: !GetAtt LambdaExecutionRole.Arn
       Runtime: !Ref myParameterRuntime
       MemorySize: !Ref myParameterMemorySize
+  myLambda3:
+    Type: AWS::Lambda::Function
+    Properties:
+      Handler: index.handler
+      Role: !GetAtt LambdaExecutionRole.Arn
+      Runtime: !Ref myParameterRuntime
+      MemorySize: !Ref myMemorySize2
+  myLambda4:
+    Type: AWS::Lambda::Function
+    Properties:
+      Handler: index.handler
+      Role: !GetAtt LambdaExecutionRole.Arn
+      Runtime: !Ref myParameterRuntime
+      MemorySize: !Ref myMemorySize3

--- a/test/templates/good/resources_lambda.yaml
+++ b/test/templates/good/resources_lambda.yaml
@@ -8,6 +8,23 @@ Parameters:
     Description: Memory Size
     MinValue: 128
     MaxValue: 1024
+  myMemorySize2:
+    Type: Number
+    AllowedValues:
+      - 128
+      - 384
+      - 512
+      - 640
+      - 768
+      - 896
+      - 1024
+      - 1152
+      - 1280
+      - 1408
+      - 1536
+    Default: 128
+    Description: Size of the Lambda function running the scheduler, increase size when
+      processing large numbers of instances
   myParameterRuntime:
     Type: String
     Description: Runtime
@@ -56,3 +73,12 @@ Resources:
         ZipFile: "amilookup.zip"
       Runtime: !Ref myParameterRuntime
       MemorySize: !Ref myParameterMemorySize
+  myLambda3:
+    Type: AWS::Lambda::Function
+    Properties:
+      Handler: index.handler
+      Role: !GetAtt myLambdaExecutionRole.Arn
+      Code:
+        ZipFile: "amilookup.zip"
+      Runtime: !Ref myParameterRuntime
+      MemorySize: !Ref myMemorySize2


### PR DESCRIPTION
Convert Lambda Warning to only be if MaxValue, MinValue, or AllowedValues aren't specified.  Convert value checks for those items to the Error equivalent

*Issue #, if available:*
Fixes #146 

*Description of changes:*
- Fixed wording of Lambda Parameter needing to be a Number (not Integer)
- Allow for template to use AllowedValues instead of MinValue, MaxValue

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
