### PR TITLE
Use list literal instead of list()

### DIFF
--- a/docs/getting_started/rules.md
+++ b/docs/getting_started/rules.md
@@ -71,7 +71,7 @@ class MyNewRule(CloudFormationLintRule):
     def match(self, cfn):
         """Basic Rule Matching"""
 
-        matches = list()
+        matches = []
 
         # Your Rule code goes here
 
@@ -208,7 +208,7 @@ The following snippet is a simple example on checking specific property values:
 ```python
 def check_value(self, value, path):
     """Check SecurityGroup descriptions"""
-    matches = list()
+    matches = []
     full_path = ('/'.join(str(x) for x in path))
 
     # Check max length
@@ -219,7 +219,7 @@ def check_value(self, value, path):
 def match(self, cfn):
     """Check SecurityGroup descriptions"""
 
-    matches = list()
+    matches = []
 
     resources = cfn.get_resources(['AWS::EC2::SecurityGroup'])
 

--- a/examples/rules/PropertiesTagsIncluded.py
+++ b/examples/rules/PropertiesTagsIncluded.py
@@ -31,7 +31,7 @@ class PropertiesTagsIncluded(CloudFormationLintRule):
         resourcespecs = cfnlint.helpers.RESOURCE_SPECS[region]
         resourcetypes = resourcespecs['ResourceTypes']
 
-        matches = list()
+        matches = []
         for resourcetype, resourceobj in resourcetypes.items():
             propertiesobj = resourceobj.get('Properties')
             if propertiesobj:
@@ -43,7 +43,7 @@ class PropertiesTagsIncluded(CloudFormationLintRule):
     def match(self, cfn):
         """Check Tags for required keys"""
 
-        matches = list()
+        matches = []
 
         all_tags = cfn.search_deep_keys('Tags')
         all_tags = [x for x in all_tags if x[0] == 'Resources']

--- a/examples/rules/PropertiesTagsRequired.py
+++ b/examples/rules/PropertiesTagsRequired.py
@@ -28,7 +28,7 @@ class PropertiesTagsRequired(CloudFormationLintRule):
     def match(self, cfn):
         """Check Tags for required keys"""
 
-        matches = list()
+        matches = []
 
         required_tags = ['CostCenter', 'ApplicationName']
 

--- a/src/cfnlint/__init__.py
+++ b/src/cfnlint/__init__.py
@@ -164,7 +164,7 @@ class RulesCollection(object):
 
     def resource_property(self, filename, cfn, path, properties, resource_type, property_type):
         """Run loops in resource checks for embedded properties"""
-        matches = list()
+        matches = []
         property_spec = cfnlint.helpers.RESOURCE_SPECS['us-east-1'].get('PropertyTypes')
         if property_type == 'Tag':
             property_spec_name = 'Tag'
@@ -221,7 +221,7 @@ class RulesCollection(object):
 
     def run_resource(self, filename, cfn, resource_type, resource_properties, path):
         """Run loops in resource checks for embedded properties"""
-        matches = list()
+        matches = []
         resource_spec = cfnlint.helpers.RESOURCE_SPECS['us-east-1'].get('ResourceTypes')
         if resource_properties and resource_type in resource_spec:
             resource_spec_properties = resource_spec.get(resource_type, {}).get('Properties')
@@ -259,7 +259,7 @@ class RulesCollection(object):
 
     def run(self, filename, cfn):
         """Run rules"""
-        matches = list()
+        matches = []
         for rule in self.rules:
             try:
                 matches.extend(rule.matchall(filename, cfn))
@@ -423,7 +423,7 @@ class Template(object):
     def get_resource_names(self):
         """Get all the Resource Names"""
         LOGGER.debug('Get the names of all resources from template...')
-        results = list()
+        results = []
         resources = self.template.get('Resources', {})
         if isinstance(resources, dict):
             for resourcename, _ in resources.items():
@@ -434,7 +434,7 @@ class Template(object):
     def get_parameter_names(self):
         """Get all Parameter Names"""
         LOGGER.debug('Get names of all parameters from template...')
-        results = list()
+        results = []
         parameters = self.template.get('Parameters', {})
         if isinstance(parameters, dict):
             for parametername, _ in parameters.items():
@@ -524,7 +524,7 @@ class Template(object):
                     if results:
                         return results
         elif isinstance(properties, list):
-            matches = list()
+            matches = []
             for index, item in enumerate(properties):
                 results = None
                 if isinstance(item, dict):
@@ -532,7 +532,7 @@ class Template(object):
                         for sub_key, sub_value in item.items():
                             if sub_key in cfnlint.helpers.CONDITION_FUNCTIONS:
                                 cond_values = self.get_condition_values(sub_value)
-                                results = list()
+                                results = []
                                 for cond_value in cond_values:
                                     result_path = path[:] + [index, sub_key] + cond_value['Path']
                                     results.extend(
@@ -551,12 +551,12 @@ class Template(object):
                     matches.extend(results)
             return matches
 
-        return list()
+        return []
 
     def get_resource_properties(self, keys):
         """Filter keys of template"""
         LOGGER.debug('Get Properties from a resource: %s', keys)
-        matches = list()
+        matches = []
         resourcetype = keys.pop(0)
         for resource_name, resource_value in self.get_resources(resourcetype).items():
             path = ['Resources', resource_name, 'Properties']
@@ -570,7 +570,7 @@ class Template(object):
     # pylint: disable=dangerous-default-value
     def _search_deep_keys(self, searchText, cfndict, path):
         """Search deep for keys and get their values"""
-        keys = list()
+        keys = []
         if isinstance(cfndict, dict):
             for key in cfndict:
                 pathprop = path[:]
@@ -606,7 +606,7 @@ class Template(object):
     def get_condition_values(self, template, path=[]):
         """Evaluates conditions and brings back the values"""
         LOGGER.debug('Get condition values...')
-        matches = list()
+        matches = []
         if not isinstance(template, list):
             return matches
         if not len(template) == 3:
@@ -656,7 +656,7 @@ class Template(object):
 
         """
         LOGGER.debug('Get the value for key %s in %s', key, obj)
-        matches = list()
+        matches = []
 
         if not isinstance(obj, dict):
             return None
@@ -774,7 +774,7 @@ class Template(object):
                                 check_join=None, check_sub=None, **kwargs):
         """ Check Resource Properties """
         LOGGER.debug('Check property %s for %s', resource_property, resource_type)
-        matches = list()
+        matches = []
         resources = self.get_resources(resource_type=resource_type)
         for resource_name, resource_object in resources.items():
             properties = resource_object.get('Properties', {})
@@ -800,7 +800,7 @@ class Template(object):
             Check the value
         """
         LOGGER.debug('Check value %s for %s', key, obj)
-        matches = list()
+        matches = []
         values_obj = self.get_values(obj=obj, key=key)
         new_path = path[:] + [key]
         if not values_obj:
@@ -882,14 +882,14 @@ class Runner(object):
     def run(self):
         """Run rules"""
         LOGGER.debug('Run scan of template...')
-        matches = list()
+        matches = []
         if self.cfn.template is not None:
             matches.extend(
                 self.rules.run(
                     self.filename, self.cfn))
 
         # uniq the list of incidents
-        return_matches = list()
+        return_matches = []
         for _, match in enumerate(matches):
             if not any(match == u for u in return_matches):
                 return_matches.append(match)

--- a/src/cfnlint/core.py
+++ b/src/cfnlint/core.py
@@ -286,7 +286,7 @@ def run_checks(filename, template, rules, regions):
                 LOGGER.error('Supported regions are %s', REGIONS)
                 exit(32)
 
-    matches = list()
+    matches = []
 
     runner = cfnlint.Runner(rules, filename, template, regions)
     matches.extend(runner.transform())

--- a/src/cfnlint/rules/conditions/Configuration.py
+++ b/src/cfnlint/rules/conditions/Configuration.py
@@ -37,7 +37,7 @@ class Configuration(CloudFormationLintRule):
     def match(self, cfn):
         """Check CloudFormation Conditions"""
 
-        matches = list()
+        matches = []
 
         conditions = cfn.template.get('Conditions', {})
         if conditions:

--- a/src/cfnlint/rules/conditions/Used.py
+++ b/src/cfnlint/rules/conditions/Used.py
@@ -30,8 +30,8 @@ class Used(CloudFormationLintRule):
     def match(self, cfn):
         """Check CloudFormation Conditions"""
 
-        matches = list()
-        ref_conditions = list()
+        matches = []
+        ref_conditions = []
 
         conditions = cfn.template.get('Conditions', {})
         if conditions:

--- a/src/cfnlint/rules/functions/Base64.py
+++ b/src/cfnlint/rules/functions/Base64.py
@@ -30,7 +30,7 @@ class Base64(CloudFormationLintRule):
     def match(self, cfn):
         """Check CloudFormation Base64"""
 
-        matches = list()
+        matches = []
 
         base64_objs = cfn.search_deep_keys('Fn::Base64')
         for base64_obj in base64_objs:

--- a/src/cfnlint/rules/functions/Cidr.py
+++ b/src/cfnlint/rules/functions/Cidr.py
@@ -31,7 +31,7 @@ class Cidr(CloudFormationLintRule):
 
     def check_parameter_count(self, cfn, parameter_name):
         """Check Count Parameter if used"""
-        matches = list()
+        matches = []
         parameter_obj = cfn.get_parameters().get(parameter_name, {})
         if parameter_obj:
             tree = ['Parameters', parameter_name]
@@ -56,7 +56,7 @@ class Cidr(CloudFormationLintRule):
 
     def check_parameter_size_mask(self, cfn, parameter_name):
         """Check SizeMask Parameter if used"""
-        matches = list()
+        matches = []
         parameter_obj = cfn.get_parameters().get(parameter_name, {})
         if parameter_obj:
             tree = ['Parameters', parameter_name]
@@ -84,7 +84,7 @@ class Cidr(CloudFormationLintRule):
     def match(self, cfn):
         """Check CloudFormation Cidr"""
 
-        matches = list()
+        matches = []
 
         cidr_objs = cfn.search_deep_keys('Fn::Cidr')
 

--- a/src/cfnlint/rules/functions/DynamicReferenceSecureString.py
+++ b/src/cfnlint/rules/functions/DynamicReferenceSecureString.py
@@ -57,7 +57,7 @@ class DynamicReferenceSecureString(CloudFormationLintRule):
 
     def check_dyn_ref_value(self, value, path):
         """Chec item type"""
-        matches = list()
+        matches = []
 
         if isinstance(value, six.string_types):
             if re.match(cfnlint.helpers.REGEX_DYN_REF_SSM_SECURE, value):
@@ -69,7 +69,7 @@ class DynamicReferenceSecureString(CloudFormationLintRule):
 
     def check_value(self, value, path, **kwargs):
         """Check Value"""
-        matches = list()
+        matches = []
         item_type = kwargs.get('item_type', {})
         if item_type in ['Map']:
             if isinstance(value, dict):
@@ -85,7 +85,7 @@ class DynamicReferenceSecureString(CloudFormationLintRule):
     # Need to disable for the function to work
     def check_sub(self, value, path, **kwargs):
         """Check Sub Function Dynamic References"""
-        matches = list()
+        matches = []
         if isinstance(value, list):
             if isinstance(value[0], six.string_types):
                 matches.extend(self.check_dyn_ref_value(value[0], path[:] + [0]))
@@ -96,7 +96,7 @@ class DynamicReferenceSecureString(CloudFormationLintRule):
 
     def check(self, cfn, properties, specs, property_type, path):
         """Check itself"""
-        matches = list()
+        matches = []
 
         for prop in properties:
             if prop in specs:
@@ -125,7 +125,7 @@ class DynamicReferenceSecureString(CloudFormationLintRule):
 
     def match_resource_sub_properties(self, properties, property_type, path, cfn):
         """Match for sub properties"""
-        matches = list()
+        matches = []
 
         property_specs = self.property_specs.get(property_type, {}).get('Properties', {})
         matches.extend(self.check(cfn, properties, property_specs, property_type, path))
@@ -134,7 +134,7 @@ class DynamicReferenceSecureString(CloudFormationLintRule):
 
     def match_resource_properties(self, properties, resource_type, path, cfn):
         """Check CloudFormation Properties"""
-        matches = list()
+        matches = []
         resource_specs = self.resource_specs.get(resource_type, {}).get('Properties', {})
         matches.extend(self.check(cfn, properties, resource_specs, resource_type, path))
 

--- a/src/cfnlint/rules/functions/FindInMap.py
+++ b/src/cfnlint/rules/functions/FindInMap.py
@@ -37,7 +37,7 @@ class FindInMap(CloudFormationLintRule):
             Check that obj is a dict with Ref as the only key
             Mappings only support Ref inside them
         """
-        matches = list()
+        matches = []
 
         if isinstance(obj, dict):
             if len(obj) == 1:
@@ -62,7 +62,7 @@ class FindInMap(CloudFormationLintRule):
     def match(self, cfn):
         """Check CloudFormation GetAtt"""
 
-        matches = list()
+        matches = []
 
         findinmaps = cfn.search_deep_keys('Fn::FindInMap')
         mappings = cfn.get_mappings()

--- a/src/cfnlint/rules/functions/GetAtt.py
+++ b/src/cfnlint/rules/functions/GetAtt.py
@@ -35,7 +35,7 @@ class GetAtt(CloudFormationLintRule):
     def match(self, cfn):
         """Check CloudFormation GetAtt"""
 
-        matches = list()
+        matches = []
 
         getatts = cfn.search_deep_keys('Fn::GetAtt')
         valid_getatts = cfn.get_valid_getatts()

--- a/src/cfnlint/rules/functions/GetAz.py
+++ b/src/cfnlint/rules/functions/GetAz.py
@@ -30,7 +30,7 @@ class GetAz(CloudFormationLintRule):
     def match(self, cfn):
         """Check CloudFormation GetAz"""
 
-        matches = list()
+        matches = []
 
         getaz_objs = cfn.search_deep_keys('Fn::GetAZs')
 

--- a/src/cfnlint/rules/functions/If.py
+++ b/src/cfnlint/rules/functions/If.py
@@ -30,7 +30,7 @@ class If(CloudFormationLintRule):
     def match(self, cfn):
         """Check CloudFormation Conditions"""
 
-        matches = list()
+        matches = []
 
         # Build the list of functions
         iftrees = cfn.search_deep_keys('Fn::If')

--- a/src/cfnlint/rules/functions/IfExist.py
+++ b/src/cfnlint/rules/functions/IfExist.py
@@ -29,7 +29,7 @@ class IfExist(CloudFormationLintRule):
     def match(self, cfn):
         """Check CloudFormation Conditions"""
 
-        matches = list()
+        matches = []
         if_conditions = {}
 
         # Build the list of functions
@@ -43,7 +43,7 @@ class IfExist(CloudFormationLintRule):
                 if_condition = iftree[-1]
             # Conditions can be referenced multiple times, check them once
             if if_condition not in if_conditions:
-                if_conditions[if_condition] = list()
+                if_conditions[if_condition] = []
 
             if_conditions[if_condition].append(iftree)
 

--- a/src/cfnlint/rules/functions/ImportValue.py
+++ b/src/cfnlint/rules/functions/ImportValue.py
@@ -30,7 +30,7 @@ class ImportValue(CloudFormationLintRule):
     def match(self, cfn):
         """Check CloudFormation ImportValue"""
 
-        matches = list()
+        matches = []
 
         iv_objs = cfn.search_deep_keys('Fn::ImportValue')
 

--- a/src/cfnlint/rules/functions/Join.py
+++ b/src/cfnlint/rules/functions/Join.py
@@ -30,7 +30,7 @@ class Join(CloudFormationLintRule):
     def match(self, cfn):
         """Check CloudFormation Join"""
 
-        matches = list()
+        matches = []
 
         join_objs = cfn.search_deep_keys('Fn::Join')
 

--- a/src/cfnlint/rules/functions/Not.py
+++ b/src/cfnlint/rules/functions/Not.py
@@ -29,7 +29,7 @@ class Not(CloudFormationLintRule):
     def match(self, cfn):
         """Check CloudFormation GetAtt"""
 
-        matches = list()
+        matches = []
 
         fnnots = cfn.search_deep_keys('Fn::Not')
         for fnnot in fnnots:

--- a/src/cfnlint/rules/functions/Ref.py
+++ b/src/cfnlint/rules/functions/Ref.py
@@ -30,7 +30,7 @@ class Ref(CloudFormationLintRule):
     def match(self, cfn):
         """Check CloudFormation Ref"""
 
-        matches = list()
+        matches = []
 
         ref_objs = cfn.search_deep_keys('Ref')
 

--- a/src/cfnlint/rules/functions/RefExist.py
+++ b/src/cfnlint/rules/functions/RefExist.py
@@ -47,17 +47,17 @@ class RefExist(CloudFormationLintRule):
     def match(self, cfn):
         """Check CloudFormation Parameters"""
 
-        matches = list()
+        matches = []
 
         # Build the list of refs
         reftrees = cfn.search_deep_keys('Ref')
-        refs = list()
+        refs = []
         for reftree in reftrees:
             refs.append(reftree[-1])
 
         # build the sub lists
         subtrees = cfn.search_deep_keys('Fn::Sub')
-        subs = list()
+        subs = []
         for subtree in subtrees:
             subs.append(subtree[-1])
 

--- a/src/cfnlint/rules/functions/RefInCondition.py
+++ b/src/cfnlint/rules/functions/RefInCondition.py
@@ -30,7 +30,7 @@ class RefInCondition(CloudFormationLintRule):
     def match(self, cfn):
         """Check CloudFormation Ref"""
 
-        matches = list()
+        matches = []
 
         ref_objs = cfn.search_deep_keys('Ref')
         resource_names = cfn.get_resource_names()

--- a/src/cfnlint/rules/functions/Select.py
+++ b/src/cfnlint/rules/functions/Select.py
@@ -30,7 +30,7 @@ class Select(CloudFormationLintRule):
     def match(self, cfn):
         """Check CloudFormation Select"""
 
-        matches = list()
+        matches = []
 
         select_objs = cfn.search_deep_keys('Fn::Select')
 

--- a/src/cfnlint/rules/functions/Split.py
+++ b/src/cfnlint/rules/functions/Split.py
@@ -30,7 +30,7 @@ class Split(CloudFormationLintRule):
     def match(self, cfn):
         """Check CloudFormation Join"""
 
-        matches = list()
+        matches = []
 
         split_objs = cfn.search_deep_keys('Fn::Split')
 

--- a/src/cfnlint/rules/functions/Sub.py
+++ b/src/cfnlint/rules/functions/Sub.py
@@ -30,7 +30,7 @@ class Sub(CloudFormationLintRule):
     def _test_string(self, cfn, sub_string, parameters, tree):
         """Test if a string has appropriate parameters"""
 
-        matches = list()
+        matches = []
         string_params = cfn.get_sub_parameters(sub_string)
         get_atts = cfn.get_valid_getatts()
 
@@ -84,7 +84,7 @@ class Sub(CloudFormationLintRule):
             'Ref'
         ]
 
-        matches = list()
+        matches = []
         for parameter_name, parameter_value_obj in parameters.items():
             param_tree = tree[:] + [parameter_name]
             if isinstance(parameter_value_obj, dict):
@@ -108,7 +108,7 @@ class Sub(CloudFormationLintRule):
     def match(self, cfn):
         """Check CloudFormation Join"""
 
-        matches = list()
+        matches = []
 
         sub_objs = cfn.search_deep_keys('Fn::Sub')
 

--- a/src/cfnlint/rules/functions/SubParametersUsed.py
+++ b/src/cfnlint/rules/functions/SubParametersUsed.py
@@ -30,7 +30,7 @@ class SubParametersUsed(CloudFormationLintRule):
     def _test_parameters(self, cfn, sub_string, parameters, tree):
         """Test if sub parmaeters are in the string"""
 
-        matches = list()
+        matches = []
         sub_string_parameters = cfn.get_sub_parameters(sub_string)
 
         for parameter_name, _ in parameters.items():
@@ -44,7 +44,7 @@ class SubParametersUsed(CloudFormationLintRule):
     def match(self, cfn):
         """Check CloudFormation Join"""
 
-        matches = list()
+        matches = []
 
         sub_objs = cfn.search_deep_keys('Fn::Sub')
 

--- a/src/cfnlint/rules/functions/SubUnneeded.py
+++ b/src/cfnlint/rules/functions/SubUnneeded.py
@@ -30,7 +30,7 @@ class SubUnneeded(CloudFormationLintRule):
     def _test_string(self, cfn, sub_string, tree):
         """Test if a string has appropriate parameters"""
 
-        matches = list()
+        matches = []
         string_params = cfn.get_sub_parameters(sub_string)
 
         if not string_params:
@@ -43,7 +43,7 @@ class SubUnneeded(CloudFormationLintRule):
     def match(self, cfn):
         """Check CloudFormation Join"""
 
-        matches = list()
+        matches = []
 
         sub_objs = cfn.search_deep_keys('Fn::Sub')
 

--- a/src/cfnlint/rules/mappings/Configuration.py
+++ b/src/cfnlint/rules/mappings/Configuration.py
@@ -30,7 +30,7 @@ class Configuration(CloudFormationLintRule):
     def match(self, cfn):
         """Check CloudFormation Parameters"""
 
-        matches = list()
+        matches = []
 
         mappings = cfn.template.get('Mappings', {})
         if mappings:

--- a/src/cfnlint/rules/mappings/KeyName.py
+++ b/src/cfnlint/rules/mappings/KeyName.py
@@ -31,7 +31,7 @@ class KeyName(CloudFormationLintRule):
 
     def check_key(self, key, path, check_alphanumeric=True):
         """ Check the key name for string and alphanumeric"""
-        matches = list()
+        matches = []
         if not isinstance(key, six.string_types):
             message = 'Mapping key ({0}) has to be a string.'
             matches.append(RuleMatch(path[:], message.format(key)))
@@ -44,7 +44,7 @@ class KeyName(CloudFormationLintRule):
     def match(self, cfn):
         """Check CloudFormation Mapping"""
 
-        matches = list()
+        matches = []
 
         mappings = cfn.template.get('Mappings', {})
         for mapping_name, mapping_value in mappings.items():

--- a/src/cfnlint/rules/mappings/LimitAttributes.py
+++ b/src/cfnlint/rules/mappings/LimitAttributes.py
@@ -30,7 +30,7 @@ class LimitAttributes(CloudFormationLintRule):
     def match(self, cfn):
         """Check CloudFormation Mappings"""
 
-        matches = list()
+        matches = []
 
         mappings = cfn.template.get('Mappings', {})
 

--- a/src/cfnlint/rules/mappings/LimitName.py
+++ b/src/cfnlint/rules/mappings/LimitName.py
@@ -30,7 +30,7 @@ class LimitName(CloudFormationLintRule):
     def match(self, cfn):
         """Check CloudFormation Mappings"""
 
-        matches = list()
+        matches = []
 
         mappings = cfn.template.get('Mappings', {})
 

--- a/src/cfnlint/rules/mappings/LimitNumber.py
+++ b/src/cfnlint/rules/mappings/LimitNumber.py
@@ -31,7 +31,7 @@ class LimitNumber(CloudFormationLintRule):
     def match(self, cfn):
         """Check CloudFormation Mappings"""
 
-        matches = list()
+        matches = []
 
         # Check number of mappings against the defined limit
         mappings = cfn.template.get('Mappings', {})

--- a/src/cfnlint/rules/mappings/Name.py
+++ b/src/cfnlint/rules/mappings/Name.py
@@ -31,7 +31,7 @@ class Name(CloudFormationLintRule):
     def match(self, cfn):
         """Check CloudFormation Mapping"""
 
-        matches = list()
+        matches = []
 
         mappings = cfn.template.get('Mappings', {})
         for mapping_name, _ in mappings.items():

--- a/src/cfnlint/rules/mappings/Used.py
+++ b/src/cfnlint/rules/mappings/Used.py
@@ -29,8 +29,8 @@ class Used(CloudFormationLintRule):
     def match(self, cfn):
         """Check CloudFormation Mappings"""
 
-        matches = list()
-        findinmap_mappings = list()
+        matches = []
+        findinmap_mappings = []
 
         mappings = cfn.template.get('Mappings', {})
 

--- a/src/cfnlint/rules/metadata/InterfaceConfiguration.py
+++ b/src/cfnlint/rules/metadata/InterfaceConfiguration.py
@@ -34,7 +34,7 @@ class InterfaceConfiguration(CloudFormationLintRule):
     def match(self, cfn):
         """Check CloudFormation Metadata Interface Configuration"""
 
-        matches = list()
+        matches = []
 
         strinterface = 'AWS::CloudFormation::Interface'
 

--- a/src/cfnlint/rules/metadata/InterfaceParameterExists.py
+++ b/src/cfnlint/rules/metadata/InterfaceParameterExists.py
@@ -34,7 +34,7 @@ class InterfaceParameterExists(CloudFormationLintRule):
     def match(self, cfn):
         """Check CloudFormation Metadata Parameters Exist"""
 
-        matches = list()
+        matches = []
 
         strinterface = 'AWS::CloudFormation::Interface'
         parameters = cfn.get_parameter_names()

--- a/src/cfnlint/rules/outputs/Configuration.py
+++ b/src/cfnlint/rules/outputs/Configuration.py
@@ -36,7 +36,7 @@ class Configuration(CloudFormationLintRule):
     def match(self, cfn):
         """Check CloudFormation Outputs"""
 
-        matches = list()
+        matches = []
 
         outputs = cfn.template.get('Outputs', {})
         if outputs:

--- a/src/cfnlint/rules/outputs/Description.py
+++ b/src/cfnlint/rules/outputs/Description.py
@@ -30,7 +30,7 @@ class Description(CloudFormationLintRule):
     def match(self, cfn):
         """Check CloudFormation Outputs"""
 
-        matches = list()
+        matches = []
 
         outputs = cfn.template.get('Outputs', {})
         if outputs:

--- a/src/cfnlint/rules/outputs/ImportValue.py
+++ b/src/cfnlint/rules/outputs/ImportValue.py
@@ -29,7 +29,7 @@ class ImportValue(CloudFormationLintRule):
     def match(self, cfn):
         """Check CloudFormation Outputs"""
 
-        matches = list()
+        matches = []
 
         # Get all import values
         importvalue_trees = cfn.search_deep_keys('Fn::ImportValue')

--- a/src/cfnlint/rules/outputs/LimitDescription.py
+++ b/src/cfnlint/rules/outputs/LimitDescription.py
@@ -30,7 +30,7 @@ class LimitDescription(CloudFormationLintRule):
     def match(self, cfn):
         """Check CloudFormation Outputs"""
 
-        matches = list()
+        matches = []
 
         outputs = cfn.template.get('Outputs', {})
 

--- a/src/cfnlint/rules/outputs/LimitName.py
+++ b/src/cfnlint/rules/outputs/LimitName.py
@@ -30,7 +30,7 @@ class LimitName(CloudFormationLintRule):
     def match(self, cfn):
         """Check CloudFormation Outputs"""
 
-        matches = list()
+        matches = []
 
         outputs = cfn.template.get('Outputs', {})
 

--- a/src/cfnlint/rules/outputs/LimitNumber.py
+++ b/src/cfnlint/rules/outputs/LimitNumber.py
@@ -31,7 +31,7 @@ class LimitNumber(CloudFormationLintRule):
     def match(self, cfn):
         """Check CloudFormation Outputs"""
 
-        matches = list()
+        matches = []
 
         # Check number of outputs against the defined limit
         outputs = cfn.template.get('Outputs', {})

--- a/src/cfnlint/rules/outputs/Name.py
+++ b/src/cfnlint/rules/outputs/Name.py
@@ -31,7 +31,7 @@ class Name(CloudFormationLintRule):
     def match(self, cfn):
         """Check CloudFormation Mapping"""
 
-        matches = list()
+        matches = []
 
         outputs = cfn.template.get('Outputs', {})
         for output_name, _ in outputs.items():

--- a/src/cfnlint/rules/outputs/Required.py
+++ b/src/cfnlint/rules/outputs/Required.py
@@ -29,7 +29,7 @@ class Required(CloudFormationLintRule):
     def match(self, cfn):
         """Check CloudFormation Outputs"""
 
-        matches = list()
+        matches = []
 
         outputs = cfn.template.get('Outputs', {})
         if outputs:

--- a/src/cfnlint/rules/outputs/Value.py
+++ b/src/cfnlint/rules/outputs/Value.py
@@ -35,7 +35,7 @@ class Value(CloudFormationLintRule):
     def match(self, cfn):
         """Check CloudFormation Outputs"""
 
-        matches = list()
+        matches = []
 
         template = cfn.template
 

--- a/src/cfnlint/rules/parameters/AvailabilityZone.py
+++ b/src/cfnlint/rules/parameters/AvailabilityZone.py
@@ -64,7 +64,7 @@ class AvailabilityZone(CloudFormationLintRule):
     # pylint: disable=W0613
     def check_az_ref(self, value, path, parameters, resources):
         """Check ref for VPC"""
-        matches = list()
+        matches = []
         if 'AvailabilityZone' in path:
             allowed_types = [
                 'AWS::SSM::Parameter::Value<AWS::EC2::AvailabilityZone::Name>',
@@ -98,7 +98,7 @@ class AvailabilityZone(CloudFormationLintRule):
 
     def check(self, properties, resource_type, path, cfn):
         """Check itself"""
-        matches = list()
+        matches = []
 
         matches.extend(
             cfn.check_value(
@@ -119,7 +119,7 @@ class AvailabilityZone(CloudFormationLintRule):
 
     def match_resource_sub_properties(self, properties, property_type, path, cfn):
         """Match for sub properties"""
-        matches = list()
+        matches = []
 
         matches.extend(self.check(properties, property_type, path, cfn))
 
@@ -127,7 +127,7 @@ class AvailabilityZone(CloudFormationLintRule):
 
     def match_resource_properties(self, properties, resource_type, path, cfn):
         """Check CloudFormation Properties"""
-        matches = list()
+        matches = []
 
         matches.extend(self.check(properties, resource_type, path, cfn))
 

--- a/src/cfnlint/rules/parameters/Cidr.py
+++ b/src/cfnlint/rules/parameters/Cidr.py
@@ -57,7 +57,7 @@ class Cidr(CloudFormationLintRule):
     # pylint: disable=W0613
     def check_cidr_ref(self, value, path, parameters, resources):
         """Check ref for VPC"""
-        matches = list()
+        matches = []
 
         if value in parameters:
             parameter = parameters.get(value, {})
@@ -74,7 +74,7 @@ class Cidr(CloudFormationLintRule):
 
     def check(self, properties, resource_type, path, cfn):
         """Check itself"""
-        matches = list()
+        matches = []
 
         matches.extend(
             cfn.check_value(
@@ -109,7 +109,7 @@ class Cidr(CloudFormationLintRule):
 
     def match_resource_sub_properties(self, properties, property_type, path, cfn):
         """Match for sub properties"""
-        matches = list()
+        matches = []
 
         matches.extend(self.check(properties, property_type, path, cfn))
 
@@ -117,7 +117,7 @@ class Cidr(CloudFormationLintRule):
 
     def match_resource_properties(self, properties, resource_type, path, cfn):
         """Check CloudFormation Properties"""
-        matches = list()
+        matches = []
 
         matches.extend(self.check(properties, resource_type, path, cfn))
 

--- a/src/cfnlint/rules/parameters/CidrAllowedValues.py
+++ b/src/cfnlint/rules/parameters/CidrAllowedValues.py
@@ -58,7 +58,7 @@ class CidrAllowedValues(CloudFormationLintRule):
     # pylint: disable=W0613
     def check_cidr_ref(self, value, path, parameters, resources):
         """Check ref for VPC"""
-        matches = list()
+        matches = []
 
         if value in parameters:
             parameter = parameters.get(value, {})
@@ -74,7 +74,7 @@ class CidrAllowedValues(CloudFormationLintRule):
 
     def check(self, properties, resource_type, path, cfn):
         """Check itself"""
-        matches = list()
+        matches = []
 
         matches.extend(
             cfn.check_value(
@@ -109,7 +109,7 @@ class CidrAllowedValues(CloudFormationLintRule):
 
     def match_resource_sub_properties(self, properties, property_type, path, cfn):
         """Match for sub properties"""
-        matches = list()
+        matches = []
 
         matches.extend(self.check(properties, property_type, path, cfn))
 
@@ -117,7 +117,7 @@ class CidrAllowedValues(CloudFormationLintRule):
 
     def match_resource_properties(self, properties, resource_type, path, cfn):
         """Check CloudFormation Properties"""
-        matches = list()
+        matches = []
 
         matches.extend(self.check(properties, resource_type, path, cfn))
 

--- a/src/cfnlint/rules/parameters/Configuration.py
+++ b/src/cfnlint/rules/parameters/Configuration.py
@@ -43,7 +43,7 @@ class Configuration(CloudFormationLintRule):
     def match(self, cfn):
         """Check CloudFormation Parameters"""
 
-        matches = list()
+        matches = []
 
         for paramname, paramvalue in cfn.get_parameters().items():
             for propname, _ in paramvalue.items():

--- a/src/cfnlint/rules/parameters/Default.py
+++ b/src/cfnlint/rules/parameters/Default.py
@@ -101,7 +101,7 @@ class Default(CloudFormationLintRule):
     def match(self, cfn):
         """Check CloudFormation Parameters"""
 
-        matches = list()
+        matches = []
 
         for paramname, paramvalue in cfn.get_parameters().items():
             default_value = paramvalue.get('Default')

--- a/src/cfnlint/rules/parameters/LambdaMemorySize.py
+++ b/src/cfnlint/rules/parameters/LambdaMemorySize.py
@@ -39,7 +39,7 @@ class LambdaMemorySize(CloudFormationLintRule):
     # pylint: disable=W0613
     def check_lambda_memory_size_ref(self, value, path, parameters, resources):
         """Check ref for VPC"""
-        matches = list()
+        matches = []
 
         if value in parameters:
             parameter = parameters.get(value)
@@ -59,7 +59,7 @@ class LambdaMemorySize(CloudFormationLintRule):
 
     def check(self, properties, resource_type, path, cfn):
         """Check itself"""
-        matches = list()
+        matches = []
 
         matches.extend(
             cfn.check_value(
@@ -73,7 +73,7 @@ class LambdaMemorySize(CloudFormationLintRule):
 
     def match_resource_properties(self, properties, resource_type, path, cfn):
         """Check CloudFormation Properties"""
-        matches = list()
+        matches = []
 
         matches.extend(self.check(properties, resource_type, path, cfn))
 

--- a/src/cfnlint/rules/parameters/LambdaRuntime.py
+++ b/src/cfnlint/rules/parameters/LambdaRuntime.py
@@ -39,7 +39,7 @@ class LambdaRuntime(CloudFormationLintRule):
     # pylint: disable=W0613
     def check_lambda_memory_size_ref(self, value, path, parameters, resources):
         """Check ref for VPC"""
-        matches = list()
+        matches = []
         runtimes = [
             'nodejs', 'nodejs4.3', 'nodejs6.10', 'nodejs8.10', 'java8', 'python2.7',
             'python3.6', 'dotnetcore1.0', 'dotnetcore2.0', 'dotnetcore2.1',
@@ -64,7 +64,7 @@ class LambdaRuntime(CloudFormationLintRule):
 
     def check(self, properties, resource_type, path, cfn):
         """Check itself"""
-        matches = list()
+        matches = []
 
         matches.extend(
             cfn.check_value(
@@ -78,7 +78,7 @@ class LambdaRuntime(CloudFormationLintRule):
 
     def match_resource_properties(self, properties, resource_type, path, cfn):
         """Check CloudFormation Properties"""
-        matches = list()
+        matches = []
 
         matches.extend(self.check(properties, resource_type, path, cfn))
 

--- a/src/cfnlint/rules/parameters/LimitName.py
+++ b/src/cfnlint/rules/parameters/LimitName.py
@@ -30,7 +30,7 @@ class LimitName(CloudFormationLintRule):
     def match(self, cfn):
         """Check CloudFormation Parameters"""
 
-        matches = list()
+        matches = []
 
         # Check number of parameters against the defined limit
         parameters = cfn.template.get('Parameters', {})

--- a/src/cfnlint/rules/parameters/LimitNumber.py
+++ b/src/cfnlint/rules/parameters/LimitNumber.py
@@ -31,7 +31,7 @@ class LimitNumber(CloudFormationLintRule):
     def match(self, cfn):
         """Check CloudFormation Parameters"""
 
-        matches = list()
+        matches = []
 
         # Check number of parameters against the defined limit
         parameters = cfn.template.get('Parameters', {})

--- a/src/cfnlint/rules/parameters/LimitValue.py
+++ b/src/cfnlint/rules/parameters/LimitValue.py
@@ -31,7 +31,7 @@ class LimitValue(CloudFormationLintRule):
     def match(self, cfn):
         """Check CloudFormation Parameters"""
 
-        matches = list()
+        matches = []
 
         value_limit = LIMITS['parameters']['value']
 

--- a/src/cfnlint/rules/parameters/Name.py
+++ b/src/cfnlint/rules/parameters/Name.py
@@ -31,7 +31,7 @@ class Name(CloudFormationLintRule):
     def match(self, cfn):
         """Check CloudFormation Mapping"""
 
-        matches = list()
+        matches = []
 
         parameters = cfn.template.get('Parameters', {})
         for parameter_name, _ in parameters.items():

--- a/src/cfnlint/rules/parameters/SecurityGroup.py
+++ b/src/cfnlint/rules/parameters/SecurityGroup.py
@@ -58,7 +58,7 @@ class SecurityGroup(CloudFormationLintRule):
     # pylint: disable=W0613
     def check_sgid_ref(self, value, path, parameters, resources):
         """Check ref for VPC"""
-        matches = list()
+        matches = []
         if 'SourceSecurityGroupId' in path:
             allowed_types = [
                 'AWS::SSM::Parameter::Value<AWS::EC2::SecurityGroup::Id>',
@@ -92,7 +92,7 @@ class SecurityGroup(CloudFormationLintRule):
 
     def check(self, properties, resource_type, path, cfn):
         """Check itself"""
-        matches = list()
+        matches = []
 
         matches.extend(
             cfn.check_value(
@@ -120,7 +120,7 @@ class SecurityGroup(CloudFormationLintRule):
 
     def match_resource_sub_properties(self, properties, property_type, path, cfn):
         """Match for sub properties"""
-        matches = list()
+        matches = []
 
         matches.extend(self.check(properties, property_type, path, cfn))
 
@@ -128,7 +128,7 @@ class SecurityGroup(CloudFormationLintRule):
 
     def match_resource_properties(self, properties, resource_type, path, cfn):
         """Check CloudFormation Properties"""
-        matches = list()
+        matches = []
 
         matches.extend(self.check(properties, resource_type, path, cfn))
 

--- a/src/cfnlint/rules/parameters/Types.py
+++ b/src/cfnlint/rules/parameters/Types.py
@@ -56,7 +56,7 @@ class Types(CloudFormationLintRule):
     def match(self, cfn):
         """Check CloudFormation Parameters"""
 
-        matches = list()
+        matches = []
 
         for paramname, paramvalue in cfn.get_parameters().items():
             # If the type isn't found we create a valid one

--- a/src/cfnlint/rules/parameters/Used.py
+++ b/src/cfnlint/rules/parameters/Used.py
@@ -46,14 +46,14 @@ class Used(CloudFormationLintRule):
     def match(self, cfn):
         """Check CloudFormation Parameters"""
 
-        matches = list()
+        matches = []
 
         reftrees = cfn.search_deep_keys('Ref')
-        refs = list()
+        refs = []
         for reftree in reftrees:
             refs.append(reftree[-1])
         subtrees = cfn.search_deep_keys('Fn::Sub')
-        subs = list()
+        subs = []
         for subtree in subtrees:
             if isinstance(subtree[-1], list):
                 subs.extend(cfn.get_sub_parameters(subtree[-1][0]))

--- a/src/cfnlint/rules/resources/CircularDependency.py
+++ b/src/cfnlint/rules/resources/CircularDependency.py
@@ -59,9 +59,9 @@ class CircularDependency(CloudFormationLintRule):
 
     def check_circular_dependencies(self, resources):
         """Check circular dependencies one item at a time"""
-        matches = list()
+        matches = []
         for resource_name, associations in resources.items():
-            resource_results = list()
+            resource_results = []
             for association in associations:
                 results = set(
                     self._check_circular_dependency(
@@ -88,7 +88,7 @@ class CircularDependency(CloudFormationLintRule):
     def match(self, cfn):
         """Check CloudFormation Resources"""
 
-        matches = list()
+        matches = []
 
         ref_objs = cfn.search_deep_keys('Ref')
         resources = {}
@@ -119,7 +119,7 @@ class CircularDependency(CloudFormationLintRule):
 
         sub_objs = cfn.search_deep_keys('Fn::Sub')
         for sub_obj in sub_objs:
-            sub_parameters = list()
+            sub_parameters = []
             sub_parameter_values = {}
             value = sub_obj[-1]
             res_type, res_name = sub_obj[:2]

--- a/src/cfnlint/rules/resources/Configuration.py
+++ b/src/cfnlint/rules/resources/Configuration.py
@@ -31,7 +31,7 @@ class Configuration(CloudFormationLintRule):
     def match(self, cfn):
         """Check CloudFormation Resources"""
 
-        matches = list()
+        matches = []
 
         valid_attributes = [
             'CreationPolicy',

--- a/src/cfnlint/rules/resources/DependsOn.py
+++ b/src/cfnlint/rules/resources/DependsOn.py
@@ -29,7 +29,7 @@ class DependsOn(CloudFormationLintRule):
 
     def check_value(self, key, path, resources):
         """Check resource names for DependsOn"""
-        matches = list()
+        matches = []
 
         if not isinstance(key, (six.text_type, six.string_types)):
             message = 'DependsOn values should be of string at {0}'
@@ -44,7 +44,7 @@ class DependsOn(CloudFormationLintRule):
     def match(self, cfn):
         """Check CloudFormation Resources"""
 
-        matches = list()
+        matches = []
 
         resources = cfn.get_resources()
 

--- a/src/cfnlint/rules/resources/DependsOnObsolete.py
+++ b/src/cfnlint/rules/resources/DependsOnObsolete.py
@@ -44,7 +44,7 @@ class DependsOnObsolete(CloudFormationLintRule):
 
     def check_depends_on(self, cfn, resource, key, path):
         """Check if the DependsOn is already specified"""
-        matches = list()
+        matches = []
 
         # Get references
         trees = self.get_resource_references(cfn, 'Ref', resource)
@@ -68,7 +68,7 @@ class DependsOnObsolete(CloudFormationLintRule):
     def match(self, cfn):
         """Check CloudFormation Resources"""
 
-        matches = list()
+        matches = []
 
         resources = cfn.get_resources()
 

--- a/src/cfnlint/rules/resources/LimitName.py
+++ b/src/cfnlint/rules/resources/LimitName.py
@@ -30,7 +30,7 @@ class LimitName(CloudFormationLintRule):
     def match(self, cfn):
         """Check CloudFormation Resources"""
 
-        matches = list()
+        matches = []
 
         resources = cfn.template.get('Resources', {})
 

--- a/src/cfnlint/rules/resources/LimitNumber.py
+++ b/src/cfnlint/rules/resources/LimitNumber.py
@@ -31,7 +31,7 @@ class LimitNumber(CloudFormationLintRule):
     def match(self, cfn):
         """Check CloudFormation Resources"""
 
-        matches = list()
+        matches = []
 
         # Check number of resources against the defined limit
         resources = cfn.get_resources()

--- a/src/cfnlint/rules/resources/Name.py
+++ b/src/cfnlint/rules/resources/Name.py
@@ -31,7 +31,7 @@ class Name(CloudFormationLintRule):
     def match(self, cfn):
         """Check CloudFormation Mapping"""
 
-        matches = list()
+        matches = []
 
         resources = cfn.template.get('Resources', {})
         for resource_name, _ in resources.items():

--- a/src/cfnlint/rules/resources/cloudfront/Aliases.py
+++ b/src/cfnlint/rules/resources/cloudfront/Aliases.py
@@ -31,7 +31,7 @@ class Aliases(CloudFormationLintRule):
     def match(self, cfn):
         """Check cloudfront Resource Parameters"""
 
-        matches = list()
+        matches = []
 
         valid_domain = re.compile(r'^(?:[a-z0-9\*](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9][a-z0-9-]{0,61}[a-z0-9]$')
 

--- a/src/cfnlint/rules/resources/codepipeline/CodepipelineStageActions.py
+++ b/src/cfnlint/rules/resources/codepipeline/CodepipelineStageActions.py
@@ -199,7 +199,7 @@ class CodepipelineStageActions(CloudFormationLintRule):
 
     def match(self, cfn):
         """Check that stage actions are set up properly."""
-        matches = list()
+        matches = []
 
         resources = cfn.get_resource_properties(['AWS::CodePipeline::Pipeline'])
         for resource in resources:

--- a/src/cfnlint/rules/resources/codepipeline/CodepipelineStages.py
+++ b/src/cfnlint/rules/resources/codepipeline/CodepipelineStages.py
@@ -96,7 +96,7 @@ class CodepipelineStages(CloudFormationLintRule):
 
     def match(self, cfn):
         """Check CodePipeline stages"""
-        matches = list()
+        matches = []
 
         resources = cfn.get_resource_properties(['AWS::CodePipeline::Pipeline'])
         for resource in resources:

--- a/src/cfnlint/rules/resources/ectwo/Ebs.py
+++ b/src/cfnlint/rules/resources/ectwo/Ebs.py
@@ -29,7 +29,7 @@ class Ebs(CloudFormationLintRule):
     tags = ['properties', 'ec2', 'ebs']
 
     def _checkEbs(self, cfn, ebs, path):
-        matches = list()
+        matches = []
 
         if isinstance(ebs, dict):
             volume_types_obj = cfn.get_values(ebs, 'VolumeType')
@@ -81,7 +81,7 @@ class Ebs(CloudFormationLintRule):
     def match(self, cfn):
         """Check Ec2 Ebs Resource Parameters"""
 
-        matches = list()
+        matches = []
 
         results = cfn.get_resource_properties(['AWS::EC2::Instance', 'BlockDeviceMappings'])
         results.extend(cfn.get_resource_properties(['AWS::AutoScaling::LaunchConfiguration', 'BlockDeviceMappings']))

--- a/src/cfnlint/rules/resources/ectwo/SecurityGroupDescription.py
+++ b/src/cfnlint/rules/resources/ectwo/SecurityGroupDescription.py
@@ -37,7 +37,7 @@ class SecurityGroupDescription(CloudFormationLintRule):
 
     def check_value(self, value, path):
         """Check SecurityGroup descriptions"""
-        matches = list()
+        matches = []
         full_path = ('/'.join(str(x) for x in path))
 
         # Check max length
@@ -57,7 +57,7 @@ class SecurityGroupDescription(CloudFormationLintRule):
     def match(self, cfn):
         """Check SecurityGroup descriptions"""
 
-        matches = list()
+        matches = []
 
         resources = cfn.get_resources(['AWS::EC2::SecurityGroup'])
 

--- a/src/cfnlint/rules/resources/ectwo/SecurityGroupIngress.py
+++ b/src/cfnlint/rules/resources/ectwo/SecurityGroupIngress.py
@@ -30,7 +30,7 @@ class SecurityGroupIngress(CloudFormationLintRule):
 
     def check_sgid_value(self, value, path):
         """Check VPC Values"""
-        matches = list()
+        matches = []
         if not value.startswith('sg-'):
             message = 'Security Group Id must have a valid Identifier {0}'
             matches.append(
@@ -39,7 +39,7 @@ class SecurityGroupIngress(CloudFormationLintRule):
 
     def check_sgid_ref(self, value, path, parameters, resources):
         """Check ref for VPC"""
-        matches = list()
+        matches = []
 
         allowed_types = [
             'AWS::SSM::Parameter::Value<AWS::EC2::SecurityGroup::Id>',
@@ -79,7 +79,7 @@ class SecurityGroupIngress(CloudFormationLintRule):
     def check_sgid_fail(self, value, path, **kwargs):
         """Automatic failure for certain functions"""
 
-        matches = list()
+        matches = []
         message = 'Use Ref, FindInMap, or string values for {0}'
         matches.append(
             RuleMatch(path, message.format('/'.join(map(str, path)))))
@@ -88,7 +88,7 @@ class SecurityGroupIngress(CloudFormationLintRule):
     def check_ingress_rule(self, vpc_id, properties, path, cfn):
         """Check ingress rule"""
 
-        matches = list()
+        matches = []
         if vpc_id:
 
             # Check that SourceSecurityGroupName isn't specified
@@ -123,7 +123,7 @@ class SecurityGroupIngress(CloudFormationLintRule):
     def match(self, cfn):
         """Check EC2 Security Group Ingress Resource Parameters"""
 
-        matches = list()
+        matches = []
 
         resources = cfn.get_resources(resource_type='AWS::EC2::SecurityGroup')
         for resource_name, resource_object in resources.items():

--- a/src/cfnlint/rules/resources/ectwo/Subnet.py
+++ b/src/cfnlint/rules/resources/ectwo/Subnet.py
@@ -30,7 +30,7 @@ class Subnet(CloudFormationLintRule):
 
     def check_az_value(self, value, path):
         """Check AZ Values"""
-        matches = list()
+        matches = []
 
         if value not in AVAILABILITY_ZONES:
             message = 'Not a valid Availbility Zone {0} at {1}'
@@ -39,7 +39,7 @@ class Subnet(CloudFormationLintRule):
 
     def check_az_ref(self, value, path, parameters, resources):
         """Check ref for AZ"""
-        matches = list()
+        matches = []
         allowed_types = [
             'AWS::EC2::AvailabilityZone::Name',
             'String'
@@ -63,7 +63,7 @@ class Subnet(CloudFormationLintRule):
 
     def check_cidr_value(self, value, path):
         """Check CIDR Strings"""
-        matches = list()
+        matches = []
 
         if not re.match(REGEX_CIDR, value):
             message = 'CidrBlock needs to be of x.x.x.x/y at {0}'
@@ -72,7 +72,7 @@ class Subnet(CloudFormationLintRule):
 
     def check_cidr_ref(self, value, path, parameters, resources):
         """Check CidrBlock for VPC"""
-        matches = list()
+        matches = []
 
         allowed_types = [
             'String'
@@ -101,7 +101,7 @@ class Subnet(CloudFormationLintRule):
 
     def check_vpc_value(self, value, path):
         """Check VPC Values"""
-        matches = list()
+        matches = []
 
         if not value.startswith('vpc-'):
             message = 'VpcId needs to be of format vpc-xxxxxxxx at {1}'
@@ -110,7 +110,7 @@ class Subnet(CloudFormationLintRule):
 
     def check_vpc_ref(self, value, path, parameters, resources):
         """Check ref for VPC"""
-        matches = list()
+        matches = []
         if value in resources:
             # Check if resource is a VPC
             message = 'VpcId can\'t use a Ref to a resource for {0}'
@@ -127,7 +127,7 @@ class Subnet(CloudFormationLintRule):
     def match(self, cfn):
         """Check EC2 VPC Resource Parameters"""
 
-        matches = list()
+        matches = []
         matches.extend(
             cfn.check_resource_property(
                 'AWS::EC2::Subnet', 'AvailabilityZone',

--- a/src/cfnlint/rules/resources/ectwo/Vpc.py
+++ b/src/cfnlint/rules/resources/ectwo/Vpc.py
@@ -31,7 +31,7 @@ class Vpc(CloudFormationLintRule):
 
     def check_vpc_value(self, value, path):
         """Check VPC Values"""
-        matches = list()
+        matches = []
 
         if value not in ('default', 'dedicated'):
             message = 'DefaultTenancy needs to be default or dedicated for {0}'
@@ -40,7 +40,7 @@ class Vpc(CloudFormationLintRule):
 
     def check_vpc_ref(self, value, path, parameters, resources):
         """Check ref for VPC"""
-        matches = list()
+        matches = []
         allowed_types = [
             'String'
         ]
@@ -63,7 +63,7 @@ class Vpc(CloudFormationLintRule):
 
     def check_cidr_value(self, value, path):
         """Check CIDR Strings"""
-        matches = list()
+        matches = []
 
         if not re.match(REGEX_CIDR, value):
             message = 'CidrBlock needs to be of x.x.x.x/y at {0}'
@@ -72,7 +72,7 @@ class Vpc(CloudFormationLintRule):
 
     def check_cidr_ref(self, value, path, parameters, resources):
         """Check CidrBlock for VPC"""
-        matches = list()
+        matches = []
 
         allowed_types = [
             'String'
@@ -101,7 +101,7 @@ class Vpc(CloudFormationLintRule):
     def match(self, cfn):
         """Check EC2 VPC Resource Parameters"""
 
-        matches = list()
+        matches = []
         matches.extend(
             cfn.check_resource_property(
                 'AWS::EC2::VPC', 'InstanceTenancy',

--- a/src/cfnlint/rules/resources/elb/Elb.py
+++ b/src/cfnlint/rules/resources/elb/Elb.py
@@ -32,7 +32,7 @@ HTTPS has certificate HTTP has no certificate'
         """
             Check Protocol Value
         """
-        matches = list()
+        matches = []
         if isinstance(value, six.string_types):
             if value.upper() not in kwargs['accepted_protocols']:
                 message = 'Protocol must be {0} is invalid at {1}'
@@ -47,7 +47,7 @@ HTTPS has certificate HTTP has no certificate'
     def match(self, cfn):
         """Check ELB Resource Parameters"""
 
-        matches = list()
+        matches = []
 
         results = cfn.get_resource_properties(['AWS::ElasticLoadBalancingV2::Listener'])
         for result in results:

--- a/src/cfnlint/rules/resources/iam/InstanceProfile.py
+++ b/src/cfnlint/rules/resources/iam/InstanceProfile.py
@@ -30,7 +30,7 @@ class InstanceProfile(CloudFormationLintRule):
     def match(self, cfn):
         """Check CloudFormation IamInstanceProfile Parameters"""
 
-        matches = list()
+        matches = []
 
         # Build the list of keys
         trees = cfn.search_deep_keys('Fn::GetAtt')

--- a/src/cfnlint/rules/resources/iam/Limits.py
+++ b/src/cfnlint/rules/resources/iam/Limits.py
@@ -36,7 +36,7 @@ class Limits(CloudFormationLintRule):
 
     def check_managed_policy_arns(self, properties, path):
         """Check ManagedPolicyArns is within limits"""
-        matches = list()
+        matches = []
 
         if 'ManagedPolicyArns' not in properties:
             return matches
@@ -53,7 +53,7 @@ class Limits(CloudFormationLintRule):
 
     def check_instance_profile_roles(self, properties, path):
         """Check InstanceProfile.Roles is within limits"""
-        matches = list()
+        matches = []
 
         if 'Roles' not in properties:
             return matches
@@ -70,7 +70,7 @@ class Limits(CloudFormationLintRule):
 
     def check_user_groups(self, properties, path):
         """Check User.Groups is within limits"""
-        matches = list()
+        matches = []
 
         if 'Groups' not in properties:
             return matches
@@ -87,7 +87,7 @@ class Limits(CloudFormationLintRule):
 
     def check_role_assume_role_policy_document(self, properties, path):
         """Check Role.AssumeRolePolicyDocument is within limits"""
-        matches = list()
+        matches = []
 
         if 'AssumeRolePolicyDocument' not in properties:
             return matches
@@ -104,7 +104,7 @@ class Limits(CloudFormationLintRule):
 
     def match(self, cfn):
         """Check that IAM resources are below limits"""
-        matches = list()
+        matches = []
         types = {
             'AWS::IAM::User': [
                 self.check_managed_policy_arns,

--- a/src/cfnlint/rules/resources/iam/Policy.py
+++ b/src/cfnlint/rules/resources/iam/Policy.py
@@ -52,7 +52,7 @@ class Policy(CloudFormationLintRule):
 
     def check_policy_document(self, value, path, cfn, is_identity_policy):
         """Check policy document"""
-        matches = list()
+        matches = []
 
         valid_keys = [
             'Version',
@@ -95,7 +95,7 @@ class Policy(CloudFormationLintRule):
 
     def _check_policy_statement(self, branch, statement, is_identity_policy):
         """Check statements"""
-        matches = list()
+        matches = []
         statement_valid_keys = [
             'Effect',
             'Principal',
@@ -146,7 +146,7 @@ class Policy(CloudFormationLintRule):
 
     def match_resource_properties(self, properties, resourcetype, path, cfn):
         """Check CloudFormation Properties"""
-        matches = list()
+        matches = []
 
         is_identity_policy = True
         if resourcetype in self.resources_and_keys:

--- a/src/cfnlint/rules/resources/iam/PolicyVersion.py
+++ b/src/cfnlint/rules/resources/iam/PolicyVersion.py
@@ -52,7 +52,7 @@ class PolicyVersion(CloudFormationLintRule):
 
     def check_policy_document(self, value, path):
         """Check policy document"""
-        matches = list()
+        matches = []
 
         if not isinstance(value, dict):
             return matches
@@ -67,7 +67,7 @@ class PolicyVersion(CloudFormationLintRule):
 
     def match_resource_properties(self, properties, resourcetype, path, cfn):
         """Check CloudFormation Properties"""
-        matches = list()
+        matches = []
 
         key = None
         if resourcetype in self.resources_and_keys:

--- a/src/cfnlint/rules/resources/lmbd/FunctionMemorySize.py
+++ b/src/cfnlint/rules/resources/lmbd/FunctionMemorySize.py
@@ -32,7 +32,7 @@ class FunctionMemorySize(CloudFormationLintRule):
 
     def check_value(self, value, path):
         """ Check memory size value """
-        matches = list()
+        matches = []
 
         message = 'You must specify a value that is greater than or equal to {0}, ' \
                   'and it must be a multiple of 64. You cannot specify a size ' \
@@ -69,7 +69,7 @@ class FunctionMemorySize(CloudFormationLintRule):
     def check_ref(self, value, path, parameters, resources):
         """ Check Memory Size Ref """
 
-        matches = list()
+        matches = []
         if value in resources:
             message = 'MemorySize can\'t use a Ref to a resource for {0}'
             matches.append(RuleMatch(path, message.format(('/'.join(path)))))
@@ -126,7 +126,7 @@ class FunctionMemorySize(CloudFormationLintRule):
     def match(self, cfn):
         """Check Lambda Function Memory Size Resource Parameters"""
 
-        matches = list()
+        matches = []
         matches.extend(
             cfn.check_resource_property(
                 'AWS::Lambda::Function', 'MemorySize',

--- a/src/cfnlint/rules/resources/lmbd/FunctionRuntime.py
+++ b/src/cfnlint/rules/resources/lmbd/FunctionRuntime.py
@@ -34,7 +34,7 @@ class FunctionRuntime(CloudFormationLintRule):
 
     def check_value(self, value, path):
         """ Check runtime value """
-        matches = list()
+        matches = []
 
         message = 'You must specify a valid value for runtime ({0}) at {1}'
 
@@ -46,7 +46,7 @@ class FunctionRuntime(CloudFormationLintRule):
     def check_ref(self, value, path, parameters, resources):
         """ Check Memory Size Ref """
 
-        matches = list()
+        matches = []
         if value in resources:
             message = 'Runtime can\'t use a Ref to a resource for {0}'
             matches.append(RuleMatch(path, message.format(('/'.join(path)))))
@@ -64,7 +64,7 @@ class FunctionRuntime(CloudFormationLintRule):
     def match(self, cfn):
         """Check Lambda Function Memory Size Resource Parameters"""
 
-        matches = list()
+        matches = []
         matches.extend(
             cfn.check_resource_property(
                 'AWS::Lambda::Function', 'Runtime',

--- a/src/cfnlint/rules/resources/properties/AtLeastOne.py
+++ b/src/cfnlint/rules/resources/properties/AtLeastOne.py
@@ -41,7 +41,7 @@ class AtLeastOne(CloudFormationLintRule):
 
     def check(self, properties, atleastoneprops, path):
         """Check itself"""
-        matches = list()
+        matches = []
         for atleastoneprop in atleastoneprops:
             count = 0
             for prop in atleastoneprop:
@@ -59,7 +59,7 @@ class AtLeastOne(CloudFormationLintRule):
 
     def match_resource_sub_properties(self, properties, property_type, path, _):
         """Match for sub properties"""
-        matches = list()
+        matches = []
 
         atleastoneprops = self.property_types_specs.get(property_type, {})
         matches.extend(self.check(properties, atleastoneprops, path))
@@ -68,7 +68,7 @@ class AtLeastOne(CloudFormationLintRule):
 
     def match_resource_properties(self, properties, resource_type, path, _):
         """Check CloudFormation Properties"""
-        matches = list()
+        matches = []
 
         atleastoneprops = self.resource_types_specs.get(resource_type, {})
         matches.extend(self.check(properties, atleastoneprops, path))

--- a/src/cfnlint/rules/resources/properties/AvailabilityZone.py
+++ b/src/cfnlint/rules/resources/properties/AvailabilityZone.py
@@ -58,7 +58,7 @@ class AvailabilityZone(CloudFormationLintRule):
     # pylint: disable=W0613
     def check_az_value(self, value, path):
         """Check ref for VPC"""
-        matches = list()
+        matches = []
 
         if path[-1] != 'Fn::GetAZs':
             message = 'Don\'t hardcode {0} for AvailabilityZones'
@@ -68,7 +68,7 @@ class AvailabilityZone(CloudFormationLintRule):
 
     def check(self, properties, resource_type, path, cfn):
         """Check itself"""
-        matches = list()
+        matches = []
 
         matches.extend(
             cfn.check_value(
@@ -89,7 +89,7 @@ class AvailabilityZone(CloudFormationLintRule):
 
     def match_resource_sub_properties(self, properties, property_type, path, cfn):
         """Match for sub properties"""
-        matches = list()
+        matches = []
 
         matches.extend(self.check(properties, property_type, path, cfn))
 
@@ -97,7 +97,7 @@ class AvailabilityZone(CloudFormationLintRule):
 
     def match_resource_properties(self, properties, resource_type, path, cfn):
         """Check CloudFormation Properties"""
-        matches = list()
+        matches = []
 
         matches.extend(self.check(properties, resource_type, path, cfn))
 

--- a/src/cfnlint/rules/resources/properties/Exclusive.py
+++ b/src/cfnlint/rules/resources/properties/Exclusive.py
@@ -40,7 +40,7 @@ class Exclusive(CloudFormationLintRule):
 
     def check(self, properties, exclusions, path):
         """Check itself"""
-        matches = list()
+        matches = []
 
         for prop in properties:
             if prop in exclusions:
@@ -56,7 +56,7 @@ class Exclusive(CloudFormationLintRule):
 
     def match_resource_sub_properties(self, properties, property_type, path, _):
         """Match for sub properties"""
-        matches = list()
+        matches = []
 
         exclusions = self.property_types_specs.get(property_type, {})
         matches.extend(self.check(properties, exclusions, path))
@@ -65,7 +65,7 @@ class Exclusive(CloudFormationLintRule):
 
     def match_resource_properties(self, properties, resource_type, path, _):
         """Check CloudFormation Properties"""
-        matches = list()
+        matches = []
 
         exclusions = self.resource_types_specs.get(resource_type, {})
         matches.extend(self.check(properties, exclusions, path))

--- a/src/cfnlint/rules/resources/properties/ImageId.py
+++ b/src/cfnlint/rules/resources/properties/ImageId.py
@@ -31,7 +31,7 @@ class ImageId(CloudFormationLintRule):
     def match(self, cfn):
         """Check CloudFormation ImageId Parameters"""
 
-        matches = list()
+        matches = []
 
         # Build the list of refs
         imageidtrees = cfn.search_deep_keys('ImageId')

--- a/src/cfnlint/rules/resources/properties/Inclusive.py
+++ b/src/cfnlint/rules/resources/properties/Inclusive.py
@@ -40,7 +40,7 @@ class Inclusive(CloudFormationLintRule):
 
     def check(self, properties, inclusions, path, cfn):
         """Check itself"""
-        matches = list()
+        matches = []
         property_sets = cfn.get_values({'Properties': properties}, 'Properties', path)
         for property_set in property_sets:
             for prop in property_set['Value']:
@@ -57,7 +57,7 @@ class Inclusive(CloudFormationLintRule):
 
     def match_resource_sub_properties(self, properties, property_type, path, cfn):
         """Match for sub properties"""
-        matches = list()
+        matches = []
 
         inclusions = self.property_types_specs.get(property_type, {})
         matches.extend(self.check(properties, inclusions, path, cfn))
@@ -66,7 +66,7 @@ class Inclusive(CloudFormationLintRule):
 
     def match_resource_properties(self, properties, resource_type, path, cfn):
         """Check CloudFormation Properties"""
-        matches = list()
+        matches = []
 
         inclusions = self.resource_types_specs.get(resource_type, {})
         matches.extend(self.check(properties, inclusions, path, cfn))

--- a/src/cfnlint/rules/resources/properties/OnlyOne.py
+++ b/src/cfnlint/rules/resources/properties/OnlyOne.py
@@ -41,7 +41,7 @@ class OnlyOne(CloudFormationLintRule):
 
     def check(self, properties, onlyoneprops, path, cfn):
         """Check itself"""
-        matches = list()
+        matches = []
         property_sets = cfn.get_values({'Properties': properties}, 'Properties', path)
         for property_set in property_sets:
             for onlyoneprop in onlyoneprops:
@@ -61,7 +61,7 @@ class OnlyOne(CloudFormationLintRule):
 
     def match_resource_sub_properties(self, properties, property_type, path, cfn):
         """Match for sub properties"""
-        matches = list()
+        matches = []
 
         onlyoneprops = self.property_types_specs.get(property_type, {})
         matches.extend(self.check(properties, onlyoneprops, path, cfn))
@@ -70,7 +70,7 @@ class OnlyOne(CloudFormationLintRule):
 
     def match_resource_properties(self, properties, resource_type, path, cfn):
         """Check CloudFormation Properties"""
-        matches = list()
+        matches = []
 
         onlyoneprops = self.resource_types_specs.get(resource_type, {})
         matches.extend(self.check(properties, onlyoneprops, path, cfn))

--- a/src/cfnlint/rules/resources/properties/Password.py
+++ b/src/cfnlint/rules/resources/properties/Password.py
@@ -32,7 +32,7 @@ class Password(CloudFormationLintRule):
     def match(self, cfn):
         """Check CloudFormation Password Parameters"""
 
-        matches = list()
+        matches = []
         password_properties = ['Password', 'DbPassword', 'MasterUserPassword']
 
         parameters = cfn.get_parameter_names()

--- a/src/cfnlint/rules/resources/properties/Properties.py
+++ b/src/cfnlint/rules/resources/properties/Properties.py
@@ -46,7 +46,7 @@ class Properties(CloudFormationLintRule):
 
         """
 
-        matches = list()
+        matches = []
         if isinstance(value, dict) and primtype == 'Json':
             return matches
         if isinstance(value, dict):
@@ -77,7 +77,7 @@ class Properties(CloudFormationLintRule):
 
     def check_list_for_condition(self, text, prop, parenttype, resourcename, propspec, path):
         """Checks lists that are a dict for conditions"""
-        matches = list()
+        matches = []
         if len(text[prop]) == 1:
             for sub_key, sub_value in text[prop].items():
                 if sub_key in cfnlint.helpers.CONDITION_FUNCTIONS:
@@ -146,7 +146,7 @@ class Properties(CloudFormationLintRule):
         """Check individual properties"""
 
         parameternames = self.parameternames
-        matches = list()
+        matches = []
         if root:
             specs = self.resourcetypes
             resourcetype = parenttype
@@ -254,7 +254,7 @@ class Properties(CloudFormationLintRule):
 
     def match(self, cfn):
         """Check CloudFormation Properties"""
-        matches = list()
+        matches = []
         self.cfn = cfn
 
         resourcespecs = cfnlint.helpers.RESOURCE_SPECS[cfn.regions[0]]

--- a/src/cfnlint/rules/resources/properties/PropertiesTemplated.py
+++ b/src/cfnlint/rules/resources/properties/PropertiesTemplated.py
@@ -37,7 +37,7 @@ class PropertiesTemplated(CloudFormationLintRule):
 
     def check_value(self, value, path):
         """ Check the value """
-        matches = list()
+        matches = []
         if isinstance(value, six.string_types):
             message = 'This code may only work with `package` cli command as the property (%s) is a string' % ('/'.join(map(str, path)))
             matches.append(RuleMatch(path, message))
@@ -46,7 +46,7 @@ class PropertiesTemplated(CloudFormationLintRule):
 
     def match_resource_properties(self, properties, resourcetype, path, cfn):
         """Check CloudFormation Properties"""
-        matches = list()
+        matches = []
 
         templated_exceptions = {
             'AWS::ApiGateway::RestApi': ['BodyS3Location'],

--- a/src/cfnlint/rules/resources/properties/Required.py
+++ b/src/cfnlint/rules/resources/properties/Required.py
@@ -38,7 +38,7 @@ class Required(CloudFormationLintRule):
     def propertycheck(self, text, proptype, parenttype, resourcename, tree, root):
         """Check individual properties"""
 
-        matches = list()
+        matches = []
         if root:
             specs = self.resourcetypes
             resourcetype = parenttype
@@ -60,7 +60,7 @@ class Required(CloudFormationLintRule):
             return matches
 
         # Check if all required properties are specified
-        resource_objects = list()
+        resource_objects = []
         base_object_properties = {}
         for key, value in text.items():
             if key not in cfnlint.helpers.CONDITION_FUNCTIONS:
@@ -121,7 +121,7 @@ class Required(CloudFormationLintRule):
 
     def match(self, cfn):
         """Check CloudFormation Properties"""
-        matches = list()
+        matches = []
 
         self.cfn = cfn
 

--- a/src/cfnlint/rules/resources/properties/ValuePrimitiveType.py
+++ b/src/cfnlint/rules/resources/properties/ValuePrimitiveType.py
@@ -42,7 +42,7 @@ class ValuePrimitiveType(CloudFormationLintRule):
 
     def check_primitive_type(self, value, item_type, path):
         """Chec item type"""
-        matches = list()
+        matches = []
 
         if isinstance(value, dict) and item_type == 'Json':
             return matches
@@ -78,7 +78,7 @@ class ValuePrimitiveType(CloudFormationLintRule):
 
     def check_value(self, value, path, **kwargs):
         """Check Value"""
-        matches = list()
+        matches = []
         primitive_type = kwargs.get('primitive_type', {})
         item_type = kwargs.get('item_type', {})
         if item_type in ['Map']:
@@ -93,7 +93,7 @@ class ValuePrimitiveType(CloudFormationLintRule):
 
     def check(self, cfn, properties, specs, path):
         """Check itself"""
-        matches = list()
+        matches = []
 
         for prop in properties:
             if prop in specs:
@@ -118,7 +118,7 @@ class ValuePrimitiveType(CloudFormationLintRule):
 
     def match_resource_sub_properties(self, properties, property_type, path, cfn):
         """Match for sub properties"""
-        matches = list()
+        matches = []
 
         property_specs = self.property_specs.get(property_type, {}).get('Properties', {})
         matches.extend(self.check(cfn, properties, property_specs, path))
@@ -127,7 +127,7 @@ class ValuePrimitiveType(CloudFormationLintRule):
 
     def match_resource_properties(self, properties, resource_type, path, cfn):
         """Check CloudFormation Properties"""
-        matches = list()
+        matches = []
         resource_specs = self.resource_specs.get(resource_type, {}).get('Properties', {})
         matches.extend(self.check(cfn, properties, resource_specs, path))
 

--- a/src/cfnlint/rules/resources/properties/VpcId.py
+++ b/src/cfnlint/rules/resources/properties/VpcId.py
@@ -31,7 +31,7 @@ class VpcId(CloudFormationLintRule):
     def match(self, cfn):
         """Check CloudFormation VpcId Parameters"""
 
-        matches = list()
+        matches = []
 
         # Build the list of refs
         trees = cfn.search_deep_keys('VpcId')

--- a/src/cfnlint/rules/resources/route53/RecordSet.py
+++ b/src/cfnlint/rules/resources/route53/RecordSet.py
@@ -48,7 +48,7 @@ class RecordSet(CloudFormationLintRule):
 
     def check_a_record(self, path, recordset):
         """Check A record Configuration"""
-        matches = list()
+        matches = []
 
         resource_records = recordset.get('ResourceRecords')
         for index, record in enumerate(resource_records):
@@ -65,7 +65,7 @@ class RecordSet(CloudFormationLintRule):
 
     def check_aaaa_record(self, path, recordset):
         """Check AAAA record Configuration"""
-        matches = list()
+        matches = []
 
         resource_records = recordset.get('ResourceRecords')
         for index, record in enumerate(resource_records):
@@ -82,7 +82,7 @@ class RecordSet(CloudFormationLintRule):
 
     def check_caa_record(self, path, recordset):
         """Check CAA record Configuration"""
-        matches = list()
+        matches = []
 
         resource_records = recordset.get('ResourceRecords')
 
@@ -121,7 +121,7 @@ class RecordSet(CloudFormationLintRule):
 
     def check_cname_record(self, path, recordset):
         """Check CNAME record Configuration"""
-        matches = list()
+        matches = []
 
         resource_records = recordset.get('ResourceRecords')
         if len(resource_records) > 1:
@@ -142,7 +142,7 @@ class RecordSet(CloudFormationLintRule):
 
     def check_txt_record(self, path, recordset):
         """Check TXT record Configuration"""
-        matches = list()
+        matches = []
 
         # Check quotation of the records
         resource_records = recordset.get('ResourceRecords')
@@ -163,7 +163,7 @@ class RecordSet(CloudFormationLintRule):
     def check_recordset(self, path, recordset):
         """Check record configuration"""
 
-        matches = list()
+        matches = []
         recordset_type = recordset.get('Type')
 
         if recordset_type not in self.VALID_RECORD_TYPES:
@@ -187,7 +187,7 @@ class RecordSet(CloudFormationLintRule):
     def match(self, cfn):
         """Check RecordSets and RecordSetGroups Properties"""
 
-        matches = list()
+        matches = []
 
         recordsets = cfn.get_resources(['AWS::Route53::RecordSet'])
 

--- a/src/cfnlint/rules/resources/stepfunctions/StateMachine.py
+++ b/src/cfnlint/rules/resources/stepfunctions/StateMachine.py
@@ -35,7 +35,7 @@ class StateMachine(CloudFormationLintRule):
 
     def _check_state_json(self, def_json, state_name, path):
         """Check State JSON Definition"""
-        matches = list()
+        matches = []
 
         common_state_keys = [
             'Next',
@@ -93,7 +93,7 @@ class StateMachine(CloudFormationLintRule):
 
     def _check_definition_json(self, def_json, path):
         """Check JSON Definition"""
-        matches = list()
+        matches = []
 
         top_level_keys = [
             'Comment',
@@ -122,7 +122,7 @@ class StateMachine(CloudFormationLintRule):
 
     def check_value(self, value, path):
         """Check Definition Value"""
-        matches = list()
+        matches = []
         try:
             def_json = json.loads(value)
         # pylint: disable=W0703
@@ -136,7 +136,7 @@ class StateMachine(CloudFormationLintRule):
 
     def check_sub(self, value, path):
         """Check Sub Object"""
-        matches = list()
+        matches = []
         if isinstance(value, list):
             matches.extend(self.check_value(value[0], path))
         elif isinstance(value, six.string_types):
@@ -146,7 +146,7 @@ class StateMachine(CloudFormationLintRule):
 
     def match_resource_properties(self, properties, _, path, cfn):
         """Check CloudFormation Properties"""
-        matches = list()
+        matches = []
 
         matches.extend(
             cfn.check_value(

--- a/src/cfnlint/rules/templates/Base.py
+++ b/src/cfnlint/rules/templates/Base.py
@@ -32,7 +32,7 @@ class Base(CloudFormationLintRule):
 
     def match(self, cfn):
         """Basic Matching"""
-        matches = list()
+        matches = []
 
         top_level = []
         for x in cfn.template:

--- a/src/cfnlint/rules/templates/Description.py
+++ b/src/cfnlint/rules/templates/Description.py
@@ -29,7 +29,7 @@ class Description(CloudFormationLintRule):
 
     def match(self, cfn):
         """Basic Matching"""
-        matches = list()
+        matches = []
 
         description = cfn.template.get('Description')
 

--- a/src/cfnlint/rules/templates/LimitDescription.py
+++ b/src/cfnlint/rules/templates/LimitDescription.py
@@ -29,7 +29,7 @@ class LimitDescription(CloudFormationLintRule):
 
     def match(self, cfn):
         """Basic Matching"""
-        matches = list()
+        matches = []
 
         description = cfn.template.get('Description', '')
 

--- a/src/cfnlint/rules/templates/LimitSize.py
+++ b/src/cfnlint/rules/templates/LimitSize.py
@@ -30,7 +30,7 @@ class LimitSize(CloudFormationLintRule):
 
     def match(self, cfn):
         """Basic Matching"""
-        matches = list()
+        matches = []
 
         # Check number of resources against the defined limit
         filename = cfn.filename

--- a/test/integration/test_good_templates.py
+++ b/test/integration/test_good_templates.py
@@ -73,7 +73,7 @@ class TestQuickStartTemplates(BaseTestCase):
             template = cfnlint.decode.cfn_yaml.load(filename)
 
             runner = Runner(self.rules, filename, template, ['us-east-1'])
-            matches = list()
+            matches = []
             matches.extend(runner.transform())
             if not matches:
                 matches.extend(runner.run())

--- a/test/integration/test_quickstart_templates.py
+++ b/test/integration/test_quickstart_templates.py
@@ -91,7 +91,7 @@ class TestQuickStartTemplates(BaseTestCase):
             template = cfnlint.decode.cfn_yaml.load(filename)
 
             runner = Runner(self.rules, filename, template, ['us-east-1'])
-            matches = list()
+            matches = []
             matches.extend(runner.transform())
             if not matches:
                 matches.extend(runner.run())

--- a/test/module/cfn_json/test_cfn_json.py
+++ b/test/module/cfn_json/test_cfn_json.py
@@ -66,7 +66,7 @@ class TestCfnJson(BaseTestCase):
             template = json.load(open(filename), cls=cfnlint.decode.cfn_json.CfnJSONDecoder)
             cfn = Template(filename, template, ['us-east-1'])
 
-            matches = list()
+            matches = []
             matches.extend(self.rules.run(filename, cfn))
             assert len(matches) == failures, 'Expected {} failures, got {} on {}'.format(failures, len(matches), filename)
 

--- a/test/module/cfn_yaml/test_yaml.py
+++ b/test/module/cfn_yaml/test_yaml.py
@@ -45,6 +45,6 @@ class TestYamlParse(BaseTestCase):
             template = cfnlint.decode.cfn_yaml.load(filename)
             cfn = Template(filename, template, ['us-east-1'])
 
-            matches = list()
+            matches = []
             matches.extend(self.rules.run(filename, cfn))
             assert len(matches) == failures, 'Expected {} failures, got {} on {}'.format(failures, len(matches), filename)

--- a/test/module/test_rules_collections.py
+++ b/test/module/test_rules_collections.py
@@ -43,7 +43,7 @@ class TestTemplate(BaseTestCase):
         template = cfnlint.decode.cfn_yaml.load(filename)
         cfn = Template(filename, template, ['us-east-1'])
 
-        matches = list()
+        matches = []
         matches.extend(self.rules.run(filename, cfn))
         assert(matches == [])
 
@@ -53,7 +53,7 @@ class TestTemplate(BaseTestCase):
         template = cfnlint.decode.cfn_yaml.load(filename)
         cfn = Template(filename, template, ['us-east-1'])
 
-        matches = list()
+        matches = []
         matches.extend(self.rules.run(filename, cfn))
         assert len(matches) == 31, 'Expected {} failures, got {}'.format(31, len(matches))
 
@@ -63,6 +63,6 @@ class TestTemplate(BaseTestCase):
         template = cfnlint.decode.cfn_yaml.load(filename)
         cfn = Template(filename, template, ['us-east-1'])
 
-        matches = list()
+        matches = []
         matches.extend(self.rules.run(filename, cfn))
         assert len(matches) == 3, 'Expected {} failures, got {}'.format(2, len(matches))


### PR DESCRIPTION
dict, tuple, and list literals are actually single instructions in the CPython virtual machine, so it's always faster and better form to use them over the type constructors.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
