### PR TITLE
Support additional attributes in checks of properties

### DIFF
--- a/src/cfnlint/rules/resources/properties/Required.py
+++ b/src/cfnlint/rules/resources/properties/Required.py
@@ -128,6 +128,8 @@ class Required(CloudFormationLintRule):
         for resourcename, resourcevalue in cfn.get_resources().items():
             if 'Properties' in resourcevalue and 'Type' in resourcevalue:
                 resourcetype = resourcevalue['Type']
+                if resourcetype.startswith('Custom::'):
+                    resourcetype = 'AWS::CloudFormation::CustomResource'
                 if resourcetype in self.resourcetypes:
                     tree = ['Resources', resourcename, 'Properties']
                     matches.extend(self.propertycheck(

--- a/test/fixtures/templates/bad/properties_required.yaml
+++ b/test/fixtures/templates/bad/properties_required.yaml
@@ -723,3 +723,13 @@ Resources:
         Type: S3
         Location:
           Ref: ArtifactStoreS3Location
+  CustomResource1:
+    Type: 'AWS::CloudFormation::CustomResource'
+    Properties:
+      # ServiceToken: arn
+      StackName: StackName
+  CustomResource2:
+    Type: 'Custom::CustomResource'
+    Properties:
+      # ServiceToken: arn
+      StackName: StackName

--- a/test/fixtures/templates/good/resource_properties.yaml
+++ b/test/fixtures/templates/good/resource_properties.yaml
@@ -593,6 +593,16 @@ Resources:
           KeyType: HASH
         - AttributeName: !Ref SortKeyName
           KeyType: RANGE
+  CustomResource1:
+    Type: 'AWS::CloudFormation::CustomResource'
+    Properties:
+      ServiceToken: arn
+      StackName: StackName
+  CustomResource2:
+    Type: 'Custom::CustomResource'
+    Properties:
+      ServiceToken: arn
+      StackName: StackName
   Distribution:
     Type: "AWS::CloudFront::Distribution"
     Properties:

--- a/test/rules/resources/properties/test_required.py
+++ b/test/rules/resources/properties/test_required.py
@@ -31,7 +31,7 @@ class TestResourceConfiguration(BaseRuleTestCase):
 
     def test_file_negative(self):
         """Test failure"""
-        self.helper_file_negative('fixtures/templates/bad/properties_required.yaml', 10)
+        self.helper_file_negative('fixtures/templates/bad/properties_required.yaml', 12)
 
     def test_file_negative_generic(self):
         """Generic Test failure"""


### PR DESCRIPTION
*Issue #, if available:*
- Fixes #289 

*Description of changes:*
- Checks spec for additional properties attribute and uses it to ignore additional properties in the template
- Add support for checking custom resources (Custom::*) for required attributes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
