### PR TITLE
Add .NET core 2.1 support to Lambda

### DIFF
--- a/src/cfnlint/rules/parameters/LambdaRuntime.py
+++ b/src/cfnlint/rules/parameters/LambdaRuntime.py
@@ -42,7 +42,8 @@ class LambdaRuntime(CloudFormationLintRule):
         matches = list()
         runtimes = [
             'nodejs', 'nodejs4.3', 'nodejs6.10', 'nodejs8.10', 'java8', 'python2.7',
-            'python3.6', 'dotnetcore1.0', 'dotnetcore2.0', 'nodejs4.3-edge', 'go1.x'
+            'python3.6', 'dotnetcore1.0', 'dotnetcore2.0', 'dotnetcore2.1',
+            'nodejs4.3-edge', 'go1.x'
         ]
 
         if value in parameters:

--- a/src/cfnlint/rules/resources/lmbd/FunctionRuntime.py
+++ b/src/cfnlint/rules/resources/lmbd/FunctionRuntime.py
@@ -28,7 +28,8 @@ class FunctionRuntime(CloudFormationLintRule):
 
     runtimes = [
         'nodejs', 'nodejs4.3', 'nodejs6.10', 'nodejs8.10', 'java8', 'python2.7',
-        'python3.6', 'dotnetcore1.0', 'dotnetcore2.0', 'nodejs4.3-edge', 'go1.x'
+        'python3.6', 'dotnetcore1.0', 'dotnetcore2.0', 'dotnetcore2.1',
+        'nodejs4.3-edge', 'go1.x'
     ]
 
     def check_value(self, value, path):


### PR DESCRIPTION
.NET core is now supported: 

* https://aws.amazon.com/about-aws/whats-new/2018/06/lambda-supports-dotnetcore-twopointone/
* https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html#SSS-CreateFunction-request-Runtime

Add support for this

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
