### PR TITLE
Centralize Cidr REGEX definitions

### DIFF
--- a/src/cfnlint/helpers.py
+++ b/src/cfnlint/helpers.py
@@ -36,6 +36,9 @@ REGIONS = ['us-east-1', 'us-east-2', 'us-west-1', 'us-west-2', 'ca-central-1',
            'sa-east-1']
 
 REGEX_ALPHANUMERIC = re.compile('^[a-zA-Z0-9]*$')
+# pylint: disable=C0301
+REGEX_CIDR = re.compile(r'^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$')
+REGEX_IPV4 = re.compile(r'^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$')
 
 AVAILABILITY_ZONES = [
     'us-east-1a', 'us-east-1b', 'us-east-1c', 'us-east-1d', 'us-east-1e', 'us-east-1f',

--- a/src/cfnlint/rules/functions/Cidr.py
+++ b/src/cfnlint/rules/functions/Cidr.py
@@ -19,6 +19,7 @@ import six
 from cfnlint import CloudFormationLintRule
 from cfnlint import RuleMatch
 
+from cfnlint.helpers import REGEX_CIDR
 
 class Cidr(CloudFormationLintRule):
     """Check if Cidr values are correct"""
@@ -114,10 +115,7 @@ class Cidr(CloudFormationLintRule):
                                     matches.append(RuleMatch(
                                         tree[:] + [0], message.format('/'.join(map(str, tree[:] + [0])))))
                     elif isinstance(ip_block_obj, (six.text_type, six.string_types)):
-                        # pylint: disable=C0301
-                        pattern = r'^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$'
-                        pattern = re.compile(pattern)
-                        if not pattern.match(ip_block_obj):
+                        if not re.match(REGEX_CIDR, ip_block_obj):
                             message = 'Cidr ipBlock should be a Cidr Range based string for {0}'
                             matches.append(RuleMatch(
                                 tree[:] + [0], message.format('/'.join(map(str, tree[:] + [0])))))

--- a/src/cfnlint/rules/parameters/Cidr.py
+++ b/src/cfnlint/rules/parameters/Cidr.py
@@ -17,6 +17,8 @@
 from cfnlint import CloudFormationLintRule
 from cfnlint import RuleMatch
 
+from cfnlint.helpers import REGEX_CIDR
+
 
 class Cidr(CloudFormationLintRule):
     """Check Availability Zone parameter checks """
@@ -25,9 +27,6 @@ class Cidr(CloudFormationLintRule):
     description = 'Check if a parameter is being used as a CIDR. ' \
                   'If it is make sure it has allowed values regex comparisons'
     tags = ['base', 'parameters', 'availabilityzone']
-
-    # pylint: disable=C0301
-    cidr_regex = r'^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$'
 
     def __init__(self):
         """Init"""
@@ -65,8 +64,10 @@ class Cidr(CloudFormationLintRule):
             allowed_values = parameter.get('AllowedValues', None)
             if not allowed_pattern and not allowed_values:
                 param_path = ['Parameters', value]
-                message = 'AllowedPattern and/or AllowedValues for Parameter should be specified at {1}. Example for AllowedPattern "{0}"'
-                matches.append(RuleMatch(param_path, message.format(self.cidr_regex, ('/'.join(param_path)))))
+                full_param_path = '/'.join(param_path)
+                message = 'AllowedPattern and/or AllowedValues for Parameter should be specified at {1}. ' \
+                          'Example for AllowedPattern: "{0}"'
+                matches.append(RuleMatch(param_path, message.format(REGEX_CIDR.pattern, full_param_path)))
 
         return matches
 

--- a/src/cfnlint/rules/parameters/CidrAllowedValues.py
+++ b/src/cfnlint/rules/parameters/CidrAllowedValues.py
@@ -18,6 +18,8 @@ import re
 from cfnlint import CloudFormationLintRule
 from cfnlint import RuleMatch
 
+from cfnlint.helpers import REGEX_CIDR
+
 
 class CidrAllowedValues(CloudFormationLintRule):
     """Check Availability Zone parameter checks """
@@ -26,9 +28,6 @@ class CidrAllowedValues(CloudFormationLintRule):
     description = 'Check if a parameter is being used as a CIDR. ' \
                   'If it is make sure allowed values are proper CIDRs'
     tags = ['base', 'parameters', 'cidr']
-
-    # pylint: disable=C0301
-    cidr_regex = r'^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$'
 
     def __init__(self):
         """Init"""
@@ -65,8 +64,7 @@ class CidrAllowedValues(CloudFormationLintRule):
             allowed_values = parameter.get('AllowedValues', None)
             if allowed_values:
                 for cidr in allowed_values:
-                    pattern = re.compile(self.cidr_regex)
-                    if not pattern.match(cidr):
+                    if not re.match(REGEX_CIDR, cidr):
                         cidr_path = ['Parameters', value]
                         message = 'Cidr should be a Cidr Range based string for {0}'
                         matches.append(RuleMatch(cidr_path, message.format(cidr)))

--- a/src/cfnlint/rules/resources/ectwo/Subnet.py
+++ b/src/cfnlint/rules/resources/ectwo/Subnet.py
@@ -17,7 +17,7 @@
 import re
 from cfnlint import CloudFormationLintRule
 from cfnlint import RuleMatch
-from cfnlint.helpers import AVAILABILITY_ZONES
+from cfnlint.helpers import AVAILABILITY_ZONES, REGEX_CIDR
 
 
 class Subnet(CloudFormationLintRule):
@@ -26,9 +26,6 @@ class Subnet(CloudFormationLintRule):
     shortdesc = 'Resource EC2 PropertiesEc2Subnet Properties'
     description = 'See if EC2 Subnet Properties are set correctly'
     tags = ['base', 'properties', 'subnet']
-
-    # pylint: disable=C0301
-    cidr_regex = r'^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$'
 
     def check_az_value(self, value, path):
         """Check AZ Values"""
@@ -67,8 +64,7 @@ class Subnet(CloudFormationLintRule):
         """Check CIDR Strings"""
         matches = list()
 
-        regex = re.compile(self.cidr_regex)
-        if not regex.match(value):
+        if not re.match(REGEX_CIDR, value):
             message = 'CidrBlock needs to be of x.x.x.x/y at {0}'
             matches.append(RuleMatch(path, message.format(('/'.join(['Parameters', value])))))
         return matches

--- a/src/cfnlint/rules/resources/ectwo/Vpc.py
+++ b/src/cfnlint/rules/resources/ectwo/Vpc.py
@@ -18,6 +18,8 @@ import re
 from cfnlint import CloudFormationLintRule
 from cfnlint import RuleMatch
 
+from cfnlint.helpers import REGEX_CIDR
+
 
 class Vpc(CloudFormationLintRule):
     """Check if EC2 VPC Resource Properties"""
@@ -25,9 +27,6 @@ class Vpc(CloudFormationLintRule):
     shortdesc = 'Resource EC2 VPC Properties'
     description = 'See if EC2 VPC Properties are set correctly'
     tags = ['base', 'properties', 'vpc']
-
-    # pylint: disable=C0301
-    cidr_regex = r'^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$'
 
     def check_vpc_value(self, value, path):
         """Check VPC Values"""
@@ -65,8 +64,7 @@ class Vpc(CloudFormationLintRule):
         """Check CIDR Strings"""
         matches = list()
 
-        regex = re.compile(self.cidr_regex)
-        if not regex.match(value):
+        if not re.match(REGEX_CIDR, value):
             message = 'CidrBlock needs to be of x.x.x.x/y at {0}'
             matches.append(RuleMatch(path, message.format(('/'.join(['Parameters', value])))))
         return matches

--- a/src/cfnlint/rules/resources/route53/RecordSet.py
+++ b/src/cfnlint/rules/resources/route53/RecordSet.py
@@ -19,6 +19,8 @@ import six
 from cfnlint import CloudFormationLintRule
 from cfnlint import RuleMatch
 
+from cfnlint.helpers import REGEX_IPV4
+
 class RecordSet(CloudFormationLintRule):
     """Check Route53 Recordset Configuration"""
     id = 'E3020'
@@ -42,8 +44,6 @@ class RecordSet(CloudFormationLintRule):
         'TXT'
     ]
 
-    ipv4_regex = r'^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$'
-
     def check_a_record(self, path, recordset):
         """Check A record Configuration"""
         matches = list()
@@ -57,8 +57,7 @@ class RecordSet(CloudFormationLintRule):
                     full_path = ('/'.join(str(x) for x in tree))
 
                     # Check if a valid IPv4 address is specified
-                    regex = re.compile(self.ipv4_regex)
-                    if not regex.match(record):
+                    if not re.match(REGEX_IPV4, record):
                         message = 'A record is not a valid IPv4 address at {0}'
                         matches.append(RuleMatch(tree, message.format(full_path)))
 


### PR DESCRIPTION
Minor code tweak. Move the IP regex definitions to a central place and use that one instead of reconfiguring the regex on every check. Makes it more transparent and less error prone.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
