### PR TITLE
correct module path

### DIFF
--- a/docs/getting_started/integration.md
+++ b/docs/getting_started/integration.md
@@ -11,7 +11,7 @@ import cfnlint.core
 filename = 'test.yaml'
 
 # Load the YAML file
-template = cfnlint.decode.cfn_yaml.load(filename)
+template = cfnlint.cfn_yaml.load(filename)
 
 # Initialize the ruleset to be applied (no overrules, no excludes)
 rules = cfnlint.core.get_rules([], [])


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

module path for `cfn_yaml` does not include `decode` :

```
In [5]: import cfnlint.core

In [6]: filename = 'test.yaml'

In [7]: template = cfnlint.decode.cfn_yaml.load(filename)
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-7-8c164c8b9ade> in <module>()
----> 1 cfnlint.decode.cfn_yaml.load(filename)

AttributeError: module 'cfnlint' has no attribute 'decode'

In [8]: template = cfnlint.cfn_yaml.load(filename)
In [9]:
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
