### PR TITLE
Clarify supported Python versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,15 +19,13 @@ before the linter processes the template.
 
 
 ## Install
-### Command line
-From a command prompt run `python setup.py clean --all` then `python setup.py install`
+
+Python 2.7+ and 3.4+ are supported.
 
 ### Pip Install
-`pip install cfn-lint`.  You may need to use sudo.
 
-## Uninstall
-If you have pip installed you can uninstall using `pip uninstall cfn-lint`.  You
-may need to manually remove the cfn-lint binary.
+`pip install cfn-lint`. If pip is not available, run
+`python setup.py clean --all` then `python setup.py install`.
 
 ### Editor Plugins
 There are IDE plugins available to get direct linter feedback from you favorite editor:

--- a/setup.py
+++ b/setup.py
@@ -48,11 +48,25 @@ setup(
     packages=find_packages('src'),
     zip_safe=False,
     install_requires=['pyyaml', 'six', 'requests', 'aws-sam-translator>=1.6.0'],
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     entry_points={
         'console_scripts': [
             'cfn-lint = cfnlint.__main__:main'
         ]
     },
     license='MIT no attribution',
-    test_suite="unittest"
+    test_suite="unittest",
+    classifiers=[
+        'Development Status :: 5 - Production/Stable',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: MIT License',
+        'Natural Language :: English',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+    ],
 )


### PR DESCRIPTION
In the documentation, add the supported Python versions, prioritize installing with pip, and remove unnecessary instructions on uninstalling.

In `setup.py`, add `python_requires` to limit usable Python versions, and classifiers to make it discoverable on the PyPI page.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
