### PR TITLE
Add rule W1019 to make sure that SUB parameters are used in the string

### DIFF
--- a/src/cfnlint/rules/functions/SubParametersUsed.py
+++ b/src/cfnlint/rules/functions/SubParametersUsed.py
@@ -1,0 +1,65 @@
+"""
+  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this
+  software and associated documentation files (the "Software"), to deal in the Software
+  without restriction, including without limitation the rights to use, copy, modify,
+  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+import six
+from cfnlint import CloudFormationLintRule
+from cfnlint import RuleMatch
+
+
+class SubParametersUsed(CloudFormationLintRule):
+    """Check if Sub Parameters are used"""
+    id = 'W1019'
+    shortdesc = 'Sub validation of parameters'
+    description = 'Validate that Fn::Sub Parameters are used'
+    source_url = 'https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-sub.html'
+    tags = ['functions', 'sub']
+
+    def _test_parameters(self, cfn, sub_string, parameters, tree):
+        """Test if sub parmaeters are in the string"""
+
+        matches = list()
+        sub_string_parameters = cfn.get_sub_parameters(sub_string)
+
+        for parameter_name, _ in parameters.items():
+            if parameter_name not in sub_string_parameters:
+                message = 'Parameter {0} not used in Fn::Sub at {1}'
+                matches.append(RuleMatch(
+                    tree, message.format(parameter_name, '/'.join(map(str, tree[:] + [parameter_name])))))
+
+        return matches
+
+    def match(self, cfn):
+        """Check CloudFormation Join"""
+
+        matches = list()
+
+        sub_objs = cfn.search_deep_keys('Fn::Sub')
+
+        for sub_obj in sub_objs:
+            sub_value_obj = sub_obj[-1]
+            tree = sub_obj[:-1]
+            if isinstance(sub_value_obj, list):
+                if len(sub_value_obj) == 2:
+                    sub_string = sub_value_obj[0]
+                    parameters = sub_value_obj[1]
+                    if not isinstance(sub_string, six.string_types):
+                        continue
+                    if not isinstance(parameters, dict):
+                        continue
+                    else:
+                        matches.extend(self._test_parameters(cfn, sub_string, parameters, tree + [1]))
+
+        return matches

--- a/test/fixtures/templates/bad/functions/sub_parameters_used.yaml
+++ b/test/fixtures/templates/bad/functions/sub_parameters_used.yaml
@@ -1,0 +1,30 @@
+---
+AWSTemplateFormatVersion: "2010-09-09"
+Mappings:
+  Authorizers:
+    us-east-1:
+      AccountId: "123456789012"
+      Name: "lambda-us-east-1"
+Resources:
+  Properties:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+        - Action: ['sts:AssumeRole']
+          Effect: Allow
+          Principal:
+            Service: [apigateway.amazonaws.com]
+        Version: '2012-10-17'
+      Policies:
+      - PolicyName: LambdaInvokation
+        PolicyDocument:
+          Statement:
+          - Action: ['lambda:Invoke*']
+            Effect: Allow
+            Resource:
+            - Fn::Sub:
+              - 'arn:aws:lambda:${AWS::Region}:{AccountId}:function:${LambdaName}'
+              - AccountId: !FindInMap [ Authorizers, !Ref "AWS::Region", AccountId ]
+                LambdaName: !FindInMap [ Authorizers, !Ref "AWS::Region", Name ]
+          Version: '2012-10-17'

--- a/test/fixtures/templates/good/functions/sub_parameters_used.yaml
+++ b/test/fixtures/templates/good/functions/sub_parameters_used.yaml
@@ -1,0 +1,30 @@
+---
+AWSTemplateFormatVersion: "2010-09-09"
+Mappings:
+  Authorizers:
+    us-east-1:
+      AccountId: "123456789012"
+      Name: "lambda-us-east-1"
+Resources:
+  Properties:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+        - Action: ['sts:AssumeRole']
+          Effect: Allow
+          Principal:
+            Service: [apigateway.amazonaws.com]
+        Version: '2012-10-17'
+      Policies:
+      - PolicyName: LambdaInvokation
+        PolicyDocument:
+          Statement:
+          - Action: ['lambda:Invoke*']
+            Effect: Allow
+            Resource:
+            - Fn::Sub:
+              - 'arn:aws:lambda:${AWS::Region}:${AccountId}:function:${LambdaName}'
+              - AccountId: !FindInMap [ Authorizers, !Ref "AWS::Region", AccountId ]
+                LambdaName: !FindInMap [ Authorizers, !Ref "AWS::Region", Name ]
+          Version: '2012-10-17'

--- a/test/rules/functions/test_sub_parameters_used.py
+++ b/test/rules/functions/test_sub_parameters_used.py
@@ -1,0 +1,37 @@
+"""
+  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this
+  software and associated documentation files (the "Software"), to deal in the Software
+  without restriction, including without limitation the rights to use, copy, modify,
+  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+from cfnlint.rules.functions.SubParametersUsed import SubParametersUsed  # pylint: disable=E0401
+from .. import BaseRuleTestCase
+
+
+class TestSubParametersUsed(BaseRuleTestCase):
+    """Test Rules Get Att """
+    def setUp(self):
+        """Setup"""
+        super(TestSubParametersUsed, self).setUp()
+        self.collection.register(SubParametersUsed())
+        self.success_templates = [
+            'fixtures/templates/good/functions/sub_parameters_used.yaml',
+        ]
+
+    def test_file_positive(self):
+        """Test Positive"""
+        self.helper_file_positive()
+
+    def test_file_negative(self):
+        """Test failure"""
+        self.helper_file_negative('fixtures/templates/bad/functions/sub_parameters_used.yaml', 1)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- New rule W1019 to show if a Sub parameter isn't used in the string

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
