### PR TITLE
Fix lowercase protocols being rejected in ELB listeners

### DIFF
--- a/src/cfnlint/rules/resources/elb/Elb.py
+++ b/src/cfnlint/rules/resources/elb/Elb.py
@@ -34,10 +34,10 @@ HTTPS has certificate HTTP has no certificate'
         """
         matches = list()
         if isinstance(value, six.string_types):
-            if value not in kwargs['accepted_protocols']:
+            if value.upper() not in kwargs['accepted_protocols']:
                 message = 'Protocol must be {0} is invalid at {1}'
                 matches.append(RuleMatch(path, message.format((', '.join(kwargs['accepted_protocols'])), ('/'.join(map(str, path))))))
-            elif value in kwargs['certificate_protocols']:
+            elif value.upper() in kwargs['certificate_protocols']:
                 if not kwargs['certificates']:
                     message = 'Certificates should be specified when using HTTPS for {0}'
                     matches.append(RuleMatch(path, message.format(('/'.join(map(str, path))))))


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Currently if you have the `Protocol` property of a listener in lower case (as below), it errors out with below error. This fixes the issue by simply upper casing the protocol and then doing the comparison
```
E2503 Protocol is invalid for Resources/myLoadBalancer/Properties/Listeners
template.yaml:72:11
```

```yaml
  myLoadBalancer:
    Type: AWS::ElasticLoadBalancing::LoadBalancer # or AWS::ElasticLoadBalancingV2::Listener
    Properties:
      # other properties
      Listeners:
        - InstancePort: "8000"
          InstanceProtocol: "tcp"
          LoadBalancerPort: "8000"
          Protocol: "tcp"
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
