### PR TITLE
Avoid importing/executing code to load version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,23 +14,27 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-import sys
-import os
+import codecs
+import re
 from setuptools import find_packages
 from setuptools import setup
 
-# python 3 only
-# from src.cfnlint.version import __version__
 
-sys.path.insert(0, os.path.abspath('src'))
-exec(open('src/cfnlint/version.py').read())
+def get_version(filename):
+    with codecs.open(filename, 'r', 'utf-8') as fp:
+        contents = fp.read()
+    return re.search(r"__version__ = ['\"]([^'\"]+)['\"]", contents).group(1)
+
+
+version = get_version('src/cfnlint/version.py')
+
 
 with open('README.md') as f:
     readme = f.read()
 
 setup(
     name='cfn-lint',
-    version=__version__,
+    version=version,
     description=('checks cloudformation for practices and behaviour \
         that could potentially be improved'),
     long_description=readme,


### PR DESCRIPTION
Add a function I use in my projects ([example](https://github.com/adamchainz/ec2-metadata/blob/master/setup.py)) that parses out the `__version__` with a regex, which is compatible with Python 2.7+.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
