### PR TITLE
Add link for vim syntastic plugin support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ may need to manually remove the cfn-lint binary.
 There are IDE plugins available to get direct linter feedback from you favorite editor:
 
 * [Atom](https://atom.io/packages/atom-cfn-lint)
-* [NeoVim 0.2.0+/Vim 8](https://github.com/w0rp/ale#supported-languages)
+* NeoVim 0.2.0+/Vim 8
+  * [ALE](https://github.com/w0rp/ale#supported-languages)
+  * [Syntastic](https://github.com/speshak/vim-cfn)
 * [Sublime](https://packagecontrol.io/packages/SublimeLinter-contrib-cloudformation)
 * [Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=kddejong.vscode-cfn-lint)
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added a link to my plugin which wires cfn-lint up in vim via the syntastic plugin as an alternative to ALE.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
