### PR TITLE
Fix rule E2502 to allow for nested stacks and custom resources

### DIFF
--- a/src/cfnlint/rules/resources/iam/InstanceProfile.py
+++ b/src/cfnlint/rules/resources/iam/InstanceProfile.py
@@ -43,12 +43,17 @@ class InstanceProfile(CloudFormationLintRule):
                 obj = tree[-1]
                 objtype = cfn.template.get('Resources', {}).get(obj[0], {}).get('Type')
                 if objtype:
-                    if objtype != 'AWS::IAM::InstanceProfile':
+                    if objtype not in ['AWS::IAM::InstanceProfile', 'AWS::CloudFormation::Stack', 'AWS::CloudFormation::CustomResource']:
                         message = 'Property IamInstanceProfile should relate to AWS::IAM::InstanceProfile for %s' % (
                             '/'.join(map(str, tree[:-1])))
                         matches.append(RuleMatch(tree[:-1], message))
                     else:
-                        if cfn.template.get('Resources', {}).get(tree[1], {}).get('Type') in ['AWS::EC2::SpotFleet']:
+                        if objtype in ['AWS::CloudFormation::Stack']:
+                            if obj[1] != 'Outputs':
+                                message = 'Property IamInstanceProfile should relate to AWS::IAM::InstanceProfile for %s' % (
+                                    '/'.join(map(str, tree[:-1])))
+                                matches.append(RuleMatch(tree[:-1], message))
+                        elif cfn.template.get('Resources', {}).get(tree[1], {}).get('Type') in ['AWS::EC2::SpotFleet']:
                             if obj[1] != 'Arn':
                                 message = 'Property IamInstanceProfile should be an ARN for %s' % (
                                     '/'.join(map(str, tree[:-1])))

--- a/test/fixtures/templates/good/resources/iam/instance_profile.yaml
+++ b/test/fixtures/templates/good/resources/iam/instance_profile.yaml
@@ -1,0 +1,12 @@
+AWSTemplateFormatVersion: 2010-09-09
+Resources:
+  IAMInstanceProfile:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: https://s3-us-west-2.amazonaws.com/example-bucket/example-instance-profile.yml
+  Instance:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      Parameters:
+        IamInstanceProfile: !GetAtt IAMInstanceProfile.Outputs.InstanceProfileArn
+      TemplateURL: https://s3-us-west-2.amazonaws.com/example-bucket/example-instance.yml

--- a/test/rules/resources/iam/test_iam_instance_profile.py
+++ b/test/rules/resources/iam/test_iam_instance_profile.py
@@ -24,6 +24,9 @@ class TestPropertyVpcId(BaseRuleTestCase):
         """Setup"""
         super(TestPropertyVpcId, self).setUp()
         self.collection.register(InstanceProfile())
+        self.success_templates = [
+            'fixtures/templates/good/resources/iam/instance_profile.yaml'
+        ]
 
     def test_file_positive(self):
         """Test Positive"""


### PR DESCRIPTION
*Issue #, if available:*
Fix #408 
*Description of changes:*
- Fix rule E2502 to allow for GetAtt against a nested stack

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
