### PR TITLE
Resource names should only contain alphanumeric

### DIFF
--- a/src/cfnlint/helpers.py
+++ b/src/cfnlint/helpers.py
@@ -35,7 +35,7 @@ REGIONS = ['us-east-1', 'us-east-2', 'us-west-1', 'us-west-2', 'ca-central-1',
            'ap-northeast-2', 'ap-southeast-1', 'ap-southeast-2', 'ap-south-1',
            'sa-east-1']
 
-REGEX_ALPHANUMERIC = re.compile('^[a-zA-Z0-9_]*$')
+REGEX_ALPHANUMERIC = re.compile('^[a-zA-Z0-9]*$')
 
 AVAILABILITY_ZONES = [
     'us-east-1a', 'us-east-1b', 'us-east-1c', 'us-east-1d', 'us-east-1e', 'us-east-1f',

--- a/test/rules/resources/test_name.py
+++ b/test/rules/resources/test_name.py
@@ -35,4 +35,4 @@ class TestName(BaseRuleTestCase):
 
     def test_file_negative(self):
         """Test failure"""
-        self.helper_file_negative('templates/bad/resources/name.yaml', 1)
+        self.helper_file_negative('templates/bad/resources/name.yaml', 2)

--- a/test/templates/bad/resources/name.yaml
+++ b/test/templates/bad/resources/name.yaml
@@ -4,3 +4,7 @@ Resources:
     Type: AWS::EC2::Instance
     Properties:
       ImageId: ami-123456
+  my_Instance:
+    Type: AWS::EC2::Instance
+    Properties:
+      ImageId: ami-123456


### PR DESCRIPTION
*Description of changes:*
CloudFormation Resource names can only contain alphanumeric. As stated here: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/resources-section-structure.html

Same goes for Outputs:
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/outputs-section-structure.html

and Parameters:
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/parameters-section-structure.html

and Mappings:
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/mappings-section-structure.html

and according the following error when uploading a CloudFormation template:
`Template validation error: Template format error: Resource name SNS_TOPIC is non alphanumeric.`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
