### PR TITLE
Add rule to check SecurityGroup Descriptions

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -27,7 +27,7 @@ Rule `E3012` is used to check the types for value of a resource property.  A num
 
 
 ## Rules
-The following **71** rules are applied by this linter:
+The following **72** rules are applied by this linter:
 
 | Rule ID  | Title | Description | Tags |
 | -------- | ----- | ----------- |----- |
@@ -63,6 +63,7 @@ The following **71** rules are applied by this linter:
 | E2506 | Resource EC2 Security Group Ingress Properties | See if EC2 Security Group Ingress Properties are set correctly. Check that "SourceSecurityGroupId" or "SourceSecurityGroupName" are  are exclusive and using the type of Ref or GetAtt  | `base`,`resources`,`securitygroup` |
 | E2507 | Check if IAM Policies are properly configured | See if there elements inside an IAM policy are correct | `base`,`properties`,`iam` |
 | E2508 | Check IAM resource limits | See if IAM resources do not breach limits | `base`,`resources`,`iam` |
+| E2509 | Validate SecurityGroup description | Check if SecurityGroup descriptions are correctly configured | `base`,`resources`,`securitygroup` |
 | E2510 | Resource EC2 PropertiesEc2Subnet Properties | See if EC2 Subnet Properties are set correctly | `base`,`properties`,`subnet` |
 | E2520 | Check Properties that are mutually exclusive | Making sure CloudFormation properties that are exclusive are not defined | `base`,`resources` |
 | E2521 | Check Properties that are required together | Make sure CloudFormation resource properties are included together when required | `base`,`resources` |

--- a/src/cfnlint/__init__.py
+++ b/src/cfnlint/__init__.py
@@ -701,7 +701,7 @@ class Template(object):
     def check_resource_property(self, resource_type, resource_property,
                                 check_value=None, check_ref=None,
                                 check_find_in_map=None, check_split=None,
-                                check_join=None, **kwargs):
+                                check_join=None, check_sub=None, **kwargs):
         """ Check Resource Properties """
         LOGGER.debug('Check property %s for %s', resource_property, resource_type)
         matches = list()
@@ -715,7 +715,7 @@ class Template(object):
                         path=['Resources', resource_name, 'Properties'],
                         check_value=check_value, check_ref=check_ref,
                         check_find_in_map=check_find_in_map, check_split=check_split,
-                        check_join=check_join, **kwargs
+                        check_join=check_join, check_sub=check_sub, **kwargs
                     )
                 )
         return matches
@@ -724,7 +724,7 @@ class Template(object):
     def check_value(self, obj, key, path,
                     check_value=None, check_ref=None,
                     check_find_in_map=None, check_split=None, check_join=None,
-                    check_import_value=None,
+                    check_import_value=None, check_sub=None,
                     **kwargs):
         """
             Check the value

--- a/src/cfnlint/rules/resources/ectwo/SecurityGroupDescription.py
+++ b/src/cfnlint/rules/resources/ectwo/SecurityGroupDescription.py
@@ -27,6 +27,13 @@ class SecurityGroupDescription(CloudFormationLintRule):
 
     description_regex = r'^([a-z,A-Z,0-9,. _\-:/()#,@[\]+=&;\{\}!$*])*$'
 
+    # pylint: disable=W0613
+    def check_sub(self, value, path, **kwargs):
+        """Check SecurityGroup descriptions in Subs"""
+        # Just check the raw sub string itself, without the replacements
+        # for special characters
+        return self.check_value(value, path)
+
     def check_value(self, value, path):
         """Check SecurityGroup descriptions"""
         matches = list()
@@ -61,8 +68,7 @@ class SecurityGroupDescription(CloudFormationLintRule):
                 matches.extend(
                     cfn.check_value(
                         properties, 'GroupDescription', path,
-                        check_value=self.check_value, check_ref=None,
-                        check_find_in_map=None, check_split=None, check_join=None
+                        check_value=self.check_value, check_sub=self.check_sub
                     )
                 )
 

--- a/src/cfnlint/rules/resources/ectwo/SecurityGroupDescription.py
+++ b/src/cfnlint/rules/resources/ectwo/SecurityGroupDescription.py
@@ -1,0 +1,62 @@
+"""
+  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this
+  software and associated documentation files (the "Software"), to deal in the Software
+  without restriction, including without limitation the rights to use, copy, modify,
+  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+import re
+import six
+from cfnlint import CloudFormationLintRule
+from cfnlint import RuleMatch
+
+class SecurityGroupDescription(CloudFormationLintRule):
+    """Check SecurityGroup Description Configuration"""
+    id = 'E2509'
+    shortdesc = 'Validate SecurityGroup description'
+    description = 'Check if SecurityGroup descriptions are correctly configured'
+    tags = ['base', 'resources', 'securitygroup']
+
+    description_regex = r'^([a-z,A-Z,0-9,. _\-:/()#,@[\]+=&;\{\}!$*])*$'
+
+    def match(self, cfn):
+        """Check SecurityGroup descriptions"""
+
+        matches = list()
+
+        resources = cfn.get_resources(['AWS::EC2::SecurityGroup'])
+
+        for resource_name, resource in resources.items():
+            path = ['Resources', resource_name, 'Properties']
+
+            props = resource.get('Properties')
+            if props:
+                description = props.get('GroupDescription')
+
+                if description:
+                    path = ['Resources', resource_name, 'Properties', 'GroupDescription']
+                    full_path = ('/'.join(str(x) for x in path))
+
+                    if isinstance(description, six.string_types):
+                        # Check max length
+                        if len(description) > 255:
+                            message = 'GroupDescription length of {0} ({1}) exceeds the limit (255) at {2}'
+                            matches.append(RuleMatch(path, message.format(resource_name, len(description), full_path)))
+                        else:
+                            # Check valid characters
+                            regex = re.compile(self.description_regex)
+                            if not regex.match(description):
+                                message = 'GroupDescription contains invalid characters (valid characters are: '\
+                                          '"a-zA-Z0-9. _-:/()#,@[]+=&;\\{{}}!$*"") at {0}'
+                                matches.append(RuleMatch(path, message.format(full_path)))
+
+        return matches

--- a/test/rules/resources/ec2/test_sg_description.py
+++ b/test/rules/resources/ec2/test_sg_description.py
@@ -1,0 +1,34 @@
+"""
+  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this
+  software and associated documentation files (the "Software"), to deal in the Software
+  without restriction, including without limitation the rights to use, copy, modify,
+  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+from cfnlint.rules.resources.ectwo.SecurityGroupDescription import SecurityGroupDescription  # pylint: disable=E0401
+from ... import BaseRuleTestCase
+
+
+class TestPropertySgDescription(BaseRuleTestCase):
+    """Test Ec2 Security Group Ingress Rules"""
+    def setUp(self):
+        """Setup"""
+        super(TestPropertySgDescription, self).setUp()
+        self.collection.register(SecurityGroupDescription())
+
+    def test_file_positive(self):
+        """Test Positive"""
+        self.helper_file_positive()
+
+    def test_file_negative(self):
+        """Test failure"""
+        self.helper_file_negative('templates/bad/properties_sg_Description.yaml', 2)

--- a/test/rules/resources/ec2/test_sg_description.py
+++ b/test/rules/resources/ec2/test_sg_description.py
@@ -31,4 +31,4 @@ class TestPropertySgDescription(BaseRuleTestCase):
 
     def test_file_negative(self):
         """Test failure"""
-        self.helper_file_negative('templates/bad/properties_sg_Description.yaml', 2)
+        self.helper_file_negative('templates/bad/properties_sg_description.yaml', 3)

--- a/test/templates/bad/properties_sg_description.yaml
+++ b/test/templates/bad/properties_sg_description.yaml
@@ -12,7 +12,7 @@ Resources:
   mySecurityGroupInvalidCharacters:
     Type: AWS::EC2::SecurityGroup
     Properties:
-      GroupDescription: 'Special charaters like ^ & and " are not supported'
+      GroupDescription: 'Special charaters like ^ and " are not supported'
   mySecurityGroupValidCharacters:
     Type: AWS::EC2::SecurityGroup
     Properties:
@@ -24,4 +24,4 @@ Resources:
   mySecurityGroupValidSub:
     Type: AWS::EC2::SecurityGroup
     Properties:
-      GroupDescription: !Sub "Securitygroup of ${AppGroup}"
+      GroupDescription: !Sub 'Securitygroup of ${AppGroup} has invalid characters like  ^ and "'

--- a/test/templates/bad/properties_sg_description.yaml
+++ b/test/templates/bad/properties_sg_description.yaml
@@ -1,5 +1,9 @@
 ---
 AWSTemplateFormatVersion: "2010-09-09"
+Parameters:
+  AppGroup:
+    Type: "String"
+    Default: "myAppgroup"
 Resources:
   mySecurityGroupLongDescription:
     Type: AWS::EC2::SecurityGroup
@@ -13,3 +17,11 @@ Resources:
     Type: AWS::EC2::SecurityGroup
     Properties:
       GroupDescription: 'This one should be perfect! some characters like {} and [] are supported'
+  mySecurityGroupValidRef:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: !Ref "AppGroup"
+  mySecurityGroupValidSub:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: !Sub "Securitygroup of ${AppGroup}"

--- a/test/templates/bad/properties_sg_description.yaml
+++ b/test/templates/bad/properties_sg_description.yaml
@@ -1,0 +1,15 @@
+---
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  mySecurityGroupLongDescription:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: 'This description is way too long. The limit is 255 characters, so this will definitely not work as it is a pretty long description. Well, to be honest, a desciption of more than 255 characters is pretty huge. Take this description, it barely hits the limit as it is 282 characters. '
+  mySecurityGroupInvalidCharacters:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: 'Special charaters like ^ & and " are not supported'
+  mySecurityGroupValidCharacters:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: 'This one should be perfect! some characters like {} and [] are supported'


### PR DESCRIPTION
*Issue https://github.com/awslabs/cfn-python-lint/issues/173:*

Add a rule that checks the description. Checks the length and a regex (based on the AWS feedback on supported characters.

Extended the `check_values` function with a `check_sub` option to validate Subs. With this we can check that value also, which increased the chance of catching errors.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
