### PR TITLE
add method to load yaml from string, fixes ##264

### DIFF
--- a/src/cfnlint/decode/cfn_yaml.py
+++ b/src/cfnlint/decode/cfn_yaml.py
@@ -177,12 +177,11 @@ def construct_getatt(node):
     raise ValueError('Unexpected node type: {}'.format(type(node.value)))
 
 
-def load(filename):
+def loads(yaml_string, fname=None):
     """
-    Load the give YAML file
+    Load the given YAML string
     """
-    fp = open(filename)
-    loader = MarkedLoader(fp.read(), filename)
+    loader = MarkedLoader(yaml_string, fname)
     loader.add_multi_constructor('!', multi_constructor)
     template = loader.get_single_data()
     # Convert an empty file to an empty dict
@@ -190,3 +189,12 @@ def load(filename):
         template = {}
 
     return template
+
+
+def load(filename):
+    """
+    Load the given YAML file
+    """
+    fp = open(filename)
+    return loads(fp.read(), filename)
+


### PR DESCRIPTION
*Issue #264*

*Description of changes:*

Adds a `loads` function that parses yaml from a string. Refactored the `load` function to consume this new function so that there's no code duplication.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
