### PR TITLE
Handle strings when using the long version of Fn::GetAtt

### DIFF
--- a/src/cfnlint/decode/cfn_yaml.py
+++ b/src/cfnlint/decode/cfn_yaml.py
@@ -176,6 +176,7 @@ def construct_getatt(node):
     """
     Reconstruct !GetAtt into a list
     """
+
     if isinstance(node.value, (six.string_types)):
         return list_node(node.value.split('.'), node.start_mark, node.end_mark)
     if isinstance(node.value, list):

--- a/src/cfnlint/rules/functions/GetAtt.py
+++ b/src/cfnlint/rules/functions/GetAtt.py
@@ -14,6 +14,7 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
+import six
 from cfnlint import CloudFormationLintRule
 from cfnlint import RuleMatch
 import cfnlint.helpers
@@ -44,8 +45,12 @@ class GetAtt(CloudFormationLintRule):
                 message = 'Invalid GetAtt for {0}'
                 matches.append(RuleMatch(getatt, message.format('/'.join(map(str, getatt[:-1])))))
                 continue
-            resname = getatt[-1][0]
-            restype = '.'.join(getatt[-1][1:])
+            if isinstance(getatt[-1], six.string_types):
+                resname, restype = getatt[-1].split('.')
+            else:
+                resname = getatt[-1][0]
+                restype = '.'.join(getatt[-1][1:])
+
             if resname in valid_getatts:
                 if restype not in valid_getatts[resname] and '*' not in valid_getatts[resname]:
                     message = 'Invalid GetAtt {0}.{1} for resource {2}'

--- a/test/fixtures/templates/bad/functions/getatt.yaml
+++ b/test/fixtures/templates/bad/functions/getatt.yaml
@@ -1,0 +1,10 @@
+---
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  myElasticSearch:
+    Type: AWS::Elasticsearch::Domain
+    Properties: {}
+Outputs:
+  ElasticSearchHostname:
+    Value:
+      Fn::GetAtt: ElasticSearchDomain.DomainEndpoint

--- a/test/fixtures/templates/good/functions/getatt.yaml
+++ b/test/fixtures/templates/good/functions/getatt.yaml
@@ -1,0 +1,10 @@
+---
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  myElasticSearch:
+    Type: AWS::Elasticsearch::Domain
+    Properties: {}
+Outputs:
+  ElasticSearchHostname:
+    Value:
+      Fn::GetAtt: myElasticSearch.DomainEndpoint

--- a/test/rules/functions/test_get_att.py
+++ b/test/rules/functions/test_get_att.py
@@ -24,6 +24,9 @@ class TestRulesGetAtt(BaseRuleTestCase):
         """Setup"""
         super(TestRulesGetAtt, self).setUp()
         self.collection.register(GetAtt())
+        self.success_templates = [
+            'fixtures/templates/good/functions/getatt.yaml'
+        ]
 
     def test_file_positive(self):
         """Test Positive"""
@@ -32,3 +35,7 @@ class TestRulesGetAtt(BaseRuleTestCase):
     def test_file_negative(self):
         """Test failure"""
         self.helper_file_negative('fixtures/templates/bad/generic.yaml', 1)
+
+    def test_file_negative_getatt(self):
+        """Test failure"""
+        self.helper_file_negative('fixtures/templates/bad/functions/getatt.yaml', 1)


### PR DESCRIPTION
*Issue #, if available:*
Fix #367 
*Description of changes:*
- Fix rule 1010 to handle strings when using the long function name of Fn::GetAtt


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
