### PR TITLE
Fix Route53 Ref checks

### DIFF
--- a/src/cfnlint/rules/resources/route53/RecordSet.py
+++ b/src/cfnlint/rules/resources/route53/RecordSet.py
@@ -166,21 +166,23 @@ class RecordSet(CloudFormationLintRule):
         matches = []
         recordset_type = recordset.get('Type')
 
-        if recordset_type not in self.VALID_RECORD_TYPES:
-            message = 'Invalid record type "{0}" specified'
-            matches.append(RuleMatch(path + ['Type'], message.format(recordset_type)))
-        elif not recordset.get('AliasTarget'):
-            # Record type specific checks
-            if recordset_type == 'A':
-                matches.extend(self.check_a_record(path, recordset))
-            elif recordset_type == 'AAAA':
-                matches.extend(self.check_aaaa_record(path, recordset))
-            elif recordset_type == 'CAA':
-                matches.extend(self.check_caa_record(path, recordset))
-            elif recordset_type == 'CNAME':
-                matches.extend(self.check_cname_record(path, recordset))
-            elif recordset_type == 'TXT':
-                matches.extend(self.check_txt_record(path, recordset))
+        # Skip Intrinsic functions
+        if not isinstance(recordset_type, dict):
+            if recordset_type not in self.VALID_RECORD_TYPES:
+                message = 'Invalid record type "{0}" specified'
+                matches.append(RuleMatch(path + ['Type'], message.format(recordset_type)))
+            elif not recordset.get('AliasTarget'):
+                # Record type specific checks
+                if recordset_type == 'A':
+                    matches.extend(self.check_a_record(path, recordset))
+                elif recordset_type == 'AAAA':
+                    matches.extend(self.check_aaaa_record(path, recordset))
+                elif recordset_type == 'CAA':
+                    matches.extend(self.check_caa_record(path, recordset))
+                elif recordset_type == 'CNAME':
+                    matches.extend(self.check_cname_record(path, recordset))
+                elif recordset_type == 'TXT':
+                    matches.extend(self.check_txt_record(path, recordset))
 
         return matches
 

--- a/test/fixtures/templates/good/route53.yaml
+++ b/test/fixtures/templates/good/route53.yaml
@@ -4,6 +4,8 @@ Parameters:
   DomainName:
     Type: String
     Default: "example.com"
+  RecordType:
+    Type: String
 Resources:
   MyHostedZone:
     Type: "AWS::Route53::HostedZone"
@@ -12,6 +14,15 @@ Resources:
       VPCs:
         - VPCId: !ImportValue "infrastructure-vpc"
           VPCRegion: !Ref "AWS::Region"
+  MyRefRecordSet:
+    Type: "AWS::Route53::RecordSet"
+    Properties:
+      HostedZoneId: !Ref "MyHostedZone"
+      Name: "x.example.com"
+      Type: !Ref "RecordType"
+      TTL: "300"
+      ResourceRecords:
+        - "value"
   MyTXTRecordSet:
     Type: "AWS::Route53::RecordSet"
     Properties:


### PR DESCRIPTION
*Issue https://github.com/awslabs/cfn-python-lint/issues/363:*

A recordtype can be specified using instrinsic functions, ignore these values .

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
