### PR TITLE
Support strings for IAM policies

### DIFF
--- a/src/cfnlint/helpers.py
+++ b/src/cfnlint/helpers.py
@@ -23,7 +23,7 @@ import logging
 import re
 import inspect
 import pkg_resources
-
+from cfnlint.decode.node import dict_node, list_node
 
 LOGGER = logging.getLogger(__name__)
 
@@ -209,6 +209,22 @@ def load_plugins(directory):
                     fh.close()
 
     return result
+
+
+def convert_dict(template, start_mark=(0, 0), end_mark=(0, 0)):
+    """Convert dict to template"""
+    if isinstance(template, dict):
+        if not isinstance(template, dict_node):
+            template = dict_node(template, start_mark, end_mark)
+        for k, v in template.items():
+            template[k] = convert_dict(v)
+    elif isinstance(template, list):
+        if not isinstance(template, list_node):
+            template = list_node(template, start_mark, end_mark)
+        for i, v in enumerate(template):
+            template[i] = convert_dict(v)
+
+    return template
 
 
 def override_specs(override_spec_file):

--- a/src/cfnlint/rules/resources/iam/Policy.py
+++ b/src/cfnlint/rules/resources/iam/Policy.py
@@ -101,6 +101,13 @@ class Policy(CloudFormationLintRule):
                                     i_s_p, i_s_v, is_identity_policy, resource_exceptions
                                 )
                             )
+                    elif isinstance(parent_value, dict):
+                        for i_s_v, i_s_p in parent_value.items_safe(p_p + ['Statement']):
+                            matches.extend(
+                                self._check_policy_statement(
+                                    i_s_p, i_s_v, is_identity_policy, resource_exceptions
+                                )
+                            )
                     else:
                         message = 'IAM Policy statement should be of list.'
                         matches.append(

--- a/src/cfnlint/transform.py
+++ b/src/cfnlint/transform.py
@@ -22,7 +22,6 @@ from samtranslator.translator.translator import Translator
 from samtranslator.public.exceptions import InvalidDocumentException
 
 import cfnlint.helpers
-from cfnlint.decode.node import dict_node, list_node
 
 
 class Transform(object):
@@ -112,8 +111,8 @@ class Transform(object):
                     pass
 
             with WarningSuppressLogger(parser.logging):
-                self._template = sam_translator.translate(sam_template=self._template, parameter_values={})
-                self._correct_objects()
+                self._template = cfnlint.helpers.convert_dict(
+                    sam_translator.translate(sam_template=self._template, parameter_values={}))
         except InvalidDocumentException as e:
             for cause in e.causes:
                 matches.append(cfnlint.Match(
@@ -122,29 +121,6 @@ class Transform(object):
                     self._filename, cfnlint.TransformError(), cause.message))
 
         return matches
-
-    def _correct_objects_loop(self, template):
-        """
-            Looping for dynamic depths and types
-        """
-        if isinstance(template, dict):
-            if not isinstance(template, dict_node):
-                template = dict_node(template, (0, 0), (0, 0))
-            for k, v in template.items():
-                template[k] = self._correct_objects_loop(v)
-        elif isinstance(template, list):
-            if not isinstance(template, list_node):
-                template = list_node(template, (0, 0), (0, 0))
-            for i, v in enumerate(template):
-                template[i] = self._correct_objects_loop(v)
-
-        return template
-
-    def _correct_objects(self):
-        """
-            Corrects the template to have the correct types of objects, list, strings
-        """
-        self._template = self._correct_objects_loop(self._template)
 
     @staticmethod
     def is_s3_uri(uri):

--- a/test/fixtures/templates/good/resources/iam/resource_policy.yaml
+++ b/test/fixtures/templates/good/resources/iam/resource_policy.yaml
@@ -4,10 +4,21 @@ Parameters:
   myExampleBucket:
     Type: String
 Resources:
+  WebsiteBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: MyBucket
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement: # doesn't fail when the statement isn't a list
+          Effect: Allow
+          Principal: "*"
+          Action: s3:GetObject
+          Resource: "arn:aws:s3:::MyBucket"
   Ecr:
     Type: AWS::ECR::Repository
     Properties:
-      RepositoryPolicyText: | 
+      RepositoryPolicyText: |
         {
           "Version": "2012-10-17",
           "Statement": [

--- a/test/fixtures/templates/good/resources/iam/resource_policy.yaml
+++ b/test/fixtures/templates/good/resources/iam/resource_policy.yaml
@@ -7,7 +7,7 @@ Resources:
   Ecr:
     Type: AWS::ECR::Repository
     Properties:
-      RepositoryPolicyText:
+      RepositoryPolicyText: | 
         {
           "Version": "2012-10-17",
           "Statement": [

--- a/test/rules/resources/iam/test_iam_policy.py
+++ b/test/rules/resources/iam/test_iam_policy.py
@@ -35,7 +35,7 @@ class TestPropertyIamPolicies(BaseRuleTestCase):
 
     def test_file_negative(self):
         """Test failure"""
-        self.helper_file_negative('fixtures/templates/bad/properties_iam_policy.yaml', 8)
+        self.helper_file_negative('fixtures/templates/bad/properties_iam_policy.yaml', 10)
 
     def test_file_resource_negative(self):
         """Test failure"""


### PR DESCRIPTION
*Issue #, if available:*
#383 

*Description of changes:*
- Fix rule E2507 to support validating policies that are completely strings.  
- Move the functions that convert a dict into the linters dict object into helpers

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
