### PR TITLE
Add Spec file and test for properties Allowed Values

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -29,7 +29,7 @@ Rule `E3012` is used to check the types for value of a resource property.  A num
 
 
 ## Rules
-The following **98** rules are applied by this linter:
+The following **99** rules are applied by this linter:
 
 | Rule ID  | Title | Description | Source | Tags |
 | -------- | ----- | ----------- | ------ | ---- |
@@ -97,6 +97,7 @@ The following **98** rules are applied by this linter:
 | E3020 <a name="E3020"></a> | Validate Route53 RecordSets | Check if all RecordSets are correctly configured | [Source](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/ResourceRecordTypes.html) | `resources`,`route53`,`record_set` |
 | E3021 <a name="E3021"></a> | Check Events Rule Targets are less than or equal to 5 | CloudWatch Events Rule can only support up to 5 targets | [Source](https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/cloudwatch_limits_cwe.html) | `resources`,`events` |
 | E3022 <a name="E3022"></a> | Resource SubnetRouteTableAssociation Properties | Validate there is only one SubnetRouteTableAssociation per subnet | [Source](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-subnet-route-table-assoc.html) | `resources`,`subnet`,`route table` |
+| E3030 <a name="E3030"></a> | Check property values against allowed values | If an array of "AllowedValues" is speficied for a property, check the value of the property. PrimitiveType and Required is handled in other rules, so those are not checked here. | [Source](https://github.com/awslabs/cfn-python-lint) | `resources`,`properties`,`allowedvalues` |
 | E4001 <a name="E4001"></a> | Metadata Interface have appropriate properties | Metadata Interface properties are properly configured | [Source](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudformation-interface.html) | `metadata` |
 | E6001 <a name="E6001"></a> | Outputs have appropriate properties | Making sure the outputs are properly configured | [Source](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/outputs-section-structure.html) | `outputs` |
 | E6002 <a name="E6002"></a> | Outputs have required properties | Making sure the outputs have required properties | [Source](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/outputs-section-structure.html) | `outputs` |

--- a/src/cfnlint/core.py
+++ b/src/cfnlint/core.py
@@ -102,18 +102,18 @@ def get_args_filenames(cli_args):
     fmt = config.format
     formatter = get_formatter(fmt)
 
-    rules = cfnlint.core.get_rules(config.append_rules, config.ignore_checks, config.include_checks)
-
     if config.update_specs:
         cfnlint.maintenance.update_resource_specs()
         exit(0)
 
     if config.update_documentation:
-        cfnlint.maintenance.update_documentation(rules)
+        # Load ALL rules when generating documentation
+        all_rules = cfnlint.core.get_rules([], [], ['E', 'W', 'I'])
+        cfnlint.maintenance.update_documentation(all_rules)
         exit(0)
 
     if config.listrules:
-        print(rules)
+        print(cfnlint.core.get_rules(config.append_rules, config.ignore_checks, config.include_checks))
         exit(0)
 
     if not config.templates:

--- a/src/cfnlint/data/AdditionalSpecs/AllowedValues.json
+++ b/src/cfnlint/data/AdditionalSpecs/AllowedValues.json
@@ -46,6 +46,19 @@
         }
       }
     },
+    "AWS::EC2::Volume": {
+      "Properties": {
+        "VolumeType": {
+          "AllowedValues": [
+            "gp2",
+            "io1",
+            "sc1",
+            "st1",
+            "standard"
+          ]
+        }
+      }
+    },
     "AWS::EC2::VPC": {
       "Properties": {
         "InstanceTenancy": {
@@ -92,15 +105,107 @@
           ]
         }
       }
+    },
+    "AWS::Route53::RecordSet": {
+      "Properties": {
+        "Type": {
+          "AllowedValues": [
+            "A",
+            "AAAA",
+            "CAA",
+            "CNAME",
+            "MX",
+            "NAPTR",
+            "NS",
+            "PTR",
+            "SOA",
+            "SPF",
+            "SRV",
+            "TXT"
+          ]
+        }
+      }
     }
   },
   "PropertyTypes": {
+    "AWS::AutoScaling::LaunchConfiguration.BlockDevice": {
+      "Properties": {
+        "VolumeType": {
+          "AllowedValues": [
+            "gp2",
+            "io1",
+            "sc1",
+            "st1",
+            "standard"
+          ]
+        }
+      }
+    },
+    "AWS::EC2::SpotFleet.EbsBlockDevice": {
+      "Properties": {
+        "VolumeType": {
+          "AllowedValues": [
+            "gp2",
+            "io1",
+            "sc1",
+            "st1",
+            "standard"
+          ]
+        }
+      }
+    },
     "AWS::Glue::Connection.ConnectionInput": {
       "Properties": {
         "ConnectionType": {
           "AllowedValues": [
             "JDBC",
             "SFTP"
+          ]
+        }
+      }
+    },
+    "AWS::OpsWorks::Instance.EbsBlockDevice": {
+      "Properties": {
+        "VolumeType": {
+          "AllowedValues": [
+            "gp2",
+            "io1",
+            "sc1",
+            "st1",
+            "standard"
+          ]
+        }
+      }
+    },
+    "AWS::OpsWorks::Layer.VolumeConfiguration": {
+      "Properties": {
+        "VolumeType": {
+          "AllowedValues": [
+            "gp2",
+            "io1",
+            "sc1",
+            "st1",
+            "standard"
+          ]
+        }
+      }
+    },
+    "AWS::Route53::RecordSetGroup.RecordSet": {
+      "Properties": {
+        "Type": {
+          "AllowedValues": [
+            "A",
+            "AAAA",
+            "CAA",
+            "CNAME",
+            "MX",
+            "NAPTR",
+            "NS",
+            "PTR",
+            "SOA",
+            "SPF",
+            "SRV",
+            "TXT"
           ]
         }
       }

--- a/src/cfnlint/data/AdditionalSpecs/AllowedValues.json
+++ b/src/cfnlint/data/AdditionalSpecs/AllowedValues.json
@@ -1,0 +1,134 @@
+{
+  "ResourceTypes": {
+    "AWS::AmazonMQ::Broker": {
+      "Properties": {
+        "EngineVersion": {
+          "AllowedValues": [
+            "5.15.0"
+          ]
+        },
+        "DeploymentMode": {
+          "AllowedValues": [
+            "SINGLE_INSTANCE",
+            "ACTIVE_STANDBY_MULTI_AZ"
+          ]
+        },
+        "EngineType": {
+          "AllowedValues": [
+            "ACTIVEMQ"
+          ]
+        }
+      }
+    },
+    "AWS::AmazonMQ::Configuration": {
+      "Properties": {
+        "EngineVersion": {
+          "AllowedValues": [
+            "5.15.0"
+          ]
+        },
+        "EngineType": {
+          "AllowedValues": [
+            "ACTIVEMQ"
+          ]
+        }
+      }
+    },
+    "AWS::DMS::Endpoint": {
+      "Properties": {
+        "SslMode": {
+          "AllowedValues": [
+            "none",
+            "require",
+            "verify-ca",
+            "verify-full"
+          ]
+        }
+      }
+    },
+    "AWS::EC2::VPC": {
+      "Properties": {
+        "InstanceTenancy": {
+          "AllowedValues": [
+            "dedicated",
+            "default"
+          ]
+        }
+      }
+    },
+    "AWS::Lambda::Function": {
+      "Properties": {
+        "Runtime": {
+          "AllowedValues": [
+            "nodejs",
+            "nodejs4.3",
+            "nodejs6.10",
+            "nodejs8.10",
+            "java8",
+            "python2.7",
+            "python3.6",
+            "dotnetcore1.0",
+            "dotnetcore2.0",
+            "dotnetcore2.1",
+            "nodejs4.3-edge",
+            "go1.x"
+          ]
+        }
+      }
+    },
+    "AWS::RDS::DBCluster": {
+      "Properties": {
+        "Engine": {
+          "AllowedValues": [
+            "aurora",
+            "aurora-mysql",
+            "aurora-postgresql"
+          ]
+        },
+        "EngineMode": {
+          "AllowedValues": [
+            "provisioned",
+            "serverless"
+          ]
+        }
+      }
+    }
+  },
+  "PropertyTypes": {
+    "AWS::Glue::Connection.ConnectionInput": {
+      "Properties": {
+        "ConnectionType": {
+          "AllowedValues": [
+            "JDBC",
+            "SFTP"
+          ]
+        }
+      }
+    },
+    "AWS::S3::Bucket.VersioningConfiguration": {
+      "Properties": {
+        "Status": {
+          "AllowedValues": [
+            "Enabled",
+            "Suspended"
+          ]
+        }
+      }
+    },
+    "AWS::WAF::Rule.Predicate": {
+      "Properties": {
+        "Type": {
+          "AllowedValues": [
+            "ByteMatch",
+            "GeoMatch",
+            "IPMatch",
+            "RegexMatch",
+            "SizeConstraint",
+            "SqlInjectionMatch",
+            "XssMatch"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/src/cfnlint/rules/resources/ectwo/Ebs.py
+++ b/src/cfnlint/rules/resources/ectwo/Ebs.py
@@ -38,12 +38,7 @@ class Ebs(CloudFormationLintRule):
                 for volume_type_obj in volume_types_obj:
                     volume_type = volume_type_obj.get('Value')
                     if isinstance(volume_type, six.string_types):
-                        if volume_type not in ['standard', 'io1', 'gp2', 'sc1', 'st1']:
-                            pathmessage = path[:] + ['VolumeType', volume_type['Path']]
-                            message = 'VolumeType should be of standard | io1 | gp2 | sc1 | st1] for {0}'
-                            matches.append(
-                                RuleMatch(pathmessage, message.format('/'.join(map(str, pathmessage)))))
-                        elif volume_type == 'io1':
+                        if volume_type == 'io1':
                             if iops_obj is None:
                                 pathmessage = path[:] + ['VolumeType']
                                 message = 'VolumeType io1 requires Iops to be specified for {0}'

--- a/src/cfnlint/rules/resources/ectwo/Vpc.py
+++ b/src/cfnlint/rules/resources/ectwo/Vpc.py
@@ -29,15 +29,6 @@ class Vpc(CloudFormationLintRule):
     source_url = 'https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpc.html'
     tags = ['properties', 'vpc']
 
-    def check_vpc_value(self, value, path):
-        """Check VPC Values"""
-        matches = []
-
-        if value not in ('default', 'dedicated'):
-            message = 'DefaultTenancy needs to be default or dedicated for {0}'
-            matches.append(RuleMatch(path, message.format(('/'.join(path)))))
-        return matches
-
     def check_vpc_ref(self, value, path, parameters, resources):
         """Check ref for VPC"""
         matches = []
@@ -102,13 +93,6 @@ class Vpc(CloudFormationLintRule):
         """Check EC2 VPC Resource Parameters"""
 
         matches = []
-        matches.extend(
-            cfn.check_resource_property(
-                'AWS::EC2::VPC', 'InstanceTenancy',
-                check_value=self.check_vpc_value,
-                check_ref=self.check_vpc_ref,
-            )
-        )
         matches.extend(
             cfn.check_resource_property(
                 'AWS::EC2::VPC', 'CidrBlock',

--- a/src/cfnlint/rules/resources/properties/AllowedValues.py
+++ b/src/cfnlint/rules/resources/properties/AllowedValues.py
@@ -1,0 +1,162 @@
+"""
+  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this
+  software and associated documentation files (the "Software"), to deal in the Software
+  without restriction, including without limitation the rights to use, copy, modify,
+  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+from cfnlint import CloudFormationLintRule
+from cfnlint import RuleMatch
+import cfnlint.helpers
+
+class AllowedValues(CloudFormationLintRule):
+    """Check Property Allowed Values Configuration"""
+    id = 'E3030'
+    shortdesc = 'Check property values against allowed values'
+    description = 'If an array of "AllowedValues" is speficied for a property, ' \
+                  'check the value of the property. PrimitiveType and Required is ' \
+                  'handled in other rules, so those are not checked here.'
+    source_url = 'https://github.com/awslabs/cfn-python-lint'
+    tags = ['resources', 'properties', 'allowedvalues']
+
+    cfn = {}
+
+    def __init__(self):
+        """Init"""
+        super(AllowedValues, self).__init__()
+        allowed_values_spec = cfnlint.helpers.load_resources('data/AdditionalSpecs/AllowedValues.json')
+        self.allowed_resourcetypes = allowed_values_spec['ResourceTypes']
+        self.allowed_propertytypes = allowed_values_spec['PropertyTypes']
+        # Grab the full resource spec for processing nested properties
+        resourcespecs = cfnlint.helpers.RESOURCE_SPECS['us-east-1']
+        self.resourcetypes = resourcespecs['ResourceTypes']
+        self.propertytypes = resourcespecs['PropertyTypes']
+
+    def propertycheck(self, text, proptype, parenttype, resourcename, tree, root):
+        """Check individual properties"""
+
+        matches = list()
+        if root:
+            allowed_specs = self.allowed_resourcetypes
+            specs = self.resourcetypes
+            resourcetype = parenttype
+        else:
+            allowed_specs = self.allowed_propertytypes
+            specs = self.propertytypes
+            resourcetype = str.format('{0}.{1}', parenttype, proptype)
+            # handle tags
+            if resourcetype not in specs:
+                if proptype in specs:
+                    resourcetype = proptype
+                else:
+                    resourcetype = str.format('{0}.{1}', parenttype, proptype)
+            else:
+                resourcetype = str.format('{0}.{1}', parenttype, proptype)
+
+        resourcespec = specs[resourcetype]['Properties']
+        allowed_resourcespec = {}
+        if resourcetype in allowed_specs:
+            allowed_resourcespec = allowed_specs[resourcetype]['Properties']
+
+        if not isinstance(text, dict):
+            # Covered with Properties
+            return matches
+
+        resource_objects = list()
+        base_object_properties = {}
+        for key, value in text.items():
+            if key not in cfnlint.helpers.CONDITION_FUNCTIONS:
+                base_object_properties[key] = value
+        condition_found = False
+        for key, value in text.items():
+            if key in cfnlint.helpers.CONDITION_FUNCTIONS:
+                condition_found = True
+                cond_values = self.cfn.get_condition_values(value)
+                for cond_value in cond_values:
+                    if isinstance(cond_value['Value'], dict):
+                        append_object = {}
+                        append_object['Path'] = tree[:] + [key] + cond_value['Path']
+                        for sub_key, sub_value in cond_value['Value'].items():
+                            append_object[sub_key] = sub_value
+
+                        append_object['Value'] = append_object
+                        append_object['Value'].update(base_object_properties)
+                        resource_objects.append(append_object)
+
+        if not condition_found:
+            resource_objects.append({
+                'Path': tree[:],
+                'Value': base_object_properties
+            })
+
+        for resource_object in resource_objects:
+            path = resource_object.get('Path')
+            value = resource_object.get('Value')
+
+            for prop in resourcespec:
+
+                if prop in allowed_resourcespec:
+                    allowed_values = allowed_resourcespec[prop].get('AllowedValues')
+
+                    # Check if there's a value at all. Required is handled by
+                    # the required properties rule (E3003)
+                    if prop in value:
+
+                        if not isinstance(value[prop], dict):
+                            if value[prop] not in allowed_values:
+                                message = 'Invalid property value "{0}" specified for {1}. Allowed value(s): {2}'
+                                spec_path = path + [prop]
+                                matches.append(RuleMatch(spec_path, message.format(
+                                    value[prop],
+                                    '/'.join(map(str, spec_path)),
+                                    ', '.join(map(str, allowed_values))
+                                )))
+
+            # For all specified properties, check all nested properties
+            for prop in value:
+                proptree = path[:]
+                proptree.append(prop)
+                if prop in resourcespec:
+                    if 'Type' in resourcespec[prop]:
+                        if resourcespec[prop]['Type'] == 'List':
+                            if 'PrimitiveItemType' not in resourcespec[prop]:
+                                if isinstance(value[prop], list):
+                                    for index, item in enumerate(value[prop]):
+                                        arrproptree = proptree[:]
+                                        arrproptree.append(index)
+                                        matches.extend(self.propertycheck(
+                                            item, resourcespec[prop]['ItemType'],
+                                            parenttype, resourcename, arrproptree, False))
+                        else:
+                            if resourcespec[prop]['Type'] not in ['Map']:
+                                matches.extend(self.propertycheck(
+                                    value[prop], resourcespec[prop]['Type'],
+                                    parenttype, resourcename, proptree, False))
+
+        return matches
+
+    def match(self, cfn):
+        """Check CloudFormation Properties"""
+        matches = list()
+
+        self.cfn = cfn
+
+        for resourcename, resourcevalue in cfn.get_resources().items():
+            if 'Properties' in resourcevalue and 'Type' in resourcevalue:
+                resourcetype = resourcevalue['Type']
+                if resourcetype in self.allowed_resourcetypes:
+                    tree = ['Resources', resourcename, 'Properties']
+                    matches.extend(self.propertycheck(
+                        resourcevalue['Properties'], '',
+                        resourcetype, resourcename, tree, True))
+
+        return matches

--- a/src/cfnlint/rules/resources/route53/RecordSet.py
+++ b/src/cfnlint/rules/resources/route53/RecordSet.py
@@ -28,22 +28,6 @@ class RecordSet(CloudFormationLintRule):
     source_url = 'https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/ResourceRecordTypes.html'
     tags = ['resources', 'route53', 'record_set']
 
-    # https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/ResourceRecordTypes.html
-    VALID_RECORD_TYPES = [
-        'A',
-        'AAAA',
-        'CAA',
-        'CNAME',
-        'MX',
-        'NAPTR',
-        'NS',
-        'PTR',
-        'SOA'
-        'SPF',
-        'SRV',
-        'TXT'
-    ]
-
     REGEX_CNAME = re.compile(r'^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])(.)$')
 
     def check_a_record(self, path, recordset):
@@ -168,10 +152,7 @@ class RecordSet(CloudFormationLintRule):
 
         # Skip Intrinsic functions
         if not isinstance(recordset_type, dict):
-            if recordset_type not in self.VALID_RECORD_TYPES:
-                message = 'Invalid record type "{0}" specified'
-                matches.append(RuleMatch(path + ['Type'], message.format(recordset_type)))
-            elif not recordset.get('AliasTarget'):
+            if not recordset.get('AliasTarget'):
                 # Record type specific checks
                 if recordset_type == 'A':
                     matches.extend(self.check_a_record(path, recordset))

--- a/test/fixtures/templates/bad/properties_allowedvalues.yaml
+++ b/test/fixtures/templates/bad/properties_allowedvalues.yaml
@@ -1,0 +1,16 @@
+---
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  Allowed Values
+Resources:
+  myLambdaFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      Handler: "index.handler"
+      Role: !GetAtt LambdaExecutionRole.Arn
+      Code:
+        S3Bucket: "lambda-functions"
+        S3Key: "amilookup.zip"
+      Runtime: "nodejs4.4"
+      Timeout: "25"
+      MemorySize: "1537"

--- a/test/fixtures/templates/bad/properties_allowedvalues.yaml
+++ b/test/fixtures/templates/bad/properties_allowedvalues.yaml
@@ -2,15 +2,25 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Description: >
   Allowed Values
+Conditions:
+  PrimaryRegion:
+    "Fn::Equals":
+    - !Ref AWS::Region
+    - 'us-east-1'
 Resources:
   myLambdaFunction:
     Type: AWS::Lambda::Function
     Properties:
       Handler: "index.handler"
-      Role: !GetAtt LambdaExecutionRole.Arn
+      Role: !ImportValue "my-lambda-execution-role"
       Code:
         S3Bucket: "lambda-functions"
         S3Key: "amilookup.zip"
-      Runtime: "nodejs4.4"
-      Timeout: "25"
-      MemorySize: "1537"
+      Runtime: !If [PrimaryRegion, "nodejs4.5", "nodejs4.4"] # Both are invalid
+      Timeout: 25
+      MemorySize: 128
+  myBucketGood:
+    Type: AWS::S3::Bucket
+    Properties:
+      VersioningConfiguration:
+        Status: Bad # Invalid value

--- a/test/rules/resources/ec2/test_ec2_vpc.py
+++ b/test/rules/resources/ec2/test_ec2_vpc.py
@@ -34,4 +34,4 @@ class TestPropertyEc2Vpc(BaseRuleTestCase):
 
     def test_file_negative(self):
         """Test failure"""
-        self.helper_file_negative('fixtures/templates/bad/properties_ec2_network.yaml', 3)
+        self.helper_file_negative('fixtures/templates/bad/properties_ec2_network.yaml', 2)

--- a/test/rules/resources/properties/test_allowedvalues.py
+++ b/test/rules/resources/properties/test_allowedvalues.py
@@ -1,0 +1,34 @@
+"""
+  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this
+  software and associated documentation files (the "Software"), to deal in the Software
+  without restriction, including without limitation the rights to use, copy, modify,
+  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+from cfnlint.rules.resources.properties.AllowedValues import AllowedValues  # pylint: disable=E0401
+from ... import BaseRuleTestCase
+
+
+class TestPropertyAllowedValues(BaseRuleTestCase):
+    """Test AtLeastOne Property Configuration"""
+    def setUp(self):
+        """Setup"""
+        super(TestPropertyAllowedValues, self).setUp()
+        self.collection.register(AllowedValues())
+
+    def test_file_positive(self):
+        """Test Positive"""
+        self.helper_file_positive()
+
+    def test_file_negative(self):
+        """Test failure"""
+        self.helper_file_negative('fixtures/templates/bad/properties_allowedvalues.yaml', 1)

--- a/test/rules/resources/properties/test_allowedvalues.py
+++ b/test/rules/resources/properties/test_allowedvalues.py
@@ -31,7 +31,7 @@ class TestPropertyAllowedValues(BaseRuleTestCase):
 
     def test_file_negative(self):
         """Test failure"""
-        self.helper_file_negative('fixtures/templates/bad/properties_allowedvalues.yaml', 1)
+        self.helper_file_negative('fixtures/templates/bad/properties_allowedvalues.yaml', 3)
 
     def test_file_negative_route53(self):
         """Test failure"""

--- a/test/rules/resources/properties/test_allowedvalues.py
+++ b/test/rules/resources/properties/test_allowedvalues.py
@@ -32,3 +32,11 @@ class TestPropertyAllowedValues(BaseRuleTestCase):
     def test_file_negative(self):
         """Test failure"""
         self.helper_file_negative('fixtures/templates/bad/properties_allowedvalues.yaml', 1)
+
+    def test_file_negative_route53(self):
+        """Test failure"""
+        self.helper_file_negative('fixtures/templates/bad/route53.yaml', 1)
+
+    def test_file_negative_vpc_tenancy(self):
+        """Test failure"""
+        self.helper_file_negative('fixtures/templates/bad/properties_ec2_network.yaml', 1)

--- a/test/rules/resources/route53/test_recordsets.py
+++ b/test/rules/resources/route53/test_recordsets.py
@@ -34,4 +34,4 @@ class TestRoute53RecordSets(BaseRuleTestCase):
 
     def test_file_negative_alias(self):
         """Test failure"""
-        self.helper_file_negative('fixtures/templates/bad/route53.yaml', 24)
+        self.helper_file_negative('fixtures/templates/bad/route53.yaml', 23)


### PR DESCRIPTION
*Issue https://github.com/awslabs/cfn-python-lint/issues/50*

Introduce new rule `E3030` to check allowed values as mentioned in the documentation. Properties sometimes have a list of "allowed values" (e.g. https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpc.html#cfn-aws-ec2-vpc-instancetenancy).

These values are not in the Spec files, and probably will never be. This PR will add a new Additional Spec file (`AllowedValues.json`) which contains these allowed values in the same format as the Spec files itself, and the other Additional Spec files. In this way all Allowed Values are maintained in a single place which makes more transparent, easier to maintain and remove this logic from current (existing) rules.

This is a first version (MVP) that introduces the new Rule and the definition file. The definition file contains a first set of known allowed values. Also "moved" some of the existing rule logic already (including altering/moving the test logic).

It's an MVP rule at the moment that is open for extension/improvement when required. By adding it already we can move move allowed values in the future from rules and more values can be added to the definition.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
