### PR TITLE
Metadata isn't supported for properties only at the top level resource

### DIFF
--- a/src/cfnlint/rules/resources/properties/Properties.py
+++ b/src/cfnlint/rules/resources/properties/Properties.py
@@ -185,7 +185,7 @@ class Properties(CloudFormationLintRule):
                         matches.extend(self.propertycheck(
                             cond_value['Value'], proptype, parenttype, resourcename,
                             proppath + cond_value['Path'], root))
-                elif prop != 'Metadata' and not supports_additional_properties:
+                elif not supports_additional_properties:
                     message = 'Invalid Property %s' % ('/'.join(map(str, proppath)))
                     matches.append(RuleMatch(proppath, message))
             else:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Metadata can't be used under resource properties.  Only directly under the resource.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
