### PR TITLE
Fix Rule W2501 to not show static password error when dynaminc ref

### DIFF
--- a/src/cfnlint/helpers.py
+++ b/src/cfnlint/helpers.py
@@ -40,8 +40,9 @@ REGEX_ALPHANUMERIC = re.compile('^[a-zA-Z0-9]*$')
 REGEX_CIDR = re.compile(r'^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$')
 REGEX_IPV4 = re.compile(r'^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$')
 REGEX_IPV6 = re.compile(r'^(((?=.*(::))(?!.*\3.+\3))\3?|[\dA-F]{1,4}:)([\dA-F]{1,4}(\3|:\b)|\2){5}(([\dA-F]{1,4}(\3|:\b|$)|\2){2}|(((2[0-4]|1\d|[1-9])?\d|25[0-5])\.?\b){4})\Z', re.I | re.S)
-REGEX_DYN_REF_SSM = re.compile(r'^.*{{resolve:ssm:[a-zA-Z0-9_.-/]+:\d+}}.*$')
-REGEX_DYN_REF_SSM_SECURE = re.compile(r'^.*{{resolve:ssm-secure:[a-zA-Z0-9_.-/]+:\d+}}.*$')
+REGEX_DYN_REF = re.compile(r'^.*{{resolve:.+}}.*$')
+REGEX_DYN_REF_SSM = re.compile(r'^.*{{resolve:ssm:[a-zA-Z0-9_\.\-/]+:\d+}}.*$')
+REGEX_DYN_REF_SSM_SECURE = re.compile(r'^.*{{resolve:ssm-secure:[a-zA-Z0-9_\.\-/]+:\d+}}.*$')
 
 
 AVAILABILITY_ZONES = [

--- a/src/cfnlint/rules/resources/properties/Password.py
+++ b/src/cfnlint/rules/resources/properties/Password.py
@@ -18,7 +18,7 @@ import re
 import six
 from cfnlint import CloudFormationLintRule
 from cfnlint import RuleMatch
-from cfnlint.helpers import REGEX_DYN_REF_SSM, REGEX_DYN_REF_SSM_SECURE
+from cfnlint.helpers import REGEX_DYN_REF_SSM, REGEX_DYN_REF
 
 
 class Password(CloudFormationLintRule):
@@ -44,15 +44,15 @@ class Password(CloudFormationLintRule):
             for tree in trees:
                 obj = tree[-1]
                 if isinstance(obj, (six.string_types)):
-                    if not re.match(REGEX_DYN_REF_SSM_SECURE, obj):
+                    if re.match(REGEX_DYN_REF, obj):
                         if re.match(REGEX_DYN_REF_SSM, obj):
                             message = 'Password should use a secure dynamic reference for %s' % (
                                 '/'.join(map(str, tree[:-1])))
                             matches.append(RuleMatch(tree[:-1], message))
-                        else:
-                            message = 'Password shouldn\'t be hardcoded for %s' % (
-                                '/'.join(map(str, tree[:-1])))
-                            matches.append(RuleMatch(tree[:-1], message))
+                    else:
+                        message = 'Password shouldn\'t be hardcoded for %s' % (
+                            '/'.join(map(str, tree[:-1])))
+                        matches.append(RuleMatch(tree[:-1], message))
                 elif isinstance(obj, dict):
                     if len(obj) == 1:
                         for key, value in obj.items():

--- a/test/fixtures/templates/good/functions/dynamic_reference.yaml
+++ b/test/fixtures/templates/good/functions/dynamic_reference.yaml
@@ -13,7 +13,7 @@ Resources:
       DBInstanceClass: db.m1.small
       Engine: MySQL
       MasterUsername: '{{resolve:ssm:MyUsername:1}}'
-      MasterUserPassword: '{{resolve:ssm-secure:MySecurePassword:1}}'
+      MasterUserPassword: '{{resolve:ssm-secure:My-Secure-Password:1}}'
     DeletionPolicy: Snapshot
   MyIAMUser:
     Type: AWS::IAM::User


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Fix Rule W2501 to not sure a static password error when there is a syntax issue with the dynamic ref
- Fix Dynamic Ref regex to escape the dot and dash and allow them with dynamic refs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
