### PR TITLE
Save globals section before transformation for rules to access

### DIFF
--- a/test/fixtures/templates/good/parameters/used_transforms.yaml
+++ b/test/fixtures/templates/good/parameters/used_transforms.yaml
@@ -1,0 +1,19 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: 'AWS::Serverless-2016-10-31'
+Parameters:
+  Version:
+    Type: String
+
+Globals:
+  Function:
+    CodeUri:
+      Bucket: "somebucket"
+      Key: !Sub "lambda/code/lambda-${Version}-shaded.jar"
+
+Resources:
+  SomeLambda:
+    Type: 'AWS::Serverless::Function'
+    Properties:
+      Handler: com.SomeLambda::handleRequest
+      Runtime: java8
+      MemorySize: 256

--- a/test/rules/parameters/test_used.py
+++ b/test/rules/parameters/test_used.py
@@ -24,6 +24,9 @@ class TestParameterUsed(BaseRuleTestCase):
         """Setup"""
         super(TestParameterUsed, self).setUp()
         self.collection.register(Used())
+        self.success_templates = [
+            'fixtures/templates/good/parameters/used_transforms.yaml'
+        ]
 
     def test_file_positive(self):
         """Test Positive"""


### PR DESCRIPTION
*Issue #, if available:*
Fix #379 

*Description of changes:*
- Save Globals section prior to transformation so it can be accessed by the rules
- Fix rule W2001 so it uses the Globals sections of Transformations

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
