### PR TITLE
Simplify cli usage

### DIFF
--- a/src/cfnlint/core.py
+++ b/src/cfnlint/core.py
@@ -91,55 +91,58 @@ def create_parser():
     """Do first round of parsing parameters to set options"""
     parser = ArgumentParser(description='CloudFormation Linter')
 
+    standard = parser.add_argument_group('Standard')
+    advanced = parser.add_argument_group('Advanced / Debugging')
+
     # Alllow the template to be passes as an optional or a positional argument
-    parser.add_argument(
+    standard.add_argument(
         'template', nargs='?', help='The CloudFormation template to be linted')
-    parser.add_argument(
+    standard.add_argument(
         '-t', '--template', dest='template_alt', help='The CloudFormation template to be linted')
 
-    parser.add_argument(
+    standard.add_argument(
         '-b', '--ignore-bad-template', help='Ignore failures with Bad template',
         action='store_true'
     )
-    parser.add_argument(
+    advanced.add_argument(
         '-d', '--debug', help='Enable debug logging', action='store_true'
     )
-    parser.add_argument(
+    standard.add_argument(
         '-f', '--format', help='Output Format', choices=['quiet', 'parseable', 'json']
     )
 
-    parser.add_argument(
+    standard.add_argument(
         '-l', '--list-rules', dest='listrules', default=False,
         action='store_true', help='list all the rules'
     )
-    parser.add_argument(
+    standard.add_argument(
         '-r', '--regions', dest='regions', default=['us-east-1'], nargs='*',
         help='list the regions to validate against.'
     )
-    parser.add_argument(
+    advanced.add_argument(
         '-a', '--append-rules', dest='append_rules', default=[], nargs='*',
         help='specify one or more rules directories using '
              'one or more --append-rules arguments. '
     )
-    parser.add_argument(
+    standard.add_argument(
         '-i', '--ignore-checks', dest='ignore_checks', default=[], nargs='*',
         help='only check rules whose id do not match these values'
     )
 
-    parser.add_argument(
+    advanced.add_argument(
         '-o', '--override-spec', dest='override_spec',
         help='A CloudFormation Spec override file that allows customization'
     )
 
-    parser.add_argument(
+    standard.add_argument(
         '-v', '--version', help='Version of cfn-lint', action='version',
         version='%(prog)s {version}'.format(version=__version__)
     )
-    parser.add_argument(
+    advanced.add_argument(
         '-u', '--update-specs', help='Update the CloudFormation Specs',
         action='store_true'
     )
-    parser.add_argument(
+    advanced.add_argument(
         '--update-documentation', help=argparse.SUPPRESS,
         action='store_true'
     )


### PR DESCRIPTION
A couple of options seem mostly intended for developers of this tool (update-specs, update-documentation, etc), so to reduce confusion for new users I moved those to a separate argument group.

I also removed `-t`/`--template`, which might be more controversial. I can't think of any cases where positional arguments would be insufficient, and having two ways to input file names is just confusing. Better to remove this duplication as early as possible in the linter's life, before lots of people start to rely on this.

Usage Before:

```
usage: cfn-lint [-h] [-t TEMPLATES] [-b] [-d] [-f {quiet,parseable,json}] [-l]
                [-r [REGIONS [REGIONS ...]]]
                [-a [APPEND_RULES [APPEND_RULES ...]]]
                [-i [IGNORE_CHECKS [IGNORE_CHECKS ...]]] [-o OVERRIDE_SPEC]
                [-v] [-u]
                [templates [templates ...]]

CloudFormation Linter

positional arguments:
  templates             The CloudFormation templates to be linted

optional arguments:
  -h, --help            show this help message and exit
  -t TEMPLATES, --templates TEMPLATES
                        The CloudFormation templates to be linted
  -b, --ignore-bad-template
                        Ignore failures with Bad template
  -d, --debug           Enable debug logging
  -f {quiet,parseable,json}, --format {quiet,parseable,json}
                        Output Format
  -l, --list-rules      list all the rules
  -r [REGIONS [REGIONS ...]], --regions [REGIONS [REGIONS ...]]
                        list the regions to validate against.
  -a [APPEND_RULES [APPEND_RULES ...]], --append-rules [APPEND_RULES [APPEND_RULES ...]]
                        specify one or more rules directories using one or
                        more --append-rules arguments.
  -i [IGNORE_CHECKS [IGNORE_CHECKS ...]], --ignore-checks [IGNORE_CHECKS [IGNORE_CHECKS ...]]
                        only check rules whose id do not match these values
  -o OVERRIDE_SPEC, --override-spec OVERRIDE_SPEC
                        A CloudFormation Spec override file that allows
                        customization
  -v, --version         Version of cfn-lint
  -u, --update-specs    Update the CloudFormation Specs
```

Usage After:

```
usage: cfn-lint [-h] [-b] [-d] [-f {quiet,parseable,json}] [-l]
                [-r [REGIONS [REGIONS ...]]]
                [-a [APPEND_RULES [APPEND_RULES ...]]]
                [-i [IGNORE_CHECKS [IGNORE_CHECKS ...]]] [-o OVERRIDE_SPEC]
                [-v] [-u]
                [template]

CloudFormation Linter

optional arguments:
  -h, --help            show this help message and exit

Standard arguments:
  template              The CloudFormation template to be linted
  -b, --ignore-bad-template
                        Ignore failures with Bad template
  -f {quiet,parseable,json}, --format {quiet,parseable,json}
                        Output Format
  -l, --list-rules      list all the rules
  -r [REGIONS [REGIONS ...]], --regions [REGIONS [REGIONS ...]]
                        list the regions to validate against.
  -i [IGNORE_CHECKS [IGNORE_CHECKS ...]], --ignore-checks [IGNORE_CHECKS [IGNORE_CHECKS ...]]
                        only check rules whose id do not match these values
  -v, --version         Version of cfn-lint

Advanced / Debugging arguments:
  -d, --debug           Enable debug logging
  -a [APPEND_RULES [APPEND_RULES ...]], --append-rules [APPEND_RULES [APPEND_RULES ...]]
                        specify one or more rules directories using one or
                        more --append-rules arguments.
  -o OVERRIDE_SPEC, --override-spec OVERRIDE_SPEC
                        A CloudFormation Spec override file that allows
                        customization
  -u, --update-specs    Update the CloudFormation Specs
```