### PR TITLE
Add linting of CNAMEs

### DIFF
--- a/src/cfnlint/rules/resources/route53/RecordSet.py
+++ b/src/cfnlint/rules/resources/route53/RecordSet.py
@@ -15,7 +15,6 @@
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 import re
-import six
 from cfnlint import CloudFormationLintRule
 from cfnlint import RuleMatch
 
@@ -45,22 +44,22 @@ class RecordSet(CloudFormationLintRule):
         'TXT'
     ]
 
+    REGEX_CNAME = re.compile(r'^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])(.)$')
+
     def check_a_record(self, path, recordset):
         """Check A record Configuration"""
         matches = list()
 
-        if not recordset.get('AliasTarget'):
-            resource_records = recordset.get('ResourceRecords')
-            for index, record in enumerate(resource_records):
+        resource_records = recordset.get('ResourceRecords')
+        for index, record in enumerate(resource_records):
 
-                if isinstance(record, six.string_types):
-                    tree = path[:] + ['ResourceRecords', index]
-                    full_path = ('/'.join(str(x) for x in tree))
+            if not isinstance(record, dict):
+                tree = path[:] + ['ResourceRecords', index]
 
-                    # Check if a valid IPv4 address is specified
-                    if not re.match(REGEX_IPV4, record):
-                        message = 'A record is not a valid IPv4 address at {0}'
-                        matches.append(RuleMatch(tree, message.format(full_path)))
+                # Check if a valid IPv4 address is specified
+                if not re.match(REGEX_IPV4, record):
+                    message = 'A record ({}) is not a valid IPv4 address'
+                    matches.append(RuleMatch(tree, message.format(record)))
 
         return matches
 
@@ -68,18 +67,16 @@ class RecordSet(CloudFormationLintRule):
         """Check AAAA record Configuration"""
         matches = list()
 
-        if not recordset.get('AliasTarget'):
-            resource_records = recordset.get('ResourceRecords')
-            for index, record in enumerate(resource_records):
+        resource_records = recordset.get('ResourceRecords')
+        for index, record in enumerate(resource_records):
 
-                if isinstance(record, six.string_types):
-                    tree = path[:] + ['ResourceRecords', index]
-                    full_path = ('/'.join(str(x) for x in tree))
+            if not isinstance(record, dict):
+                tree = path[:] + ['ResourceRecords', index]
 
-                    # Check if a valid IPv4 address is specified
-                    if not re.match(REGEX_IPV6, record):
-                        message = 'AAAA record is not a valid IPv6 address at {0}'
-                        matches.append(RuleMatch(tree, message.format(full_path)))
+                # Check if a valid IPv4 address is specified
+                if not re.match(REGEX_IPV6, record):
+                    message = 'AAAA record ({}) is not a valid IPv6 address'
+                    matches.append(RuleMatch(tree, message.format(record)))
 
         return matches
 
@@ -92,32 +89,51 @@ class RecordSet(CloudFormationLintRule):
         for index, record in enumerate(resource_records):
             tree = path[:] + ['ResourceRecords', index]
 
-            # Split the record up to the mandatory settings (flags tag "value")
-            items = record.split(' ', 2)
+            if not isinstance(record, dict):
+                # Split the record up to the mandatory settings (flags tag "value")
+                items = record.split(' ', 2)
 
-            # Check if the 3 settings are given.
-            if len(items) != 3:
-                message = 'CAA record must contain 3 settings (flags tag "value"), record contains {} settings.'
-                matches.append(RuleMatch(tree, message.format(len(items))))
-            else:
-                # Check the flag value
-                if not items[0].isdigit():
-                    message = 'CAA record flag setting ({}) should be of type Integer.'
-                    matches.append(RuleMatch(tree, message.format(items[0])))
+                # Check if the 3 settings are given.
+                if len(items) != 3:
+                    message = 'CAA record must contain 3 settings (flags tag "value"), record contains {} settings.'
+                    matches.append(RuleMatch(tree, message.format(len(items))))
                 else:
-                    if int(items[0]) not in [0, 128]:
-                        message = 'Invalid CAA record flag setting ({}) given, must be 0 or 128.'
+                    # Check the flag value
+                    if not items[0].isdigit():
+                        message = 'CAA record flag setting ({}) should be of type Integer.'
+                        matches.append(RuleMatch(tree, message.format(items[0])))
+                    else:
+                        if int(items[0]) not in [0, 128]:
+                            message = 'Invalid CAA record flag setting ({}) given, must be 0 or 128.'
+                            matches.append(RuleMatch(tree, message.format(items[0])))
+
+                    # Check the tag value
+                    if not re.match(REGEX_ALPHANUMERIC, items[1]):
+                        message = 'Invalid CAA record tag setting {}. Value has to be alphanumeric.'
                         matches.append(RuleMatch(tree, message.format(items[0])))
 
-                # Check the tag value
-                if not re.match(REGEX_ALPHANUMERIC, items[1]):
-                    message = 'Invalid CAA record tag setting {}. Value has to be alphanumeric.'
-                    matches.append(RuleMatch(tree, message.format(items[0])))
+                    # Check the value
+                    if not items[2].startswith('"') or not items[2].endswith('"'):
+                        message = 'CAA record value setting has to be enclosed in double quotation marks (").'
+                        matches.append(RuleMatch(tree, message))
 
-                # Check the value
-                if not items[2].startswith('"') or not items[2].endswith('"'):
-                    message = 'CAA record value setting has to be enclosed in double quotation marks (").'
-                    matches.append(RuleMatch(tree, message))
+        return matches
+
+    def check_cname_record(self, path, recordset):
+        """Check CNAME record Configuration"""
+        matches = list()
+
+        resource_records = recordset.get('ResourceRecords')
+        if len(resource_records) > 1:
+            message = 'A CNAME recordset can only contain 1 value'
+            matches.append(RuleMatch(path + ['ResourceRecords'], message))
+        else:
+            for index, record in enumerate(resource_records):
+                if not isinstance(record, dict):
+                    tree = path[:] + ['ResourceRecords', index]
+                    if not re.match(self.REGEX_CNAME, record):
+                        message = 'CNAME record ({}) does not contain a valid domain name'
+                        matches.append(RuleMatch(tree, message.format(record)))
 
         return matches
 
@@ -130,14 +146,14 @@ class RecordSet(CloudFormationLintRule):
 
         for index, record in enumerate(resource_records):
             tree = path[:] + ['ResourceRecords', index]
-            full_path = ('/'.join(str(x) for x in tree))
 
-            if not record.startswith('"') or not record.endswith('"'):
-                message = 'TXT record has to be enclosed in double quotation marks (") at {0}'
-                matches.append(RuleMatch(tree, message.format(full_path)))
-            elif len(record) > 255:
-                message = 'The length of the TXT record ({0}) exceeds the limit (255) as {1}'
-                matches.append(RuleMatch(tree, message.format(len(record), full_path)))
+            if not isinstance(record, dict):
+                if not record.startswith('"') or not record.endswith('"'):
+                    message = 'TXT record ({}) has to be enclosed in double quotation marks (")'
+                    matches.append(RuleMatch(tree, message.format(record)))
+                elif len(record) > 255:
+                    message = 'The length of the TXT record ({}) exceeds the limit (255)'
+                    matches.append(RuleMatch(tree, message.format(len(record))))
 
         return matches
 
@@ -150,14 +166,18 @@ class RecordSet(CloudFormationLintRule):
         if recordset_type not in self.VALID_RECORD_TYPES:
             message = 'Invalid record type "{0}" specified'
             matches.append(RuleMatch(path + ['Type'], message.format(recordset_type)))
-        elif recordset_type == 'A':
-            matches.extend(self.check_a_record(path, recordset))
-        elif recordset_type == 'AAAA':
-            matches.extend(self.check_aaaa_record(path, recordset))
-        elif recordset_type == 'CAA':
-            matches.extend(self.check_caa_record(path, recordset))
-        elif recordset_type == 'TXT':
-            matches.extend(self.check_txt_record(path, recordset))
+        elif not recordset.get('AliasTarget'):
+            # Record type specific checks
+            if recordset_type == 'A':
+                matches.extend(self.check_a_record(path, recordset))
+            elif recordset_type == 'AAAA':
+                matches.extend(self.check_aaaa_record(path, recordset))
+            elif recordset_type == 'CAA':
+                matches.extend(self.check_caa_record(path, recordset))
+            elif recordset_type == 'CNAME':
+                matches.extend(self.check_cname_record(path, recordset))
+            elif recordset_type == 'TXT':
+                matches.extend(self.check_txt_record(path, recordset))
 
         return matches
 

--- a/test/fixtures/templates/bad/route53.yaml
+++ b/test/fixtures/templates/bad/route53.yaml
@@ -59,6 +59,17 @@ Resources:
       ResourceRecords:
         - "127.0.0.1" # No 3 items
         - "0 issue amazon.com; henk" # Missing quotes around the value
+  MyCNAMERecordSet:
+    Type: "AWS::Route53::RecordSet"
+    Properties:
+      Comment: "Invalid CAA Record"
+      HostedZoneId: !Ref "MyHostedZone"
+      Name: "cname.example.com"
+      Type: "CNAME"
+      TTL: "300"
+      ResourceRecords: # Multiple records
+        - "cname1.example.com"
+        - "cname2.example.com"
   MyRecordSetGroup:
     Type: "AWS::Route53::RecordSetGroup"
     Properties:
@@ -100,6 +111,11 @@ Resources:
           ResourceRecords:
             - "1 issue \"amazon.com; example.com\"" # Invalid flag
             - "0 special-value \"amazon.com\"" # Invalid tag (not numeric)
+        - Name: "cname.example.com"
+          Type: "CNAME"
+          TTL: "300"
+          ResourceRecords:
+            - "No valid domain name" # No valid domain name
   MySecondRecordSetGroup:
     Type: "AWS::Route53::RecordSetGroup"
     Properties:

--- a/test/fixtures/templates/good/route53.yaml
+++ b/test/fixtures/templates/good/route53.yaml
@@ -3,7 +3,7 @@ Description: "Route53 resources"
 Parameters:
   DomainName:
     Type: String
-    Default: "www.example.com"
+    Default: "example.com"
 Resources:
   MyHostedZone:
     Type: "AWS::Route53::HostedZone"
@@ -11,7 +11,7 @@ Resources:
       Name: !Ref "DomainName"
       VPCs:
         - VPCId: !ImportValue "infrastructure-vpc"
-          VPCRegion: AWS::Region
+          VPCRegion: !Ref "AWS::Region"
   MyTXTRecordSet:
     Type: "AWS::Route53::RecordSet"
     Properties:
@@ -56,6 +56,26 @@ Resources:
         - "2001:0db8:85a3:0:0:8a2e:0370:7334"
         - "2001:0db8:3c4d:0015:0000:0000:1a2f:1a2b"
         - "0:0:0:0:0:0:A00:1"
+  MyCNAMERecordSet:
+    Type: "AWS::Route53::RecordSet"
+    Properties:
+      Comment: "A valid CNAME Record"
+      HostedZoneId: !Ref "MyHostedZone"
+      Name: "cname1.example.com"
+      Type: "CNAME"
+      TTL: "300"
+      ResourceRecords:
+        - "hostname.example.com"
+  MyCNAME2RecordSet:
+    Type: "AWS::Route53::RecordSet"
+    Properties:
+      Comment: "A valid CNAME Record"
+      HostedZoneId: !Ref "MyHostedZone"
+      Name: "cname2.example.com"
+      Type: "CNAME"
+      TTL: "300"
+      ResourceRecords:
+        - !Sub "www.${DomainName}"
   MyRecordSetGroup:
     Type: "AWS::Route53::RecordSetGroup"
     Properties:

--- a/test/rules/resources/route53/test_recordsets.py
+++ b/test/rules/resources/route53/test_recordsets.py
@@ -34,4 +34,4 @@ class TestRoute53RecordSets(BaseRuleTestCase):
 
     def test_file_negative_alias(self):
         """Test failure"""
-        self.helper_file_negative('fixtures/templates/bad/route53.yaml', 22)
+        self.helper_file_negative('fixtures/templates/bad/route53.yaml', 24)


### PR DESCRIPTION
*Issue https://github.com/awslabs/cfn-python-lint/issues/94*

Added basic linting of CNAME records:

* Only 1 value allowed (https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resource-record-sets-values-basic.html#rrsets-values-basic-value)
* Simple domain name value check for the value. 

Along the way:

* [Since Aliases can be used for everything except NS and SOA records](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resource-record-sets-values-alias.html#rrsets-values-alias-type), moved the `AliasTarget` check to the central RecordSet check
* All RecordSets are now checked on being a dict (a.k.a. instrinsic function logic), this complexity is not checked (yet)
* Removed all the full Path information from the error messages for clarity  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
