### PR TITLE
Refactored the Formatters

### DIFF
--- a/src/cfnlint/__main__.py
+++ b/src/cfnlint/__main__.py
@@ -24,11 +24,11 @@ LOGGER = logging.getLogger('cfnlint')
 
 def main():
     """Main function"""
-    (args, filename, template, rules, fmt, formatter) = cfnlint.core.get_template_args_rules(sys.argv[1:])
+    (args, filename, template, rules, formatter) = cfnlint.core.get_template_args_rules(sys.argv[1:])
 
     return(
         cfnlint.core.run_cli(
-            filename, template, rules, fmt,
+            filename, template, rules,
             args.regions,
             args.override_spec, formatter))
 

--- a/src/cfnlint/formatters/__init__.py
+++ b/src/cfnlint/formatters/__init__.py
@@ -14,11 +14,24 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
+import json
+from cfnlint import Match
 
+class BaseFormatter(object):
+    """Base Formatter class"""
 
-class Formatter(object):
+    def _format(self, match):
+        """Format the specific match"""
+
+    def print_matches(self, matches):
+        """Output all the matches"""
+        # Output each match on a separate line by default
+        for match in matches:
+            print(self._format(match))
+
+class Formatter(BaseFormatter):
     """Generic Formatter"""
-    def format(self, match):
+    def _format(self, match):
         """Format output"""
         formatstr = u'{0} {1}\n{2}:{3}:{4}\n'
         return formatstr.format(
@@ -29,10 +42,50 @@ class Formatter(object):
             match.columnnumber
         )
 
+class JsonFormatter(BaseFormatter):
+    """Json Formatter"""
 
-class QuietFormatter(object):
+    class CustomEncoder(json.JSONEncoder):
+        """Custom Encoding for the Match Object"""
+        # pylint: disable=E0202
+        def default(self, o):
+            if isinstance(o, Match):
+                if o.rule.id[0] == 'W':
+                    level = 'Warning'
+                else:
+                    level = 'Error'
+
+                return {
+                    'Rule': {
+                        'Id': o.rule.id,
+                        'Description': o.rule.description,
+                        'ShortDescription': o.rule.shortdesc,
+                        'Source': o.rule.source_url
+                    },
+                    'Location': {
+                        'Start': {
+                            'ColumnNumber': o.columnnumber,
+                            'LineNumber': o.linenumber,
+                        },
+                        'End': {
+                            'ColumnNumber': o.columnnumberend,
+                            'LineNumber': o.linenumberend,
+                        }
+                    },
+                    'Level': level,
+                    'Message': o.message,
+                    'Filename': o.filename,
+                }
+            return {'__{}__'.format(o.__class__.__name__): o.__dict__}
+
+    def print_matches(self, matches):
+        # JSON formatter outputs a single JSON object
+        print(json.dumps(matches, indent=4, cls=self.CustomEncoder))
+
+
+class QuietFormatter(BaseFormatter):
     """Quiet Formatter"""
-    def format(self, match):
+    def _format(self, match):
         """Format output"""
         formatstr = u'{0} {1}:{2}'
         return formatstr.format(
@@ -42,9 +95,9 @@ class QuietFormatter(object):
         )
 
 
-class ParseableFormatter(object):
-    """Parseable Formmatter"""
-    def format(self, match):
+class ParseableFormatter(BaseFormatter):
+    """Parseable Formatter"""
+    def _format(self, match):
         """Format output"""
         formatstr = u'{0}:{1}:{2}:{3}:{4}:{5}:{6}'
         return formatstr.format(

--- a/test/module/core/test_run_checks.py
+++ b/test/module/core/test_run_checks.py
@@ -27,7 +27,7 @@ class TestRunChecks(BaseTestCase):
         """Test success run"""
 
         filename = 'fixtures/templates/good/generic.yaml'
-        (args, filename, template, rules, _, _) = cfnlint.core.get_template_args_rules([
+        (args, filename, template, rules, _) = cfnlint.core.get_template_args_rules([
             '--template', filename])
 
         results = cfnlint.core.run_checks(
@@ -39,7 +39,7 @@ class TestRunChecks(BaseTestCase):
         """Test bad template"""
 
         filename = 'fixtures/templates/quickstart/nat-instance.json'
-        (args, filename, template, rules, _, _) = cfnlint.core.get_template_args_rules([
+        (args, filename, template, rules, _) = cfnlint.core.get_template_args_rules([
             '--template', filename])
 
         results = cfnlint.core.run_checks(

--- a/test/module/core/test_run_cli.py
+++ b/test/module/core/test_run_cli.py
@@ -82,7 +82,7 @@ class TestCli(BaseTestCase):
     def test_template_config(self):
         """Test template config"""
         filename = 'fixtures/templates/good/core/config_parameters.yaml'
-        (args, _, _, _, _, _) = cfnlint.core.get_template_args_rules([
+        (args, _, _, _, _) = cfnlint.core.get_template_args_rules([
             '--template', filename, '--ignore-bad-template'])
 
         self.assertEqual(vars(args), {
@@ -102,7 +102,7 @@ class TestCli(BaseTestCase):
     def test_positional_template_parameters(self):
         """Test overriding parameters"""
         filename = 'fixtures/templates/good/core/config_parameters.yaml'
-        (args, _, _, _, _, _) = cfnlint.core.get_template_args_rules([
+        (args, _, _, _, _) = cfnlint.core.get_template_args_rules([
             filename, '--ignore-bad-template',
             '--ignore-checks', 'E0000'])
 
@@ -123,7 +123,7 @@ class TestCli(BaseTestCase):
     def test_override_parameters(self):
         """Test overriding parameters"""
         filename = 'fixtures/templates/good/core/config_parameters.yaml'
-        (args, _, _, _, _, _) = cfnlint.core.get_template_args_rules([
+        (args, _, _, _, _) = cfnlint.core.get_template_args_rules([
             '--template', filename, '--ignore-bad-template',
             '--ignore-checks', 'E0000'])
 
@@ -145,7 +145,7 @@ class TestCli(BaseTestCase):
         """ Test bad formatting in config"""
 
         filename = 'fixtures/templates/bad/core/config_parameters.yaml'
-        (args, _, _, _, _, _) = cfnlint.core.get_template_args_rules([
+        (args, _, _, _, _) = cfnlint.core.get_template_args_rules([
             '--template', filename, '--ignore-bad-template'])
 
         self.assertEqual(vars(args), {


### PR DESCRIPTION
While writing our own custom wrapper on `cfn-lint`, I noticed the formatter was set up a bit less optimal:

- The Format of outputting a Match was defined in a `Formatter` class
- The `print_matches()` had a "special" JSON check in there
- There was a `CustomEncoder` class in the Core for formatting JSON output
- There were 2 formatter parameters all over the place

Tried to clean it up a bit:

- Created a BaseFormatter containing a `_format` method and the `print_rules()` method
- Added a `JSONFormatter` for the outputting of json to make it less "special (. Moved the CustomEncoder class into that Formatter)
- Refactored back to a single `Formatter` parameter

Possible next step could be to make the Formatter pluggable (like the rules) so custom formatting can be specified. (That would probably refactor the "if formatter ==" code away... That part feels a bit meh atm)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
