### PR TITLE
Remove exclusive attributes for RDS

### DIFF
--- a/src/cfnlint/data/AdditionalSpecs/Exclusive.json
+++ b/src/cfnlint/data/AdditionalSpecs/Exclusive.json
@@ -53,12 +53,6 @@
       ]
     },
     "AWS::RDS::DBInstance": {
-      "DBSnapshotIdentifier": [
-        "CharacterSetName",
-        "MasterUsername",
-        "MasterUserPassword",
-        "StorageEncrypted"
-      ],
       "SourceDBInstanceIdentifier": [
         "CharacterSetName",
         "MasterUsername",


### PR DESCRIPTION
*Issue #, if available:*
Short term fix for #227
#132

*Description of changes:*
- Remove exclusive checks for RDS.  There are some extra checks that will have to be implemented to support the empty space that is possible.  https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html#cfn-rds-dbinstance-dbsnapshotidentifier

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
