### PR TITLE
Cidr supports GetAtt

### DIFF
--- a/src/cfnlint/rules/functions/Cidr.py
+++ b/src/cfnlint/rules/functions/Cidr.py
@@ -91,6 +91,7 @@ class Cidr(CloudFormationLintRule):
         supported_functions = [
             'Fn::Select',
             'Ref',
+            'Fn::GetAtt',
             'Fn::ImportValue'
         ]
 
@@ -113,7 +114,7 @@ class Cidr(CloudFormationLintRule):
                         if len(ip_block_obj) == 1:
                             for index_key, _ in ip_block_obj.items():
                                 if index_key not in supported_functions:
-                                    message = 'Cidr ipBlock should be Cidr Range, Ref, or Select for {0}'
+                                    message = 'Cidr ipBlock should be Cidr Range, Ref, GetAtt, or Select for {0}'
                                     matches.append(RuleMatch(
                                         tree[:] + [0], message.format('/'.join(map(str, tree[:] + [0])))))
                     elif isinstance(ip_block_obj, (six.text_type, six.string_types)):


### PR DESCRIPTION
The current E1024 contains a list of supported functions
for Select, Ref and ImportValue, but it should also support
GetAtt. For example when the CidrBlock of the VPC
resource is used.
This commit will fix #320