### PR TITLE
Fix rule E2540 to not fail when the stage name isn't a string

### DIFF
--- a/src/cfnlint/rules/resources/codepipeline/CodepipelineStages.py
+++ b/src/cfnlint/rules/resources/codepipeline/CodepipelineStages.py
@@ -14,6 +14,7 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
+import six
 from cfnlint import CloudFormationLintRule
 from cfnlint import RuleMatch
 
@@ -83,15 +84,17 @@ class CodepipelineStages(CloudFormationLintRule):
         """Check that stage names are unique."""
         matches = []
         stage_names = set()
-
         for sidx, stage in enumerate(value):
-            if stage.get('Name') in stage_names:
-                message = 'All stage names within a pipeline must be unique. ({name})'.format(
-                    name=stage.get('Name'),
-                )
-                matches.append(RuleMatch(path + [sidx, 'Name'], message))
-            stage_names.add(stage.get('Name'))
-
+            stage_name = stage.get('Name')
+            if isinstance(stage_name, six.string_types):
+                if stage_name in stage_names:
+                    message = 'All stage names within a pipeline must be unique. ({name})'.format(
+                        name=stage_name,
+                    )
+                    matches.append(RuleMatch(path + [sidx, 'Name'], message))
+                stage_names.add(stage_name)
+            else:
+                self.logger.debug('Found non string for stage name: %s', stage_name)
         return matches
 
     def match(self, cfn):

--- a/test/fixtures/templates/good/resources_codepipeline.yaml
+++ b/test/fixtures/templates/good/resources_codepipeline.yaml
@@ -37,3 +37,15 @@ Resources:
                 ProjectName: cfn-python-lint
               InputArtifacts:
               - Name: MyApp
+        - Name: !ImportValue TestImport
+          Actions:
+            - Name: CodeBuild
+              ActionTypeId:
+                Category: Build
+                Owner: AWS
+                Version: "1"
+                Provider: CodeBuild
+              Configuration:
+                ProjectName: cfn-python-lint
+              InputArtifacts:
+              - Name: MyApp


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Fix rule E2540 to not crash when the stage name isn't a string

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
