### PR TITLE
Fix ResourceWarnings

### DIFF
--- a/src/cfnlint/decode/__init__.py
+++ b/src/cfnlint/decode/__init__.py
@@ -57,7 +57,8 @@ def decode(filename, ignore_bad_template):
     except ScannerError as err:
         if err.problem == 'found character \'\\t\' that cannot start any token':
             try:
-                template = json.load(open(filename), cls=cfnlint.decode.cfn_json.CfnJSONDecoder)
+                with open(filename) as fp:
+                    template = json.load(fp, cls=cfnlint.decode.cfn_json.CfnJSONDecoder)
             except cfnlint.decode.cfn_json.JSONDecodeError as json_err:
                 json_err.match.filename = filename
                 matches = [json_err.match]

--- a/src/cfnlint/decode/cfn_yaml.py
+++ b/src/cfnlint/decode/cfn_yaml.py
@@ -195,5 +195,5 @@ def load(filename):
     """
     Load the given YAML file
     """
-    fp = open(filename)
-    return loads(fp.read(), filename)
+    with open(filename) as fp:
+        return loads(fp.read(), filename)

--- a/src/cfnlint/helpers.py
+++ b/src/cfnlint/helpers.py
@@ -106,9 +106,8 @@ def load_resources(filename='/data/CloudSpecs/us-east-1.json'):
         filename
     )
 
-    data = json.load(open(filename))
-
-    return data
+    with open(filename) as fp:
+        return json.load(fp)
 
 
 RESOURCE_SPECS = {}
@@ -211,7 +210,8 @@ def override_specs(override_spec_file):
     """Override specs file"""
     try:
         filename = override_spec_file
-        custom_spec_data = json.load(open(filename))
+        with open(filename) as fp:
+            custom_spec_data = json.load(fp)
 
         set_specs(custom_spec_data)
     except IOError as e:

--- a/test/module/cfn_json/test_cfn_json.py
+++ b/test/module/cfn_json/test_cfn_json.py
@@ -63,7 +63,8 @@ class TestCfnJson(BaseTestCase):
         for _, values in self.filenames.items():
             filename = values.get('filename')
             failures = values.get('failures')
-            template = json.load(open(filename), cls=cfnlint.decode.cfn_json.CfnJSONDecoder)
+            with open(filename) as fp:
+                template = json.load(fp, cls=cfnlint.decode.cfn_json.CfnJSONDecoder)
             cfn = Template(filename, template, ['us-east-1'])
 
             matches = []
@@ -76,7 +77,8 @@ class TestCfnJson(BaseTestCase):
         filename = 'fixtures/templates/bad/json_parse.json'
 
         try:
-            json.load(open(filename), cls=cfnlint.decode.cfn_json.CfnJSONDecoder)
+            with open(filename) as fp:
+                json.load(fp, cls=cfnlint.decode.cfn_json.CfnJSONDecoder)
         except cfnlint.decode.cfn_json.JSONDecodeError:
             assert(True)
             return

--- a/test/module/override/test_complete.py
+++ b/test/module/override/test_complete.py
@@ -39,7 +39,8 @@ class TestComplete(BaseTestCase):
         """Success test"""
         filename = 'fixtures/templates/good/override/complete.yaml'
         template = self.load_template(filename)
-        custom_spec = json.load(open('fixtures/templates/override_spec/complete.json'))
+        with open('fixtures/templates/override_spec/complete.json') as fp:
+            custom_spec = json.load(fp)
 
         cfnlint.helpers.set_specs(custom_spec)
 
@@ -51,7 +52,8 @@ class TestComplete(BaseTestCase):
         filename = 'fixtures/templates/bad/override/complete.yaml'
         template = self.load_template(filename)
 
-        custom_spec = json.load(open('fixtures/templates/override_spec/complete.json'))
+        with open('fixtures/templates/override_spec/complete.json') as fp:
+            custom_spec = json.load(fp)
         cfnlint.helpers.set_specs(custom_spec)
 
         bad_runner = Runner(self.collection, filename, template, ['us-east-1'], [])

--- a/test/module/override/test_exclude.py
+++ b/test/module/override/test_exclude.py
@@ -37,7 +37,8 @@ class TestExclude(BaseTestCase):
         """Success test"""
         filename = 'fixtures/templates/good/generic.yaml'
         template = self.load_template(filename)
-        custom_spec = json.load(open('fixtures/templates/override_spec/exclude.json'))
+        with open('fixtures/templates/override_spec/exclude.json') as fp:
+            custom_spec = json.load(fp)
 
         cfnlint.helpers.set_specs(custom_spec)
 
@@ -49,7 +50,8 @@ class TestExclude(BaseTestCase):
         filename = 'fixtures/templates/bad/override/exclude.yaml'
         template = self.load_template(filename)
 
-        custom_spec = json.load(open('fixtures/templates/override_spec/exclude.json'))
+        with open('fixtures/templates/override_spec/exclude.json') as fp:
+            custom_spec = json.load(fp)
         cfnlint.helpers.set_specs(custom_spec)
 
         bad_runner = Runner(self.collection, filename, template, ['us-east-1'], [])

--- a/test/module/override/test_include.py
+++ b/test/module/override/test_include.py
@@ -38,7 +38,8 @@ class TestInclude(BaseTestCase):
         filename = 'fixtures/templates/bad/override/include.yaml'
         template = self.load_template(filename)
 
-        custom_spec = json.load(open('fixtures/templates/override_spec/include.json'))
+        with open('fixtures/templates/override_spec/include.json') as fp:
+            custom_spec = json.load(fp)
         cfnlint.helpers.set_specs(custom_spec)
 
         bad_runner = Runner(self.collection, filename, template, ['us-east-1'], [])

--- a/test/module/override/test_required.py
+++ b/test/module/override/test_required.py
@@ -37,7 +37,8 @@ class TestOverrideRequired(BaseTestCase):
         """Success test"""
         filename = 'fixtures/templates/good/override/required.yaml'
         template = self.load_template(filename)
-        custom_spec = json.load(open('fixtures/templates/override_spec/required.json'))
+        with open('fixtures/templates/override_spec/required.json') as fp:
+            custom_spec = json.load(fp)
 
         cfnlint.helpers.set_specs(custom_spec)
 
@@ -48,7 +49,8 @@ class TestOverrideRequired(BaseTestCase):
         """Failure test required"""
         filename = 'fixtures/templates/bad/override/required.yaml'
         template = self.load_template(filename)
-        custom_spec = json.load(open('fixtures/templates/override_spec/required.json'))
+        with open('fixtures/templates/override_spec/required.json') as fp:
+            custom_spec = json.load(fp)
 
         cfnlint.helpers.set_specs(custom_spec)
 

--- a/test/module/test_duplicate.py
+++ b/test/module/test_duplicate.py
@@ -54,7 +54,8 @@ class TestDuplicate(BaseTestCase):
         filename = 'fixtures/templates/bad/duplicate.json'
 
         try:
-            json.load(open(filename), cls=cfnlint.decode.cfn_json.CfnJSONDecoder)
+            with open(filename) as fp:
+                json.load(fp, cls=cfnlint.decode.cfn_json.CfnJSONDecoder)
         except cfnlint.decode.cfn_json.JSONDecodeError:
             assert(True)
             return

--- a/test/module/test_null_values.py
+++ b/test/module/test_null_values.py
@@ -54,7 +54,8 @@ class TestNulls(BaseTestCase):
         filename = 'fixtures/templates/bad/null_values.json'
 
         try:
-            json.load(open(filename), cls=cfnlint.decode.cfn_json.CfnJSONDecoder)
+            with open(filename) as fp:
+                json.load(fp, cls=cfnlint.decode.cfn_json.CfnJSONDecoder)
         except cfnlint.decode.cfn_json.JSONDecodeError as err:
             self.assertIn("Null Error \"EbsOptimized\"", err.msg)
             return


### PR DESCRIPTION
Running the test suite with unittest in #336 I saw a lot of `ResourceWarning`s e.g.:

```
cfn-python-lint/test/testlib/testcase.py:31: ResourceWarning: unclosed file <_io.TextIOWrapper name='fixtures/templates/good/templates/description.yaml' mode='r' encoding='UTF-8'>
```

This fixes them all, by ensuring files are closed after `open()` by using it in its context manager form.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
