### PR TITLE
Fix E2509 check when Fn::Sub has a mapping

### DIFF
--- a/src/cfnlint/rules/resources/ectwo/SecurityGroupDescription.py
+++ b/src/cfnlint/rules/resources/ectwo/SecurityGroupDescription.py
@@ -15,6 +15,7 @@
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 import re
+import six
 from cfnlint import CloudFormationLintRule
 from cfnlint import RuleMatch
 
@@ -28,12 +29,20 @@ class SecurityGroupDescription(CloudFormationLintRule):
 
     description_regex = r'^([a-z,A-Z,0-9,. _\-:/()#,@[\]+=&;\{\}!$*])*$'
 
+
     # pylint: disable=W0613
     def check_sub(self, value, path, **kwargs):
         """Check SecurityGroup descriptions in Subs"""
         # Just check the raw sub string itself, without the replacements
         # for special characters
-        return self.check_value(value, path)
+        matches = []
+        if isinstance(value, list):
+            if isinstance(value[0], six.string_types):
+                matches.extend(self.check_value(value[0], path[:] + [0]))
+        else:
+            matches.extend(self.check_value(value, path[:]))
+        return matches
+
 
     def check_value(self, value, path):
         """Check SecurityGroup descriptions"""

--- a/test/fixtures/templates/bad/properties_sg_description.yaml
+++ b/test/fixtures/templates/bad/properties_sg_description.yaml
@@ -25,3 +25,15 @@ Resources:
     Type: AWS::EC2::SecurityGroup
     Properties:
       GroupDescription: !Sub 'Securitygroup of ${AppGroup} has invalid characters like  ^ and "'
+  mySecurityGroupValidMapping:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: !Sub
+      - '${Var} works fine with the mapping below'
+      - Var: content
+  mySecurityGroupBadMapping:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: !Sub
+      - '${Var} works will faill because ^ is an invalid character'
+      - Var: content

--- a/test/rules/resources/ec2/test_sg_description.py
+++ b/test/rules/resources/ec2/test_sg_description.py
@@ -31,4 +31,4 @@ class TestPropertySgDescription(BaseRuleTestCase):
 
     def test_file_negative(self):
         """Test failure"""
-        self.helper_file_negative('fixtures/templates/bad/properties_sg_description.yaml', 3)
+        self.helper_file_negative('fixtures/templates/bad/properties_sg_description.yaml', 4)


### PR DESCRIPTION
*Issue #, if available:*
#355 

*Description of changes:*

* Fix Security Group Description check for Fn::Sub that contains a mapping (E2509)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
