### PR TITLE
Set AWS region to control the region in SAM

### DIFF
--- a/src/cfnlint/transform.py
+++ b/src/cfnlint/transform.py
@@ -14,6 +14,7 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
+import os
 import six
 
 from samtranslator.parser import parser
@@ -84,6 +85,10 @@ class Transform(object):
                                         sam_parser=self._sam_parser)
 
             self._replace_local_codeuri()
+
+            # Tell SAM to use the region we're linting in, this has to be controlled using the default AWS mechanisms, see also:
+            # https://github.com/awslabs/serverless-application-model/blob/master/samtranslator/translator/arn_generator.py
+            os.environ['AWS_DEFAULT_REGION'] = self._region
 
             # In the Paser class, within the SAM Translator, they log a warning for when the template
             # does not match the schema. The logger they use is the root logger instead of one scoped to


### PR DESCRIPTION
*Issue https://github.com/awslabs/cfn-python-lint/issues/253*

There is a "hidden" depency on AWS being configured locally when SAM Transofmations. SAM extracts the region when generating AWS Service Role ARNS.

Apart from this dependancy, this is also means SAM works on a different region than the linter, which could result in unexpected results.

This PR sets the `AWS_DEFAULT_REGION` Environment Variable (also as [suggested by SAM](https://github.com/awslabs/serverless-application-model/blob/master/samtranslator/translator/arn_generator.py#L39) as the way to control this, since this is the first value being checked by Boto).

So this PR makes sure the region of SAM transformations and the linter are the same, and removed the dependency. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
