### PR TITLE
Support the new dynamic reference option for password fields

### DIFF
--- a/src/cfnlint/helpers.py
+++ b/src/cfnlint/helpers.py
@@ -40,6 +40,9 @@ REGEX_ALPHANUMERIC = re.compile('^[a-zA-Z0-9]*$')
 REGEX_CIDR = re.compile(r'^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$')
 REGEX_IPV4 = re.compile(r'^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$')
 REGEX_IPV6 = re.compile(r'^(((?=.*(::))(?!.*\3.+\3))\3?|[\dA-F]{1,4}:)([\dA-F]{1,4}(\3|:\b)|\2){5}(([\dA-F]{1,4}(\3|:\b|$)|\2){2}|(((2[0-4]|1\d|[1-9])?\d|25[0-5])\.?\b){4})\Z', re.I | re.S)
+REGEX_DYN_REF_SSM = re.compile(r'^.*{{resolve:ssm:[a-zA-Z0-9_.-/]+:\d+}}.*$')
+REGEX_DYN_REF_SSM_SECURE = re.compile(r'^.*{{resolve:ssm-secure:[a-zA-Z0-9_.-/]+:\d+}}.*$')
+
 
 AVAILABILITY_ZONES = [
     'us-east-1a', 'us-east-1b', 'us-east-1c', 'us-east-1d', 'us-east-1e', 'us-east-1f',

--- a/test/fixtures/templates/good/resources/properties/password.yaml
+++ b/test/fixtures/templates/good/resources/properties/password.yaml
@@ -1,17 +1,16 @@
 ---
 AWSTemplateFormatVersion: "2010-09-09"
 Description: >
-  Bad Template for testing Password Parameters
+  Good Template for testing Password Parameters
 Parameters:
   MyPassword:
     Type: String
     Default: String
     Description: String
-  MyNewPassword:
+    NoEcho: True
+  Environment:
     Type: String
-    Default: String
-    Description: String
-    NoEcho: False
+    Default: "Dev"
 Resources:
   MyDB:
     Type: AWS::RDS::DBInstance
@@ -22,14 +21,14 @@ Resources:
       MasterUsername: MyName
       MasterUserPassword: !Ref MyPassword
     DeletionPolicy: Snapshot
-  MyNewDB:
+  myNewDb:
     Type: AWS::RDS::DBInstance
     Properties:
       AllocatedStorage: '5'
       DBInstanceClass: db.m1.small
       Engine: MySQL
       MasterUsername: MyName
-      MasterUserPassword: !Ref MyNewPassword
+      MasterUserPassword: '{{resolve:ssm-secure:MySecurePassword:1}}'
     DeletionPolicy: Snapshot
   myThirdDb:
     Type: AWS::RDS::DBInstance
@@ -38,5 +37,11 @@ Resources:
       DBInstanceClass: db.m1.small
       Engine: MySQL
       MasterUsername: MyName
-      MasterUserPassword: '{{resolve:ssm:IAMUserPassword:10}}'
+      MasterUserPassword: 'Prefix-{{resolve:ssm-secure:MySecurePassword:1}}-Postfix'
     DeletionPolicy: Snapshot
+  MyIAMUser:
+    Type: AWS::IAM::User
+    Properties:
+      UserName: !Sub ${Environment}-{{resolve:ssm:MyUsername:1}}
+      LoginProfile:
+        Password: !Sub 'list-{{resolve:ssm-secure:MySecurePassword:1}}'

--- a/test/rules/resources/properties/test_password.py
+++ b/test/rules/resources/properties/test_password.py
@@ -24,6 +24,9 @@ class TestPropertyPassword(BaseRuleTestCase):
         """Setup"""
         super(TestPropertyPassword, self).setUp()
         self.collection.register(Password())
+        self.success_templates = [
+            'fixtures/templates/good/resources/properties/password.yaml'
+        ]
 
     def test_file_positive(self):
         """Test Positive"""
@@ -31,4 +34,4 @@ class TestPropertyPassword(BaseRuleTestCase):
 
     def test_file_negative(self):
         """Test failure"""
-        self.helper_file_negative('fixtures/templates/bad/properties_password.yaml', 2)
+        self.helper_file_negative('fixtures/templates/bad/properties_password.yaml', 3)


### PR DESCRIPTION
*Issue #, if available:*
- Fixes #290
*Description of changes:*
- Supports checking dynamic references for password fields.
- Validates that passwords are secure dynamic references

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
