### PR TITLE
don't trigger when value of protocol is an intrinsic function. Fixes #272

### DIFF
--- a/test/fixtures/templates/bad/properties_elb.yaml
+++ b/test/fixtures/templates/bad/properties_elb.yaml
@@ -17,6 +17,11 @@ Parameters:
     AllowedValues:
       - internal
       - internet-facing
+  TestParam:
+    Type: String
+    Default: TCP
+Conditions:
+  TestCond: !Equals ['a', 'a']
 Resources:
   LoadBalancer:
     Type: "AWS::ElasticLoadBalancingV2::LoadBalancer"
@@ -108,6 +113,22 @@ Resources:
       AvailabilityZones:
         Fn::GetAZs: ''
       Listeners:
+      - InstancePort: '4'
+        InstanceProtocol: !If [TestCond, TCP, SSL]
+        LoadBalancerPort: '4'
+        Protocol: [test]
+      - InstancePort: '5'
+        InstanceProtocol: !If [TestCond, TCP, SSL]
+        LoadBalancerPort: '5'
+        Protocol: ererere
+      - InstancePort: '4'
+        InstanceProtocol: !If [TestCond, TCP, SSL]
+        LoadBalancerPort: '4'
+        Protocol: {"arbKey": ""}
+      - InstancePort: '4'
+        InstanceProtocol: !If [TestCond, TCP, SSL]
+        LoadBalancerPort: '4'
+        Protocol: {"arbKey": "", "moreArb": ""}
       - LoadBalancerPort: '80'
         InstancePort: '80'
         Protocol: TCP

--- a/test/fixtures/templates/good/properties_elb.yaml
+++ b/test/fixtures/templates/good/properties_elb.yaml
@@ -21,6 +21,11 @@ Parameters:
     Type: List<AWS::EC2::SecurityGroup::Id>
   CertARN:
     Type: String
+  TestParam:
+    Type: String
+    Default: TCP
+Conditions:
+  TestCond: !Equals ['a', 'a']
 Resources:
   LoadBalancer:
     Type: "AWS::ElasticLoadBalancingV2::LoadBalancer"
@@ -114,6 +119,14 @@ Resources:
       AvailabilityZones:
         Fn::GetAZs: ''
       Listeners:
+      - InstancePort: '1'
+        InstanceProtocol: !Ref TestParam
+        LoadBalancerPort: '1'
+        Protocol: !Ref TestParam
+      - InstancePort: '2'
+        InstanceProtocol: !If [TestCond, TCP, SSL]
+        LoadBalancerPort: '2'
+        Protocol: !If [TestCond, TCP, SSL]
       - LoadBalancerPort: '80'
         InstancePort: '80'
         Protocol: TCP

--- a/test/rules/resources/elb/test_elb.py
+++ b/test/rules/resources/elb/test_elb.py
@@ -34,4 +34,4 @@ class TestPropertyElb(BaseRuleTestCase):
 
     def test_file_negative(self):
         """Test failure"""
-        self.helper_file_negative('fixtures/templates/bad/properties_elb.yaml', 2)
+        self.helper_file_negative('fixtures/templates/bad/properties_elb.yaml', 6)


### PR DESCRIPTION
*Issue #, if available: #272*

*Description of changes:*
protocol was being treated as if it's always a string with a list of valid values, when Ref or Fn::If are used to populate the value this rule was generating a false positive.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
