### PR TITLE
Hotfix possible A-record issue

### DIFF
--- a/src/cfnlint/rules/resources/route53/RecordSet.py
+++ b/src/cfnlint/rules/resources/route53/RecordSet.py
@@ -15,6 +15,7 @@
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 import re
+import six
 from cfnlint import CloudFormationLintRule
 from cfnlint import RuleMatch
 
@@ -50,14 +51,16 @@ class RecordSet(CloudFormationLintRule):
         if not recordset.get('AliasTarget'):
             resource_records = recordset.get('ResourceRecords')
             for index, record in enumerate(resource_records):
-                tree = path[:] + ['ResourceRecords', index]
-                full_path = ('/'.join(str(x) for x in tree))
 
-                # Check if a valid IPv4 address is specified
-                regex = re.compile(self.ipv4_regex)
-                if not regex.match(record):
-                    message = 'A record is not a valid IPv4 address at {0}'
-                    matches.append(RuleMatch(tree, message.format(full_path)))
+                if isinstance(record, six.string_types):
+                    tree = path[:] + ['ResourceRecords', index]
+                    full_path = ('/'.join(str(x) for x in tree))
+
+                    # Check if a valid IPv4 address is specified
+                    regex = re.compile(self.ipv4_regex)
+                    if not regex.match(record):
+                        message = 'A record is not a valid IPv4 address at {0}'
+                        matches.append(RuleMatch(tree, message.format(full_path)))
 
         return matches
 


### PR DESCRIPTION
*Issue https://github.com/awslabs/cfn-python-lint/issues/94*

The records in an A-record can also be more complex like References. Which can be a Parameter but even a Reference to for instance an EIP.

Example:

```
  MyEIP:
    Type: "AWS::EC2::EIP"
  MyRecordSet:
    Type: "AWS::Route53::RecordSet"
    Properties:
      Type: "A"
      TTL: "900"
      ResourceRecords:
        - !Ref "MyEIP"
```

So even a simple "is it a valid IPv4" address is complexer. Will fix this structurally later on, but this hotfix makes sure the code wont "break" 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
