### PR TITLE
Support lists in mapping values

### DIFF
--- a/src/cfnlint/rules/mappings/Configuration.py
+++ b/src/cfnlint/rules/mappings/Configuration.py
@@ -14,6 +14,7 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
+import six
 from cfnlint import CloudFormationLintRule
 from cfnlint import RuleMatch
 
@@ -50,7 +51,9 @@ class Configuration(CloudFormationLintRule):
                             ))
                         else:
                             for secondkey in firstkeyobj:
-                                if isinstance(firstkeyobj[secondkey], (dict, list)):
+                                if not isinstance(
+                                        firstkeyobj[secondkey],
+                                        (six.string_types, list, six.integer_types)):
                                     message = 'Mapping {0} has invalid property at {1}'
                                     matches.append(RuleMatch(
                                         ['Mappings', mapname, firstkey, secondkey],

--- a/test/rules/mappings/test_configuration.py
+++ b/test/rules/mappings/test_configuration.py
@@ -29,6 +29,10 @@ class TestMappingConfiguration(BaseRuleTestCase):
         """Test Positive"""
         self.helper_file_positive()
 
+    def test_file_positive_configuration(self):
+        """Test Positive"""
+        self.helper_file_positive_template('templates/good/mappings/configuration.yaml')
+
     def test_file_negative(self):
         """Test failure"""
-        self.helper_file_negative('templates/bad/mappings/configuration.yaml', 4)
+        self.helper_file_negative('templates/bad/mappings/configuration.yaml', 3)

--- a/test/templates/good/mappings/configuration.yaml
+++ b/test/templates/good/mappings/configuration.yaml
@@ -1,0 +1,16 @@
+---
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  Test Mapping Configuration
+Mappings:
+  RegionAccountToAZ:
+    ap-northeast-1:
+      0123456789:
+        - ap-northeast-1a
+        - ap-northeast-1c
+        - none
+      9876543210:
+        - ap-northeast-1a
+        - ap-northeast-1b
+        - ap-northeast-1c
+Resources: {}


### PR DESCRIPTION
*Issue #, if available:*
Fixes #165 

*Description of changes:*
- Support lists for values in a mapping.

From https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/mappings-section-structure.html `The values can be String or List types`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
