### PR TITLE
Fix E2502 for Spot Fleet configurations

### DIFF
--- a/src/cfnlint/rules/resources/iam/InstanceProfile.py
+++ b/src/cfnlint/rules/resources/iam/InstanceProfile.py
@@ -48,10 +48,16 @@ class InstanceProfile(CloudFormationLintRule):
                             '/'.join(map(str, tree[:-1])))
                         matches.append(RuleMatch(tree[:-1], message))
                     else:
-                        if obj[1] == 'Arn':
-                            message = 'Property IamInstanceProfile shouldn\'t be an ARN for %s' % (
-                                '/'.join(map(str, tree[:-1])))
-                            matches.append(RuleMatch(tree[:-1], message))
+                        if cfn.template.get('Resources', {}).get(tree[1], {}).get('Type') in ['AWS::EC2::SpotFleet']:
+                            if obj[1] != 'Arn':
+                                message = 'Property IamInstanceProfile should be an ARN for %s' % (
+                                    '/'.join(map(str, tree[:-1])))
+                                matches.append(RuleMatch(tree[:-1], message))
+                        else:
+                            if obj[1] == 'Arn':
+                                message = 'Property IamInstanceProfile shouldn\'t be an ARN for %s' % (
+                                    '/'.join(map(str, tree[:-1])))
+                                matches.append(RuleMatch(tree[:-1], message))
 
         # Search Refs
         trees = cfn.search_deep_keys('Ref')


### PR DESCRIPTION
*Issue #, if available:*
- Fixes #267
*Description of changes:*
- Fixes E2502 to not show a failure when doing IamInstanceProfiles for Spot Fleet

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
