### PR TITLE
Fix rule E1029 resolve missing sub on resource and conditions in IAM Policy

### DIFF
--- a/src/cfnlint/rules/functions/SubNeeded.py
+++ b/src/cfnlint/rules/functions/SubNeeded.py
@@ -27,7 +27,7 @@ class SubNeeded(CloudFormationLintRule):
     tags = ['functions', 'sub']
 
     # Free-form text properties to exclude from this rule
-    excludes = ['UserData', 'ZipFile']
+    excludes = ['UserData', 'ZipFile', 'Resource', 'Condition']
 
     def _match_values(self, searchRegex, cfnelem, path):
         """Recursively search for values matching the searchRegex"""

--- a/test/fixtures/templates/good/functions/sub_needed.yaml
+++ b/test/fixtures/templates/good/functions/sub_needed.yaml
@@ -1,0 +1,20 @@
+---
+AWSTemplateFormatVersion: "2010-09-09"
+Parameters:
+  AMIId:
+    Type: 'String'
+    Description: 'The AMI ID for the image to use.'
+Resources:
+  myPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      Roles:
+      - testRole
+      PolicyName: test
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+        - Effect: "Allow"
+          Action:
+            - "iam:UploadSSHPublicKey"
+          Resource: "arn:aws:iam::*:user/${aws:username}"

--- a/test/rules/functions/test_sub_needed.py
+++ b/test/rules/functions/test_sub_needed.py
@@ -26,6 +26,7 @@ class TestSubNeeded(BaseRuleTestCase):
         self.collection.register(SubNeeded())
         self.success_templates = [
             'fixtures/templates/good/functions_sub.yaml',
+            'fixtures/templates/good/functions/sub_needed.yaml',
         ]
 
     def test_file_positive(self):


### PR DESCRIPTION
*Issue #, if available:*
Fix #401 
*Description of changes:*
- Fix rule E1029 to not check Resource, Conditions inside in an IAM Policy for missing Sub

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
