### PR TITLE
Issue an error when trying to load plugins from a bad directory

### DIFF
--- a/src/cfnlint/core.py
+++ b/src/cfnlint/core.py
@@ -181,9 +181,13 @@ def get_rules(rulesdir, ignore_rules):
     """Get rules"""
     rules = RulesCollection(ignore_rules)
     rules_dirs = [DEFAULT_RULESDIR] + rulesdir
-    for rules_dir in rules_dirs:
-        rules.extend(
-            RulesCollection.create_from_directory(rules_dir))
+    try:
+        for rules_dir in rules_dirs:
+            rules.extend(
+                RulesCollection.create_from_directory(rules_dir))
+    except OSError as e:
+        LOGGER.error('Tried to append rules but got an error: %s', str(e))
+        exit(1)
 
     return rules
 

--- a/src/cfnlint/helpers.py
+++ b/src/cfnlint/helpers.py
@@ -188,7 +188,11 @@ def load_plugins(directory):
     result = []
     fh = None
 
-    for root, _, filenames in os.walk(directory):
+    def onerror(os_error):
+        """Raise an error"""
+        raise os_error
+
+    for root, _, filenames in os.walk(directory, onerror=onerror):
         for filename in fnmatch.filter(filenames, '[A-Za-z]*.py'):
             pluginname = filename.replace('.py', '')
             try:
@@ -203,6 +207,7 @@ def load_plugins(directory):
             finally:
                 if fh:
                     fh.close()
+
     return result
 
 


### PR DESCRIPTION
*Issue #, if available:*
- Fixes #334 
*Description of changes:*
- Fix load_plugins to raise an error when there is an OS Error processing the parameters

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
