### PR TITLE
Fix checks for only one attribute when Fn::If is used as a top level …

### DIFF
--- a/src/cfnlint/__init__.py
+++ b/src/cfnlint/__init__.py
@@ -647,7 +647,7 @@ class Template(object):
                             for result in results:
                                 check_obj = obj.copy()
                                 check_obj[key] = result['Value']
-                                matches.extend(self.get_values(check_obj, key, path[:] + result['Path']))
+                                matches.extend(self.get_values(check_obj, key, result['Path']))
                 if not is_condition:
                     result = {}
                     result['Path'] = path[:]


### PR DESCRIPTION
…value

*Issue #, if available:*
- Fixes #255 

*Description of changes:*
- Handle Fn::If as a value of a property for rule E2523 and E2521

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
