### PR TITLE
Check types of values before using them in an expected way for E2541

### DIFF
--- a/src/cfnlint/rules/resources/codepipeline/CodepipelineStageActions.py
+++ b/src/cfnlint/rules/resources/codepipeline/CodepipelineStageActions.py
@@ -111,6 +111,10 @@ class CodepipelineStageActions(CloudFormationLintRule):
         category = action_type_id.get('Category')
         provider = action_type_id.get('Provider')
 
+        if isinstance(owner, dict) or isinstance(category, dict) or isinstance(provider, dict):
+            self.logger.debug('owner, category, provider need to be strings to validate. Skipping.')
+            return matches
+
         constraints = self.CONSTRAINTS.get(owner, {}).get(category, {}).get(provider, {})
         if not constraints:
             return matches
@@ -175,13 +179,15 @@ class CodepipelineStageActions(CloudFormationLintRule):
         """Check that action type version is valid."""
         matches = []
 
-        if action.get('ActionTypeId').get('Version') != '1':
+        version = action.get('ActionTypeId', {}).get('Version')
+        if isinstance(version, dict):
+            self.logger.debug('Unable to validate version when an object is used.  Skipping')
+        elif version != '1':
             message = 'For all currently supported action types, the only valid version string is "1".'
             matches.append(RuleMatch(
                 path + ['ActionTypeId', 'Version'],
                 message
             ))
-
         return matches
 
     def check_names_unique(self, action, path, action_names):

--- a/test/fixtures/templates/good/resources_codepipeline.yaml
+++ b/test/fixtures/templates/good/resources_codepipeline.yaml
@@ -43,7 +43,7 @@ Resources:
               ActionTypeId:
                 Category: Build
                 Owner: AWS
-                Version: "1"
+                Version: !ImportValue Version  # doesn't fail on objects
                 Provider: CodeBuild
               Configuration:
                 ProjectName: cfn-python-lint


### PR DESCRIPTION
*Issue #, if available:*
#397 
*Description of changes:*
- Fix rule E2541 to validate certain types of values before using them as strings.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
