### PR TITLE
fix typo, enfoced -> enforced.

### DIFF
--- a/src/cfnlint/rules/resources/DependsOnObsolete.py
+++ b/src/cfnlint/rules/resources/DependsOnObsolete.py
@@ -51,7 +51,7 @@ class DependsOnObsolete(CloudFormationLintRule):
 
         for tree in trees:
             if tree[-1] == key:
-                message = 'Obsolete DependsOn on resource ({0}), dependency already enfoced by a "Ref" at {1}'
+                message = 'Obsolete DependsOn on resource ({0}), dependency already enforced by a "Ref" at {1}'
                 matches.append(RuleMatch(path, message.format(key, '/'.join(map(str, tree)))))
 
         # Get the GetAtt

--- a/test/fixtures/results/quickstart/cis_benchmark.json
+++ b/test/fixtures/results/quickstart/cis_benchmark.json
@@ -1016,7 +1016,7 @@
             }
         },
         "Level": "Warning",
-        "Message": "Obsolete DependsOn on resource (SnsTopicForCloudWatchEvents), dependency already enfoced by \"!Ref\" at Resources/RoleForCloudWatchEvents/Properties/Policies/0/PolicyDocument/Statement/0/Resource/Ref/SnsTopicForCloudWatchEvents",
+        "Message": "Obsolete DependsOn on resource (SnsTopicForCloudWatchEvents), dependency already enforced by \"!Ref\" at Resources/RoleForCloudWatchEvents/Properties/Policies/0/PolicyDocument/Statement/0/Resource/Ref/SnsTopicForCloudWatchEvents",
         "Filename": "test/templates/quickstart/cis_benchmark.yaml"
     },
     {

--- a/test/fixtures/results/quickstart/nist_application.json
+++ b/test/fixtures/results/quickstart/nist_application.json
@@ -196,7 +196,7 @@
             }
         },
         "Level": "Warning",
-        "Message": "Obsolete DependsOn on resource (rAutoScalingConfigApp), dependency already enfoced by \"!Ref\" at Resources/rAutoScalingGroupApp/Properties/LaunchConfigurationName/Ref/rAutoScalingConfigApp",
+        "Message": "Obsolete DependsOn on resource (rAutoScalingConfigApp), dependency already enforced by \"!Ref\" at Resources/rAutoScalingGroupApp/Properties/LaunchConfigurationName/Ref/rAutoScalingConfigApp",
         "Filename": "test/templates/quickstart/nist_application.yaml"
     },
     {
@@ -276,7 +276,7 @@
             }
         },
         "Level": "Warning",
-        "Message": "Obsolete DependsOn on resource (rAutoScalingConfigWeb), dependency already enfoced by \"!Ref\" at Resources/rAutoScalingGroupWeb/Properties/LaunchConfigurationName/Ref/rAutoScalingConfigWeb",
+        "Message": "Obsolete DependsOn on resource (rAutoScalingConfigWeb), dependency already enforced by \"!Ref\" at Resources/rAutoScalingGroupWeb/Properties/LaunchConfigurationName/Ref/rAutoScalingConfigWeb",
         "Filename": "test/templates/quickstart/nist_application.yaml"
     },
     {
@@ -576,7 +576,7 @@
             }
         },
         "Level": "Warning",
-        "Message": "Obsolete DependsOn on resource (rAutoScalingGroupWeb), dependency already enfoced by \"!Ref\" at Resources/rCWAlarmLowCPUWeb/Properties/Dimensions/0/Value/Ref/rAutoScalingGroupWeb",
+        "Message": "Obsolete DependsOn on resource (rAutoScalingGroupWeb), dependency already enforced by \"!Ref\" at Resources/rCWAlarmLowCPUWeb/Properties/Dimensions/0/Value/Ref/rAutoScalingGroupWeb",
         "Filename": "test/templates/quickstart/nist_application.yaml"
     },
     {
@@ -656,7 +656,7 @@
             }
         },
         "Level": "Warning",
-        "Message": "Obsolete DependsOn on resource (rS3ELBAccessLogs), dependency already enfoced by \"!Ref\" at Resources/rELBApp/Properties/AccessLoggingPolicy/S3BucketName/Ref/rS3ELBAccessLogs",
+        "Message": "Obsolete DependsOn on resource (rS3ELBAccessLogs), dependency already enforced by \"!Ref\" at Resources/rELBApp/Properties/AccessLoggingPolicy/S3BucketName/Ref/rS3ELBAccessLogs",
         "Filename": "test/templates/quickstart/nist_application.yaml"
     },
     {
@@ -676,7 +676,7 @@
             }
         },
         "Level": "Warning",
-        "Message": "Obsolete DependsOn on resource (rSecurityGroupApp), dependency already enfoced by \"!Ref\" at Resources/rELBApp/Properties/SecurityGroups/0/Ref/rSecurityGroupApp",
+        "Message": "Obsolete DependsOn on resource (rSecurityGroupApp), dependency already enforced by \"!Ref\" at Resources/rELBApp/Properties/SecurityGroups/0/Ref/rSecurityGroupApp",
         "Filename": "test/templates/quickstart/nist_application.yaml"
     },
     {
@@ -736,7 +736,7 @@
             }
         },
         "Level": "Warning",
-        "Message": "Obsolete DependsOn on resource (rS3ELBAccessLogs), dependency already enfoced by \"!Ref\" at Resources/rELBWeb/Properties/AccessLoggingPolicy/S3BucketName/Ref/rS3ELBAccessLogs",
+        "Message": "Obsolete DependsOn on resource (rS3ELBAccessLogs), dependency already enforced by \"!Ref\" at Resources/rELBWeb/Properties/AccessLoggingPolicy/S3BucketName/Ref/rS3ELBAccessLogs",
         "Filename": "test/templates/quickstart/nist_application.yaml"
     },
     {
@@ -756,7 +756,7 @@
             }
         },
         "Level": "Warning",
-        "Message": "Obsolete DependsOn on resource (rSecurityGroupWeb), dependency already enfoced by \"!Ref\" at Resources/rELBWeb/Properties/SecurityGroups/0/Ref/rSecurityGroupWeb",
+        "Message": "Obsolete DependsOn on resource (rSecurityGroupWeb), dependency already enforced by \"!Ref\" at Resources/rELBWeb/Properties/SecurityGroups/0/Ref/rSecurityGroupWeb",
         "Filename": "test/templates/quickstart/nist_application.yaml"
     },
     {
@@ -816,7 +816,7 @@
             }
         },
         "Level": "Warning",
-        "Message": "Obsolete DependsOn on resource (rDBSubnetGroup), dependency already enfoced by \"!Ref\" at Resources/rRDSInstanceMySQL/Properties/DBSubnetGroupName/Ref/rDBSubnetGroup",
+        "Message": "Obsolete DependsOn on resource (rDBSubnetGroup), dependency already enforced by \"!Ref\" at Resources/rRDSInstanceMySQL/Properties/DBSubnetGroupName/Ref/rDBSubnetGroup",
         "Filename": "test/templates/quickstart/nist_application.yaml"
     },
     {
@@ -836,7 +836,7 @@
             }
         },
         "Level": "Warning",
-        "Message": "Obsolete DependsOn on resource (rSecurityGroupRDS), dependency already enfoced by \"!Ref\" at Resources/rRDSInstanceMySQL/Properties/VPCSecurityGroups/0/Ref/rSecurityGroupRDS",
+        "Message": "Obsolete DependsOn on resource (rSecurityGroupRDS), dependency already enforced by \"!Ref\" at Resources/rRDSInstanceMySQL/Properties/VPCSecurityGroups/0/Ref/rSecurityGroupRDS",
         "Filename": "test/templates/quickstart/nist_application.yaml"
     },
     {
@@ -1376,7 +1376,7 @@
             }
         },
         "Level": "Warning",
-        "Message": "Obsolete DependsOn on resource (rWebContentBucket), dependency already enfoced by \"!Ref\" at Resources/rWebContentS3Policy/Properties/Bucket/Ref/rWebContentBucket",
+        "Message": "Obsolete DependsOn on resource (rWebContentBucket), dependency already enforced by \"!Ref\" at Resources/rWebContentS3Policy/Properties/Bucket/Ref/rWebContentBucket",
         "Filename": "test/templates/quickstart/nist_application.yaml"
     },
     {
@@ -1396,7 +1396,7 @@
             }
         },
         "Level": "Warning",
-        "Message": "Obsolete DependsOn on resource (rWebContentBucket), dependency already enfoced by \"!Ref\" at Resources/rWebContentS3Policy/Properties/PolicyDocument/Statement/0/Resource/Fn::Join/1/3/Ref/rWebContentBucket",
+        "Message": "Obsolete DependsOn on resource (rWebContentBucket), dependency already enforced by \"!Ref\" at Resources/rWebContentS3Policy/Properties/PolicyDocument/Statement/0/Resource/Fn::Join/1/3/Ref/rWebContentBucket",
         "Filename": "test/templates/quickstart/nist_application.yaml"
     },
     {
@@ -1416,7 +1416,7 @@
             }
         },
         "Level": "Warning",
-        "Message": "Obsolete DependsOn on resource (rWebContentBucket), dependency already enfoced by \"!Ref\" at Resources/rWebContentS3Policy/Properties/PolicyDocument/Statement/1/Resource/Fn::Join/1/3/Ref/rWebContentBucket",
+        "Message": "Obsolete DependsOn on resource (rWebContentBucket), dependency already enforced by \"!Ref\" at Resources/rWebContentS3Policy/Properties/PolicyDocument/Statement/1/Resource/Fn::Join/1/3/Ref/rWebContentBucket",
         "Filename": "test/templates/quickstart/nist_application.yaml"
     }
 ]

--- a/test/fixtures/results/quickstart/nist_iam.json
+++ b/test/fixtures/results/quickstart/nist_iam.json
@@ -16,7 +16,7 @@
             }
         },
         "Level": "Warning",
-        "Message": "Obsolete DependsOn on resource (rIAMAdminRole), dependency already enfoced by \"!Ref\" at Resources/rIAMAdminProfile/Properties/Roles/0/Ref/rIAMAdminRole",
+        "Message": "Obsolete DependsOn on resource (rIAMAdminRole), dependency already enforced by \"!Ref\" at Resources/rIAMAdminProfile/Properties/Roles/0/Ref/rIAMAdminRole",
         "Filename": "test/templates/quickstart/nist_iam.yaml"
     },
     {
@@ -36,7 +36,7 @@
             }
         },
         "Level": "Warning",
-        "Message": "Obsolete DependsOn on resource (rInstanceOpsRole), dependency already enfoced by \"!Ref\" at Resources/rInstanceOpsProfile/Properties/Roles/0/Ref/rInstanceOpsRole",
+        "Message": "Obsolete DependsOn on resource (rInstanceOpsRole), dependency already enforced by \"!Ref\" at Resources/rInstanceOpsProfile/Properties/Roles/0/Ref/rInstanceOpsRole",
         "Filename": "test/templates/quickstart/nist_iam.yaml"
     },
     {
@@ -56,7 +56,7 @@
             }
         },
         "Level": "Warning",
-        "Message": "Obsolete DependsOn on resource (rReadOnlyAdminRole), dependency already enfoced by \"!Ref\" at Resources/rReadOnlyAdminProfile/Properties/Roles/0/Ref/rReadOnlyAdminRole",
+        "Message": "Obsolete DependsOn on resource (rReadOnlyAdminRole), dependency already enforced by \"!Ref\" at Resources/rReadOnlyAdminProfile/Properties/Roles/0/Ref/rReadOnlyAdminRole",
         "Filename": "test/templates/quickstart/nist_iam.yaml"
     },
     {
@@ -76,7 +76,7 @@
             }
         },
         "Level": "Warning",
-        "Message": "Obsolete DependsOn on resource (rSysAdminRole), dependency already enfoced by \"!Ref\" at Resources/rSysAdminProfile/Properties/Roles/0/Ref/rSysAdminRole",
+        "Message": "Obsolete DependsOn on resource (rSysAdminRole), dependency already enforced by \"!Ref\" at Resources/rSysAdminProfile/Properties/Roles/0/Ref/rSysAdminRole",
         "Filename": "test/templates/quickstart/nist_iam.yaml"
     }
 ]

--- a/test/fixtures/results/quickstart/nist_logging.json
+++ b/test/fixtures/results/quickstart/nist_logging.json
@@ -56,7 +56,7 @@
             }
         },
         "Level": "Warning",
-        "Message": "Obsolete DependsOn on resource (rArchiveLogsBucket), dependency already enfoced by \"!Ref\" at Resources/rArchiveLogsBucketPolicy/Properties/Bucket/Ref/rArchiveLogsBucket",
+        "Message": "Obsolete DependsOn on resource (rArchiveLogsBucket), dependency already enforced by \"!Ref\" at Resources/rArchiveLogsBucketPolicy/Properties/Bucket/Ref/rArchiveLogsBucket",
         "Filename": "test/templates/quickstart/nist_logging.yaml"
     },
     {
@@ -76,7 +76,7 @@
             }
         },
         "Level": "Warning",
-        "Message": "Obsolete DependsOn on resource (rArchiveLogsBucket), dependency already enfoced by \"!Ref\" at Resources/rArchiveLogsBucketPolicy/Properties/PolicyDocument/Statement/0/Resource/0/Fn::Join/1/3/Ref/rArchiveLogsBucket",
+        "Message": "Obsolete DependsOn on resource (rArchiveLogsBucket), dependency already enforced by \"!Ref\" at Resources/rArchiveLogsBucketPolicy/Properties/PolicyDocument/Statement/0/Resource/0/Fn::Join/1/3/Ref/rArchiveLogsBucket",
         "Filename": "test/templates/quickstart/nist_logging.yaml"
     },
     {
@@ -96,7 +96,7 @@
             }
         },
         "Level": "Warning",
-        "Message": "Obsolete DependsOn on resource (rArchiveLogsBucket), dependency already enfoced by \"!Ref\" at Resources/rArchiveLogsBucketPolicy/Properties/PolicyDocument/Statement/1/Resource/0/Fn::Join/1/3/Ref/rArchiveLogsBucket",
+        "Message": "Obsolete DependsOn on resource (rArchiveLogsBucket), dependency already enforced by \"!Ref\" at Resources/rArchiveLogsBucketPolicy/Properties/PolicyDocument/Statement/1/Resource/0/Fn::Join/1/3/Ref/rArchiveLogsBucket",
         "Filename": "test/templates/quickstart/nist_logging.yaml"
     },
     {
@@ -116,7 +116,7 @@
             }
         },
         "Level": "Warning",
-        "Message": "Obsolete DependsOn on resource (rArchiveLogsBucket), dependency already enfoced by \"!Ref\" at Resources/rArchiveLogsBucketPolicy/Properties/PolicyDocument/Statement/2/Resource/0/Fn::Join/1/3/Ref/rArchiveLogsBucket",
+        "Message": "Obsolete DependsOn on resource (rArchiveLogsBucket), dependency already enforced by \"!Ref\" at Resources/rArchiveLogsBucketPolicy/Properties/PolicyDocument/Statement/2/Resource/0/Fn::Join/1/3/Ref/rArchiveLogsBucket",
         "Filename": "test/templates/quickstart/nist_logging.yaml"
     },
     {
@@ -216,7 +216,7 @@
             }
         },
         "Level": "Warning",
-        "Message": "Obsolete DependsOn on resource (rCloudTrailRole), dependency already enfoced by \"!Ref\" at Resources/rCloudTrailProfile/Properties/Roles/0/Ref/rCloudTrailRole",
+        "Message": "Obsolete DependsOn on resource (rCloudTrailRole), dependency already enforced by \"!Ref\" at Resources/rCloudTrailProfile/Properties/Roles/0/Ref/rCloudTrailRole",
         "Filename": "test/templates/quickstart/nist_logging.yaml"
     },
     {
@@ -236,7 +236,7 @@
             }
         },
         "Level": "Warning",
-        "Message": "Obsolete DependsOn on resource (rCloudTrailBucket), dependency already enfoced by \"!Ref\" at Resources/rCloudTrailS3Policy/Properties/Bucket/Ref/rCloudTrailBucket",
+        "Message": "Obsolete DependsOn on resource (rCloudTrailBucket), dependency already enforced by \"!Ref\" at Resources/rCloudTrailS3Policy/Properties/Bucket/Ref/rCloudTrailBucket",
         "Filename": "test/templates/quickstart/nist_logging.yaml"
     },
     {
@@ -256,7 +256,7 @@
             }
         },
         "Level": "Warning",
-        "Message": "Obsolete DependsOn on resource (rCloudTrailBucket), dependency already enfoced by \"!Ref\" at Resources/rCloudTrailS3Policy/Properties/PolicyDocument/Statement/0/Resource/0/Fn::Join/1/3/Ref/rCloudTrailBucket",
+        "Message": "Obsolete DependsOn on resource (rCloudTrailBucket), dependency already enforced by \"!Ref\" at Resources/rCloudTrailS3Policy/Properties/PolicyDocument/Statement/0/Resource/0/Fn::Join/1/3/Ref/rCloudTrailBucket",
         "Filename": "test/templates/quickstart/nist_logging.yaml"
     },
     {
@@ -276,7 +276,7 @@
             }
         },
         "Level": "Warning",
-        "Message": "Obsolete DependsOn on resource (rCloudTrailBucket), dependency already enfoced by \"!Ref\" at Resources/rCloudTrailS3Policy/Properties/PolicyDocument/Statement/1/Resource/0/Fn::Join/1/3/Ref/rCloudTrailBucket",
+        "Message": "Obsolete DependsOn on resource (rCloudTrailBucket), dependency already enforced by \"!Ref\" at Resources/rCloudTrailS3Policy/Properties/PolicyDocument/Statement/1/Resource/0/Fn::Join/1/3/Ref/rCloudTrailBucket",
         "Filename": "test/templates/quickstart/nist_logging.yaml"
     },
     {
@@ -296,7 +296,7 @@
             }
         },
         "Level": "Warning",
-        "Message": "Obsolete DependsOn on resource (rCloudTrailBucket), dependency already enfoced by \"!Ref\" at Resources/rCloudTrailS3Policy/Properties/PolicyDocument/Statement/2/Resource/0/Fn::Join/1/3/Ref/rCloudTrailBucket",
+        "Message": "Obsolete DependsOn on resource (rCloudTrailBucket), dependency already enforced by \"!Ref\" at Resources/rCloudTrailS3Policy/Properties/PolicyDocument/Statement/2/Resource/0/Fn::Join/1/3/Ref/rCloudTrailBucket",
         "Filename": "test/templates/quickstart/nist_logging.yaml"
     },
     {
@@ -316,7 +316,7 @@
             }
         },
         "Level": "Warning",
-        "Message": "Obsolete DependsOn on resource (rCloudTrailBucket), dependency already enfoced by \"!Ref\" at Resources/rCloudTrailS3Policy/Properties/PolicyDocument/Statement/3/Resource/0/Fn::Join/1/3/Ref/rCloudTrailBucket",
+        "Message": "Obsolete DependsOn on resource (rCloudTrailBucket), dependency already enforced by \"!Ref\" at Resources/rCloudTrailS3Policy/Properties/PolicyDocument/Statement/3/Resource/0/Fn::Join/1/3/Ref/rCloudTrailBucket",
         "Filename": "test/templates/quickstart/nist_logging.yaml"
     },
     {
@@ -336,7 +336,7 @@
             }
         },
         "Level": "Warning",
-        "Message": "Obsolete DependsOn on resource (rCloudTrailBucket), dependency already enfoced by \"!Ref\" at Resources/rCloudTrailS3Policy/Properties/PolicyDocument/Statement/4/Resource/0/Fn::Join/1/3/Ref/rCloudTrailBucket",
+        "Message": "Obsolete DependsOn on resource (rCloudTrailBucket), dependency already enforced by \"!Ref\" at Resources/rCloudTrailS3Policy/Properties/PolicyDocument/Statement/4/Resource/0/Fn::Join/1/3/Ref/rCloudTrailBucket",
         "Filename": "test/templates/quickstart/nist_logging.yaml"
     },
     {

--- a/test/fixtures/results/quickstart/nist_vpc_management.json
+++ b/test/fixtures/results/quickstart/nist_vpc_management.json
@@ -236,7 +236,7 @@
             }
         },
         "Level": "Warning",
-        "Message": "Obsolete DependsOn on resource (rIGWManagement), dependency already enfoced by \"!Ref\" at Resources/rGWAttachmentMgmtIGW/Properties/InternetGatewayId/Ref/rIGWManagement",
+        "Message": "Obsolete DependsOn on resource (rIGWManagement), dependency already enforced by \"!Ref\" at Resources/rGWAttachmentMgmtIGW/Properties/InternetGatewayId/Ref/rIGWManagement",
         "Filename": "test/templates/quickstart/nist_vpc_management.yaml"
     },
     {

--- a/test/fixtures/results/quickstart/nist_vpc_production.json
+++ b/test/fixtures/results/quickstart/nist_vpc_production.json
@@ -196,7 +196,7 @@
             }
         },
         "Level": "Warning",
-        "Message": "Obsolete DependsOn on resource (rIGWProd), dependency already enfoced by \"!Ref\" at Resources/rGWAttachmentProdIGW/Properties/InternetGatewayId/Ref/rIGWProd",
+        "Message": "Obsolete DependsOn on resource (rIGWProd), dependency already enforced by \"!Ref\" at Resources/rGWAttachmentProdIGW/Properties/InternetGatewayId/Ref/rIGWProd",
         "Filename": "test/templates/quickstart/nist_vpc_production.yaml"
     },
     {

--- a/test/fixtures/results/quickstart/openshift.json
+++ b/test/fixtures/results/quickstart/openshift.json
@@ -36,7 +36,7 @@
             }
         },
         "Level": "Warning",
-        "Message": "Obsolete DependsOn on resource (OpenShiftNodeASG), dependency already enfoced by \"!Ref\" at Resources/AnsibleConfigServer/Properties/UserData/Fn::Base64/Fn::Join/1/43/Ref/OpenShiftNodeASG",
+        "Message": "Obsolete DependsOn on resource (OpenShiftNodeASG), dependency already enforced by \"!Ref\" at Resources/AnsibleConfigServer/Properties/UserData/Fn::Base64/Fn::Join/1/43/Ref/OpenShiftNodeASG",
         "Filename": "test/templates/quickstart/openshift.yaml"
     },
     {
@@ -56,7 +56,7 @@
             }
         },
         "Level": "Warning",
-        "Message": "Obsolete DependsOn on resource (OpenShiftNodeASG), dependency already enfoced by \"!Ref\" at Resources/AnsibleConfigServer/Properties/UserData/Fn::Base64/Fn::Join/1/88/Ref/OpenShiftNodeASG",
+        "Message": "Obsolete DependsOn on resource (OpenShiftNodeASG), dependency already enforced by \"!Ref\" at Resources/AnsibleConfigServer/Properties/UserData/Fn::Base64/Fn::Join/1/88/Ref/OpenShiftNodeASG",
         "Filename": "test/templates/quickstart/openshift.yaml"
     },
     {


### PR DESCRIPTION
*Issue #, if available:*
None, trivial issue of fixing typo on a word across the project. 

*Description of changes:*
Encountered an issue while using `cfn-python-lint` where the linter warned on the DependsOn but had a typo in one of the word, `enfoced`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
