### PR TITLE
Add rules for Outputs Descriptions and Template Description type

### DIFF
--- a/src/cfnlint/helpers.py
+++ b/src/cfnlint/helpers.py
@@ -78,7 +78,8 @@ LIMITS = {
     },
     'outputs': {
         'number': 60,
-        'name': 255  # in characters
+        'name': 255,  # in characters
+        'description': 1024  # in bytes
     },
     'parameters': {
         'number': 60,

--- a/src/cfnlint/rules/outputs/Description.py
+++ b/src/cfnlint/rules/outputs/Description.py
@@ -1,0 +1,44 @@
+"""
+  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this
+  software and associated documentation files (the "Software"), to deal in the Software
+  without restriction, including without limitation the rights to use, copy, modify,
+  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+import six
+from cfnlint import CloudFormationLintRule
+from cfnlint import RuleMatch
+
+
+class Description(CloudFormationLintRule):
+    """Check if Outputs Descriptions are only string values"""
+    id = 'E6005'
+    shortdesc = 'Outputs descriptions can only be strings'
+    description = 'Outputs descriptions can only be strings'
+    source_url = 'https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/outputs-section-structure.html'
+    tags = ['outputs']
+
+    def match(self, cfn):
+        """Check CloudFormation Outputs"""
+
+        matches = list()
+
+        outputs = cfn.template.get('Outputs', {})
+        if outputs:
+            for output_name, output_value in outputs.items():
+                description = output_value.get('Description')
+                if description:
+                    if not isinstance(description, six.string_types):
+                        message = 'Output Description can only be a string'
+                        matches.append(RuleMatch(['Outputs', output_name, 'Description'], message))
+
+        return matches

--- a/src/cfnlint/rules/outputs/LimitDescription.py
+++ b/src/cfnlint/rules/outputs/LimitDescription.py
@@ -1,0 +1,45 @@
+"""
+  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this
+  software and associated documentation files (the "Software"), to deal in the Software
+  without restriction, including without limitation the rights to use, copy, modify,
+  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+from cfnlint import CloudFormationLintRule
+from cfnlint import RuleMatch
+from cfnlint.helpers import LIMITS
+
+
+class LimitDescription(CloudFormationLintRule):
+    """Check if maximum Output description size limit is exceeded"""
+    id = 'E6012'
+    shortdesc = 'Output description limit not exceeded'
+    description = 'Check the size of Output description in the template is less than the upper limit'
+    source_url = 'https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/outputs-section-structure.html'
+    tags = ['outputs', 'limits']
+
+    def match(self, cfn):
+        """Check CloudFormation Outputs"""
+
+        matches = list()
+
+        outputs = cfn.template.get('Outputs', {})
+
+        for output_name, output_value in outputs.items():
+            description = output_value.get('Description')
+            if description:
+                path = ['Outputs', output_name, 'Description']
+                if len(description) > LIMITS['outputs']['description']:
+                    message = 'The length of output description ({0}) exceeds the limit ({1})'
+                    matches.append(RuleMatch(path, message.format(len(description), LIMITS['outputs']['description'])))
+
+        return matches

--- a/src/cfnlint/rules/templates/Description.py
+++ b/src/cfnlint/rules/templates/Description.py
@@ -1,0 +1,40 @@
+"""
+  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this
+  software and associated documentation files (the "Software"), to deal in the Software
+  without restriction, including without limitation the rights to use, copy, modify,
+  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+import six
+from cfnlint import CloudFormationLintRule
+from cfnlint import RuleMatch
+
+
+class Description(CloudFormationLintRule):
+    """Check Template Description is only a String"""
+    id = 'E1004'
+    shortdesc = 'Template description can only be a string'
+    description = 'Template description can only be a string'
+    source_url = 'https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-description-structure.html'
+    tags = ['description']
+
+    def match(self, cfn):
+        """Basic Matching"""
+        matches = list()
+
+        description = cfn.template.get('Description')
+
+        if description:
+            if not isinstance(description, six.string_types):
+                message = 'Description can only be a string'
+                matches.append(RuleMatch(['Description'], message))
+        return matches

--- a/test/fixtures/templates/bad/outputs/description.yaml
+++ b/test/fixtures/templates/bad/outputs/description.yaml
@@ -1,0 +1,12 @@
+---
+AWSTemplateFormatVersion: "2010-09-09"
+Resources: {}
+Outputs:
+  outputSubFunction:
+    Description: !Sub "${AWS::Region}"
+    Value: Test
+  outputDescriptionLength:
+    Description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. In aliquet justo nibh, a venenatis justo suscipit et. Sed vulputate est non vulputate cursus. In et mollis nunc. Ut semper justo nec odio dignissim semper. Sed interdum elementum ante. Phasellus bibendum mattis ultrices. Nullam varius dui mi, ac fermentum ante sodales nec. Mauris id libero id turpis sollicitudin imperdiet. Praesent volutpat, elit ut malesuada ultricies, magna velit ullamcorper leo, sagittis pulvinar elit erat faucibus felis.
+
+    Morbi sagittis pretium ligula in tristique. Suspendisse odio lectus, condimentum eget egestas pharetra, elementum sit amet sapien. Nullam ipsum eros, ullamcorper ut mi nec, maximus sagittis lacus. In laoreet quam sit amet ante dictum efficitur. Praesent pellentesque purus sit amet nisl scelerisque feugiat. Phasellus feugiat, ex posuere pharetra eleifend, ipsum libero viverra est, sit amet sodales ipsum urna in quam. Donec sit amet pharetra nibh. Nulla eu fermentum leo, a venenatis urna. Nam ac sagittis magna volutpat."
+    Value: Test

--- a/test/fixtures/templates/bad/templates/description.yaml
+++ b/test/fixtures/templates/bad/templates/description.yaml
@@ -1,0 +1,4 @@
+---
+AWSTemplateFormatVersion: "2010-09-09"
+Description: !Sub "Template for ${AWS::Region}"
+Resources: {}

--- a/test/fixtures/templates/good/outputs/description.yaml
+++ b/test/fixtures/templates/good/outputs/description.yaml
@@ -1,0 +1,7 @@
+---
+AWSTemplateFormatVersion: "2010-09-09"
+Resources: {}
+Outputs:
+  outputDescription:
+    Description: "Smaller description"
+    Value: Test

--- a/test/fixtures/templates/good/templates/description.yaml
+++ b/test/fixtures/templates/good/templates/description.yaml
@@ -1,0 +1,4 @@
+---
+AWSTemplateFormatVersion: "2010-09-09"
+Description: 'Just a String'
+Resources: {}

--- a/test/rules/outputs/test_description.py
+++ b/test/rules/outputs/test_description.py
@@ -1,0 +1,37 @@
+"""
+  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this
+  software and associated documentation files (the "Software"), to deal in the Software
+  without restriction, including without limitation the rights to use, copy, modify,
+  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+from cfnlint.rules.outputs.Description import Description  # pylint: disable=E0401
+from .. import BaseRuleTestCase
+
+
+class TestDescription(BaseRuleTestCase):
+    """Test Output Description"""
+    def setUp(self):
+        """Setup"""
+        super(TestDescription, self).setUp()
+        self.collection.register(Description())
+        self.success_templates = [
+            'fixtures/templates/good/outputs/description.yaml',
+        ]
+
+    def test_file_positive(self):
+        """Test Positive"""
+        self.helper_file_positive()
+
+    def test_file_negative(self):
+        """Test failure"""
+        self.helper_file_negative('fixtures/templates/bad/outputs/description.yaml', 1)

--- a/test/rules/outputs/test_limit_description.py
+++ b/test/rules/outputs/test_limit_description.py
@@ -1,0 +1,37 @@
+"""
+  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this
+  software and associated documentation files (the "Software"), to deal in the Software
+  without restriction, including without limitation the rights to use, copy, modify,
+  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+from cfnlint.rules.outputs.LimitDescription import LimitDescription  # pylint: disable=E0401
+from .. import BaseRuleTestCase
+
+
+class TestLimitDescription(BaseRuleTestCase):
+    """Test Output Description"""
+    def setUp(self):
+        """Setup"""
+        super(TestLimitDescription, self).setUp()
+        self.collection.register(LimitDescription())
+        self.success_templates = [
+            'fixtures/templates/good/outputs/description.yaml',
+        ]
+
+    def test_file_positive(self):
+        """Test Positive"""
+        self.helper_file_positive()
+
+    def test_file_negative(self):
+        """Test failure"""
+        self.helper_file_negative('fixtures/templates/bad/outputs/description.yaml', 1)

--- a/test/rules/templates/test_description.py
+++ b/test/rules/templates/test_description.py
@@ -1,0 +1,37 @@
+"""
+  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this
+  software and associated documentation files (the "Software"), to deal in the Software
+  without restriction, including without limitation the rights to use, copy, modify,
+  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+from cfnlint.rules.templates.Description import Description  # pylint: disable=E0401
+from .. import BaseRuleTestCase
+
+
+class TestDescription(BaseRuleTestCase):
+    """Test template limit size"""
+    def setUp(self):
+        """Setup"""
+        super(TestDescription, self).setUp()
+        self.collection.register(Description())
+        self.success_templates = [
+            'fixtures/templates/good/templates/description.yaml'
+        ]
+
+    def test_file_positive(self):
+        """Test Positive"""
+        self.helper_file_positive()
+
+    def test_file_negative(self):
+        """Test failure"""
+        self.helper_file_negative('fixtures/templates/bad/templates/description.yaml', 1)


### PR DESCRIPTION
*Issue #, if available:*
Fixes #304 

*Description of changes:*
- New rule E1004 to validate that the Template Description is only a String
- New rule E6005 to validate that the Outputs Description is only a String
- New rule E6012 to validate that the Outputs Description is within the length limits.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
