### PR TITLE
Fix get resources when resources aren't properly configured

### DIFF
--- a/src/cfnlint/__init__.py
+++ b/src/cfnlint/__init__.py
@@ -20,6 +20,7 @@ import os
 import re
 from copy import deepcopy
 from datetime import datetime
+import six
 from yaml.parser import ParserError
 import cfnlint.helpers
 from cfnlint.transform import Transform
@@ -361,12 +362,18 @@ class Template(object):
         """
         LOGGER.debug('Get resources from template...')
         resources = self.template.get('Resources', {})
-        if isinstance(resource_type, list):
-            return {k: v for (k, v) in resources.items()
-                    if v.get('Type', None) in resource_type or not resource_type}
+        if not isinstance(resources, dict):
+            return {}
+        if isinstance(resource_type, six.string_types):
+            resource_type = [resource_type]
 
-        return {k: v for (k, v) in resources.items()
-                if v.get('Type', None) == resource_type or len(resource_type) == 0}
+        results = {}
+        for k, v in resources.items():
+            if isinstance(v, dict):
+                if (v.get('Type', None) in resource_type) or (not resource_type and v.get('Type') is not None):
+                    results[k] = v
+
+        return results
 
     def get_parameters(self):
         """Get Resources"""

--- a/test/module/test_template.py
+++ b/test/module/test_template.py
@@ -48,6 +48,20 @@ class TestTemplate(BaseTestCase):
         resources = self.template.get_resources()
         assert len(resources) == valid_resource_count, 'Expected {} resources, got {}'.format(valid_resource_count, len(resources))
 
+    def test_get_resources_bad(self):
+        """Don't get resources that aren't properly configured"""
+        template = {
+            'Resources': {
+                'Properties': {
+                    'BucketName': "bucket_test"
+                },
+                'Type': "AWS::S3::Bucket"
+            }
+        }
+        self.template = Template('test.yaml', template)
+        resources = self.template.get_resources()
+        assert resources == {}
+
     def test_get_resource_names(self):
         """ Test Resource Names"""
         resource_names = self.template.get_resource_names()


### PR DESCRIPTION
*Issue #, if available:*
- Fixes https://github.com/awslabs/aws-cfn-lint-visual-studio-code/issues/16

*Description of changes:*
- Does better checking of resource object types before using them as a normal resource.
- Changed E3001 to not use Template get_resources which is a safe checker.  Since we are checking the configuration this rule needs to manually check each resource.
- Added a test for get_resources that will show what happens if the resource is improperly configured.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
