### PR TITLE
Catch invalid property specifications

### DIFF
--- a/test/fixtures/templates/bad/resources_codepipeline_stages_one_stage.yaml
+++ b/test/fixtures/templates/bad/resources_codepipeline_stages_one_stage.yaml
@@ -20,7 +20,7 @@ Resources:
                 Provider: GitHub
                 Version: "1"
               OutputArtifacts:
-                - Name: MyApp
+                - "MyApp"
               Configuration:
                 Owner: awslabs
                 Repo: cfn-python-lint


### PR DESCRIPTION
*Issue https://github.com/awslabs/cfn-python-lint/issues/209:*

Catch invalid specifications where properties are written incorrectly. Basically by skipping non-dicts to be processed as dicts. Rule `E3002` then catches them.

Output of linting the `resources_codepipeline_stages_one_stage.yaml`, with the invalid values (as specified in the issue): 

Before code fix:
```
$ cfn-lint test/fixtures/templates/bad/resources_codepipeline_stages_one_stage.yaml
2018-07-18 16:46:17,170 - cfnlint - ERROR - Tried to process rules on file test/fixtures/templates/bad/resources_codepipeline_stages_one_stage.yaml but got an error: 'str_node' object has no attribute 'items'
```

After code fix:
```
$ cfn-lint test/fixtures/templates/bad/resources_codepipeline_stages_one_stage.yaml
E2540 A pipeline must contain at least two stages.
test/fixtures/templates/bad/resources_codepipeline_stages_one_stage.yaml:13:7

E2540 The first stage of a pipeline must contain only source actions.
test/fixtures/templates/bad/resources_codepipeline_stages_one_stage.yaml:13:7

E3002 Expecting an object at Resources/TestPipeline/Properties/Stages/0/Actions/0/OutputArtifacts/0
test/fixtures/templates/bad/resources_codepipeline_stages_one_stage.yaml:22:15
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
