### PR TITLE
Removed Fn::Sub parameter checks from E1012 (now covered by E1019)

### DIFF
--- a/src/cfnlint/rules/functions/RefExist.py
+++ b/src/cfnlint/rules/functions/RefExist.py
@@ -55,12 +55,6 @@ class RefExist(CloudFormationLintRule):
         for reftree in reftrees:
             refs.append(reftree[-1])
 
-        # build the sub lists
-        subtrees = cfn.search_deep_keys('Fn::Sub')
-        subs = []
-        for subtree in subtrees:
-            subs.append(subtree[-1])
-
         valid_refs = cfn.get_valid_refs()
 
         # start with the basic ref calls
@@ -72,23 +66,5 @@ class RefExist(CloudFormationLintRule):
                     matches.append(RuleMatch(
                         reftree[:-2], message.format(ref)
                     ))
-        for subtree in subtrees:
-            sub = subtree[-1]
-            parammatches = []
-            subparams = []
-            if isinstance(sub, (six.text_type, six.string_types)):
-                parammatches = self.searchstring(sub)
-            elif isinstance(subtree[-1], (list)):
-                if len(sub) == 2:
-                    parammatches = self.searchstring(sub[0])
-                    for subparam in sub[1]:
-                        subparams.append(subparam)
-            for parammatch in parammatches:
-                if parammatch not in valid_refs:
-                    if parammatch not in subparams:
-                        message = 'Ref {0} not found as a resource or parameter'
-                        matches.append(RuleMatch(
-                            subtree[:-2], message.format(parammatch)
-                        ))
 
         return matches

--- a/test/rules/functions/test_ref_exist.py
+++ b/test/rules/functions/test_ref_exist.py
@@ -31,4 +31,4 @@ class TestRulesRefExist(BaseRuleTestCase):
 
     def test_file_negative(self):
         """Test failure"""
-        self.helper_file_negative('fixtures/templates/bad/functions/ref.yaml', 5)
+        self.helper_file_negative('fixtures/templates/bad/functions/ref.yaml', 3)


### PR DESCRIPTION
*Issue #, if available:*
#361 

*Description of changes:*

Removed parameter validation for Fn::Sub in E1012 since we now do more robust Fn::Sub validation in E1019 and this was creating the duplicate errors.

Reduced the expected error count in E1012 tests to reflect this change (similar tests are already in place for E1019).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
