### PR TITLE
Add run to check for unneeded DependsOn usage

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -27,7 +27,7 @@ Rule `E3012` is used to check the types for value of a resource property.  A num
 
 
 ## Rules
-The following **71** rules are applied by this linter:
+The following **72** rules are applied by this linter:
 
 | Rule ID  | Title | Description | Tags |
 | -------- | ----- | ----------- |----- |
@@ -101,6 +101,7 @@ The following **71** rules are applied by this linter:
 | W2509 | CIDR Parameters have allowed values | Check if a parameter is being used as a CIDR. If it is make sure it has allowed values regex comparisons | `base`,`parameters`,`availabilityzone` |
 | W2510 | Parameter Memory Size attributes should have max and min | Check if a parameter that is used for Lambda memory size  should have a min and max size that matches Lambda constraints | `base`,`parameters`,`lambda` |
 | W2512 | Parameter Lambda Runtime has allowed values set | Check if a parameter that is used for Lambda runtime  has allowed values constraint defined | `base`,`parameters`,`lambda` |
+| W3005 | Check obsolete DependsOn configuration for Resources | Check if DependsOn is specified if not needed. A Ref and GetAtt implicitly results in DependsOn behaviour. | `base`,`resources`,`dependson` |
 | W3010 | Availability Zone Parameters should not be hardcoded | Check if an Availability Zone property is hardcoded. | `base`,`parameters`,`availabilityzone` |
 | W4001 | Metadata Interface parameters exist | Metadata Interface parameters actually exist | `base`,`metadata` |
 | W7001 | Check if Mappings are Used | Making sure the mappings defined are used | `base`,`conditions` |

--- a/src/cfnlint/rules/resources/DependsOnObsolete.py
+++ b/src/cfnlint/rules/resources/DependsOnObsolete.py
@@ -1,0 +1,85 @@
+"""
+  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this
+  software and associated documentation files (the "Software"), to deal in the Software
+  without restriction, including without limitation the rights to use, copy, modify,
+  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+from cfnlint import CloudFormationLintRule
+from cfnlint import RuleMatch
+
+
+class DependsOnObsolete(CloudFormationLintRule):
+    """Check unneeded DepensOn Resource Configuration"""
+    id = 'W3005'
+    shortdesc = 'Check obsolete DependsOn configuration for Resources'
+    description = 'Check if DependsOn is specified if not needed. ' \
+                  'A Ref and GetAtt implicitly results in DependsOn behaviour.'
+    tags = ['base', 'resources', 'dependson']
+
+    def get_resource_references(self, cfn, ref_function, resource):
+        """Get tree of all resource references of a resource"""
+        trees = cfn.search_deep_keys(ref_function)
+
+        # Filter only resoureces
+        # Disable pylint for Pylint 2
+        # pylint: disable=W0110
+        trees = filter(lambda x: x[0] == 'Resources', trees)
+        # Filter on the given resource only
+        # Disable pylint for Pylint 2
+        # pylint: disable=W0110
+        trees = filter(lambda x: x[1] == resource, trees)
+
+        return trees
+
+    def check_depends_on(self, cfn, resource, key, path):
+        """Check if the DependsOn is already specified"""
+        matches = list()
+
+        # Get references
+        trees = self.get_resource_references(cfn, 'Ref', resource)
+
+        for tree in trees:
+            if tree[-1] == key:
+                message = 'Obsolete DependsOn on resource ({0}), dependency already enfoced by "!Ref" at {1}'
+                matches.append(RuleMatch(path, message.format(key, '/'.join(map(str, tree)))))
+
+        # Get the GetAtt
+        trees = self.get_resource_references(cfn, 'Fn::GetAtt', resource)
+
+        for tree in trees:
+            # GettAtt formation is "resource : Attribute", just check the resource
+            if tree[-1][0] == key:
+                message = 'Obsolete DependsOn on resource ({0}), dependency already enforced by "!Fn:GetAtt" at {1}'
+                matches.append(RuleMatch(path, message.format(key, '/'.join(map(str, tree)))))
+
+        return matches
+
+    def match(self, cfn):
+        """Check CloudFormation Resources"""
+
+        matches = list()
+
+        resources = cfn.get_resources()
+
+        for resource_name, resource_values in resources.items():
+            depends_ons = resource_values.get('DependsOn')
+            if depends_ons:
+                path = ['Resources', resource_name, 'DependsOn']
+                self.logger.debug('Validating unneeded DependsOn for %s', resource_name)
+                if isinstance(depends_ons, list):
+                    for index, depends_on in enumerate(depends_ons):
+                        matches.extend(self.check_depends_on(cfn, resource_name, depends_on, path[:] + [index]))
+                else:
+                    matches.extend(self.check_depends_on(cfn, resource_name, depends_ons, path))
+
+        return matches

--- a/test/module/cfn_json/test_cfn_json.py
+++ b/test/module/cfn_json/test_cfn_json.py
@@ -34,11 +34,11 @@ class TestCfnJson(BaseTestCase):
         self.filenames = {
             "config_rule": {
                 "filename": 'templates/quickstart/config-rules.json',
-                "failures": 2
+                "failures": 4
             },
             "iam": {
                 "filename": 'templates/quickstart/iam.json',
-                "failures": 0
+                "failures": 4
             },
             "nat_instance": {
                 "filename": 'templates/quickstart/nat-instance.json',
@@ -46,7 +46,7 @@ class TestCfnJson(BaseTestCase):
             },
             "vpc_management": {
                 "filename": 'templates/quickstart/vpc-management.json',
-                "failures": 32
+                "failures": 35
             },
             "vpc": {
                 "filename": 'templates/quickstart/vpc.json',

--- a/test/templates/bad/resources_dependson.yaml
+++ b/test/templates/bad/resources_dependson.yaml
@@ -24,3 +24,13 @@ Resources:
     Type: AWS::EC2::Instance
     Properties:
       ImageId: String
+  myInstance5:
+    Type: AWS::EC2::Instance
+    DependsOn: myInstance4
+    Properties:
+      ImageId: String
+      Tags:
+        - Key: "Dependency"
+          Value: !Ref "myInstance4"
+        - Key: "GetAtt"
+          Value: !GetAtt [ myInstance4, AvailabilityZone ]


### PR DESCRIPTION
*Issue https://github.com/awslabs/cfn-python-lint/issues/151*

According to an AWS Blog post:
```
You can also introduce references between elements by using either the { "Ref": "MyResource" } or the { "Fn::GetAtt" : [ "MyResource" , "MyAttribute" ] } functions. 
When you use one of these functions, CloudFormation behaves as if you’ve added a DependsOn attribute to the resource. 
 ```
Source: https://aws.amazon.com/blogs/devops/optimize-aws-cloudformation-templates/

This rules add this check as a Warning `W3005` (Other `DependsOn` check is an error with the same number).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
