### PR TITLE
Fix rule E3002 when using NoValue in conditions with lists as values

### DIFF
--- a/test/fixtures/templates/good/resource_properties.yaml
+++ b/test/fixtures/templates/good/resource_properties.yaml
@@ -589,10 +589,7 @@ Resources:
           KeyType: HASH
         - AttributeName: !Ref SortKeyName
           KeyType: RANGE
-      - - AttributeName: !Ref PartitionKeyName
-          KeyType: HASH
-        - AttributeName: !Ref SortKeyName
-          KeyType: RANGE
+      - !Ref AWS::NoValue
   CustomResource1:
     Type: 'AWS::CloudFormation::CustomResource'
     Properties:


### PR DESCRIPTION
*Issue #, if available:*
Fixes #350 

*Description of changes:*
- Fix rule E3002 when using Ref: AWS::NoValue in conditions with lists 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
