### PR TITLE
Add new rule W3011 to validate DynamoDB has a deletion policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,10 +70,14 @@ Optional parameters:
 | -b, --ignore-bad-template | ignore_bad_template | | Ignores bad template errors |
 | -a, --append-rules | append_rules | [RULESDIR [RULESDIR ...]] | Specify one or more rules directories using one or more --append-rules arguments. |
 | -i, --ignore-checks | ignore_checks | [IGNORE_CHECKS [IGNORE_CHECKS ...]] | Only check rules whose ID do not match or prefix these values.  Examples: <br />- A value of `W` will disable all warnings<br />- `W2` disables all Warnings for Parameter rules.<br />- `W2001` will disable rule `W2001` |
+| -c, --include-checks | INCLUDE_CHECKS [INCLUDE_CHECKS ...] | Include rules whose id match these values
 | -d, --debug |  |  | Specify to enable debug logging |
 | -u, --update-specs | | | Update the CloudFormation Specs.  You may need sudo to run this.  You will need internet access when running this command |
 | -o, --override-spec | | filename | Spec-style file containing custom definitions. Can be used to override CloudFormation specifications. More info [here](#customise-specifications) |
 | -v, --version | | | Version of cfn-lint |
+
+### Info Rules
+To maintain backwards compatibility `info` rules are not included by default.  To include these rules you will need to include `-c I` or `--include-checks I`
 
 ### Metadata
 Inside the root level Metadata key you can configure cfn-lint using the supported parameters.

--- a/src/cfnlint/rules/resources/dynamodb/TableDeletionPolicy.py
+++ b/src/cfnlint/rules/resources/dynamodb/TableDeletionPolicy.py
@@ -1,0 +1,43 @@
+"""
+  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this
+  software and associated documentation files (the "Software"), to deal in the Software
+  without restriction, including without limitation the rights to use, copy, modify,
+  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+from cfnlint import CloudFormationLintRule
+from cfnlint import RuleMatch
+
+
+class TableDeletionPolicy(CloudFormationLintRule):
+    """Check Dynamo DB Deletion Policy"""
+    id = 'I3011'
+    shortdesc = 'Check DynamoDB tables have a set DeletionPolicy'
+    description = 'The default action when removing a DynamoDB Table is to ' \
+                  'delete it. This check requires you to specifically set a DeletionPolicy ' \
+                  'and you know the risks'
+    source_url = 'https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html'
+    tags = ['resources', 'dynamodb']
+
+    def match(self, cfn):
+        """Check CloudFormation DynamDB Tables"""
+        matches = []
+
+        resources = cfn.get_resources(resource_type=['AWS::DynamoDB::Table'])
+        for r_name, r_values in resources.items():
+            if not r_values.get('DeletionPolicy'):
+                path = ['Resources', r_name]
+                message = 'The default action on removal of a DynamoDB is to delete it. ' \
+                          'Set a DeletionPolicy and specify either \'retain\' or \'delete\'.'
+                matches.append(RuleMatch(path, message))
+
+        return matches

--- a/src/cfnlint/rules/resources/dynamodb/__init__.py
+++ b/src/cfnlint/rules/resources/dynamodb/__init__.py
@@ -1,0 +1,16 @@
+"""
+  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this
+  software and associated documentation files (the "Software"), to deal in the Software
+  without restriction, including without limitation the rights to use, copy, modify,
+  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""

--- a/test/fixtures/templates/bad/resources/dynamodb/delete_policy.yaml
+++ b/test/fixtures/templates/bad/resources/dynamodb/delete_policy.yaml
@@ -1,0 +1,16 @@
+---
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  myTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      KeySchema:
+        -
+          AttributeName: "ArtistId"
+          KeyType: "HASH"
+        -
+          AttributeName: "Concert"
+          KeyType: "RANGE"
+      ProvisionedThroughput:
+        ReadCapacityUnits: 5
+        WriteCapacityUnits: 5

--- a/test/fixtures/templates/good/resources/dynamodb/delete_policy.yaml
+++ b/test/fixtures/templates/good/resources/dynamodb/delete_policy.yaml
@@ -1,0 +1,17 @@
+---
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  myTable:
+    Type: AWS::DynamoDB::Table
+    DeletionPolicy: retain
+    Properties:
+      KeySchema:
+        -
+          AttributeName: "ArtistId"
+          KeyType: "HASH"
+        -
+          AttributeName: "Concert"
+          KeyType: "RANGE"
+      ProvisionedThroughput:
+        ReadCapacityUnits: 5
+        WriteCapacityUnits: 5

--- a/test/rules/resources/dynamodb/__init__.py
+++ b/test/rules/resources/dynamodb/__init__.py
@@ -1,0 +1,16 @@
+"""
+  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this
+  software and associated documentation files (the "Software"), to deal in the Software
+  without restriction, including without limitation the rights to use, copy, modify,
+  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""

--- a/test/rules/resources/dynamodb/test_delete_policy.py
+++ b/test/rules/resources/dynamodb/test_delete_policy.py
@@ -1,0 +1,37 @@
+"""
+  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this
+  software and associated documentation files (the "Software"), to deal in the Software
+  without restriction, including without limitation the rights to use, copy, modify,
+  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+from cfnlint.rules.resources.dynamodb.TableDeletionPolicy import TableDeletionPolicy  # pylint: disable=E0401
+from ... import BaseRuleTestCase
+
+
+class TestTableDeletionPolicy(BaseRuleTestCase):
+    """Test StateMachine for Step Functions"""
+    def setUp(self):
+        """Setup"""
+        super(TestTableDeletionPolicy, self).setUp()
+        self.collection.register(TableDeletionPolicy())
+        self.success_templates = [
+            'fixtures/templates/good/resources/dynamodb/delete_policy.yaml'
+        ]
+
+    def test_file_positive(self):
+        """Test Positive"""
+        self.helper_file_positive()
+
+    def test_file_negative_alias(self):
+        """Test failure"""
+        self.helper_file_negative('fixtures/templates/bad/resources/dynamodb/delete_policy.yaml', 1)


### PR DESCRIPTION
*Issue #, if available:*
Fix #369
*Description of changes:*
- New rule W3011 to validate DeletionPolicy is specified for AWS::DynamoDB::Table resources as the default policy is to delete them

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
