### PR TITLE
Fix Output check when ImportValue is part of another intrinsic function(s)

### DIFF
--- a/src/cfnlint/rules/outputs/ImportValue.py
+++ b/src/cfnlint/rules/outputs/ImportValue.py
@@ -40,7 +40,10 @@ class ImportValue(CloudFormationLintRule):
         # Check if the importvalue is set on the Value
         for importvalue_tree in importvalue_trees:
             if importvalue_tree[2] == 'Value':
-                message = 'The value of output ({0}) is imported from another output ({1})'
-                matches.append(RuleMatch(importvalue_tree, message.format(importvalue_tree[1], importvalue_tree[-1])))
+
+                # ImportValue can be used within other intrinic function, exclude those
+                if importvalue_tree[3] == 'Fn::ImportValue':
+                    message = 'The value of output ({0}) is imported from another output ({1})'
+                    matches.append(RuleMatch(importvalue_tree, message.format(importvalue_tree[1], importvalue_tree[-1])))
 
         return matches

--- a/test/fixtures/templates/good/outputs/importvalue.yaml
+++ b/test/fixtures/templates/good/outputs/importvalue.yaml
@@ -1,0 +1,12 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  myInstance:
+    Type: AWS::EC2::Instance
+    Properties:
+      ImageId: ami-123456
+Outputs:
+  GitlabDomain:
+    Description: The domain name of the Gitlab server
+    Value: !Sub
+    - 'gitlab.${zone}'
+    - zone: !ImportValue infra-ZonePublic-Name

--- a/test/rules/outputs/test_importvalue.py
+++ b/test/rules/outputs/test_importvalue.py
@@ -24,6 +24,9 @@ class TestOutputImportValue(BaseRuleTestCase):
         """Setup"""
         super(TestOutputImportValue, self).setUp()
         self.collection.register(ImportValue())
+        self.success_templates = [
+            'fixtures/templates/good/outputs/importvalue.yaml',
+        ]
 
     def test_file_positive(self):
         """Test Positive"""


### PR DESCRIPTION
*Issue https://github.com/awslabs/cfn-python-lint/issues/291*

ImportValue can actually be used by another instrinsic function, e.g. a `!Sub` which is a totally valid scenario. Fixed this and added the sample template from the issue as a "good" testing scenario

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
