### PR TITLE
Correct invalid runtime message

### DIFF
--- a/src/cfnlint/rules/resources/lmbd/FunctionRuntime.py
+++ b/src/cfnlint/rules/resources/lmbd/FunctionRuntime.py
@@ -34,7 +34,7 @@ class FunctionRuntime(CloudFormationLintRule):
         """ Check runtime value """
         matches = list()
 
-        message = 'You must specify a valid value for runtime at {0}'
+        message = 'You must specify a valid value for runtime ({0}) at {1}'
 
         if value not in self.runtimes:
             matches.append(RuleMatch(path, message.format(value, ('/'.join(path)))))


### PR DESCRIPTION
*Issue https://github.com/awslabs/cfn-python-lint/issues/157*

Quickfix to correct (possible) confusing error message

Old:
```
cfn-lint test.yaml
E2531 You must specify a valid value for runtime at nodejs8.11
test.yaml:10:3
```
New:
```
cfn-lint test.yaml
E2531 You must specify a valid value for runtime (nodejs8.11) at Resources/MyExampleFunction/Properties/Runtime
test.yaml:10:3
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
