### PR TITLE
 Add (Warning) rule for Outputs values using ImportValue

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -27,7 +27,7 @@ Rule `E3012` is used to check the types for value of a resource property.  A num
 
 
 ## Rules
-The following **81** rules are applied by this linter:
+The following **82** rules are applied by this linter:
 
 | Rule ID  | Title | Description | Source | Tags |
 | -------- | ----- | ----------- | ------ | ---- |
@@ -113,5 +113,6 @@ The following **81** rules are applied by this linter:
 | W3005 <a name="W3005"></a> | Check obsolete DependsOn configuration for Resources | Check if DependsOn is specified if not needed. A Ref or a Fn::GetAtt already is an implicit dependency. | [Source](https://aws.amazon.com/blogs/devops/optimize-aws-cloudformation-templates/) | `resources`,`dependson` |
 | W3010 <a name="W3010"></a> | Availability Zone Parameters should not be hardcoded | Check if an Availability Zone property is hardcoded. | [Source](https://github.com/awslabs/cfn-python-lint) | `parameters`,`availabilityzone` |
 | W4001 <a name="W4001"></a> | Metadata Interface parameters exist | Metadata Interface parameters actually exist | [Source](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudformation-interface.html) | `metadata` |
+| W6001 <a name="W6001"></a> | Output using ImportValue | Check if the Output value is set using ImportValue, so creating an Output of an Output | [Source](https://github.com/awslabs/cfn-python-lint) | `outputs`,`importvalue` |
 | W7001 <a name="W7001"></a> | Check if Mappings are Used | Making sure the mappings defined are used | [Source](https://github.com/awslabs/cfn-python-lint) | `conditions` |
 | W8001 <a name="W8001"></a> | Check if Conditions are Used | Making sure the conditions defined are used | [Source](https://github.com/awslabs/cfn-python-lint) | `conditions` |

--- a/src/cfnlint/rules/outputs/ImportValue.py
+++ b/src/cfnlint/rules/outputs/ImportValue.py
@@ -1,0 +1,46 @@
+"""
+  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this
+  software and associated documentation files (the "Software"), to deal in the Software
+  without restriction, including without limitation the rights to use, copy, modify,
+  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+from cfnlint import CloudFormationLintRule
+from cfnlint import RuleMatch
+
+
+class ImportValue(CloudFormationLintRule):
+    """Check if a Output is done of another output"""
+    id = 'W6001'
+    shortdesc = 'Check Outputs using ImportValue'
+    description = 'Check if the Output value is set using ImportValue, so creating an Output of an Output'
+    source_url = 'https://github.com/awslabs/cfn-python-lint'
+    tags = ['outputs', 'importvalue']
+
+    def match(self, cfn):
+        """Check CloudFormation Outputs"""
+
+        matches = list()
+
+        # Get all import values
+        importvalue_trees = cfn.search_deep_keys('Fn::ImportValue')
+
+        # Filter out the Outputs
+        importvalue_trees = [x for x in importvalue_trees if x[0] == 'Outputs']
+
+        # Check if the importvalue is set on the Value
+        for importvalue_tree in importvalue_trees:
+            if importvalue_tree[2] == 'Value':
+                message = 'The value of output ({0}) is imported from another output ({1})'
+                matches.append(RuleMatch(importvalue_tree, message.format(importvalue_tree[1], importvalue_tree[-1])))
+
+        return matches

--- a/test/fixtures/templates/bad/outputs.yaml
+++ b/test/fixtures/templates/bad/outputs.yaml
@@ -36,3 +36,5 @@ Outputs:
   myGoodRefArrayOutput:
     Value:
       Fn::Join: [ ',', !Ref myNumbers]
+  myOutputImportValue:
+    Value: !ImportValue "existing-output"

--- a/test/rules/outputs/test_importvalue.py
+++ b/test/rules/outputs/test_importvalue.py
@@ -1,0 +1,34 @@
+"""
+  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this
+  software and associated documentation files (the "Software"), to deal in the Software
+  without restriction, including without limitation the rights to use, copy, modify,
+  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+from cfnlint.rules.outputs.ImportValue import ImportValue  # pylint: disable=E0401
+from .. import BaseRuleTestCase
+
+
+class TestOutputImportValue(BaseRuleTestCase):
+    """Test Output ImportValue"""
+    def setUp(self):
+        """Setup"""
+        super(TestOutputImportValue, self).setUp()
+        self.collection.register(ImportValue())
+
+    def test_file_positive(self):
+        """Test Positive"""
+        self.helper_file_positive()
+
+    def test_file_negative(self):
+        """Test failure"""
+        self.helper_file_negative('fixtures/templates/bad/outputs.yaml', 1)

--- a/test/rules/outputs/test_limitname.py
+++ b/test/rules/outputs/test_limitname.py
@@ -18,11 +18,11 @@ from cfnlint.rules.outputs.LimitName import LimitName  # pylint: disable=E0401
 from .. import BaseRuleTestCase
 
 
-class TestParameterLimitNumber(BaseRuleTestCase):
-    """Test parameters limit number"""
+class TestOutputLimitName(BaseRuleTestCase):
+    """Test output limit name"""
     def setUp(self):
         """Setup"""
-        super(TestParameterLimitNumber, self).setUp()
+        super(TestOutputLimitName, self).setUp()
         self.collection.register(LimitName())
 
     def test_file_positive(self):


### PR DESCRIPTION
Creating an Output with a value coming from an ImportValue, it is basically creating an Output of an Output. Since there might be edge case scenario's and it actually deploys it's a warning (`W6001`)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
