### PR TITLE
New rule E3022 to validate SubnetIDs are only used in one Route Table association

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# vscode
+.vscode/

--- a/src/cfnlint/rules/resources/ectwo/RouteTableAssociation.py
+++ b/src/cfnlint/rules/resources/ectwo/RouteTableAssociation.py
@@ -1,0 +1,95 @@
+"""
+  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this
+  software and associated documentation files (the "Software"), to deal in the Software
+  without restriction, including without limitation the rights to use, copy, modify,
+  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+from collections import defaultdict
+import six
+from cfnlint import CloudFormationLintRule
+from cfnlint import RuleMatch
+import cfnlint.helpers
+
+
+class RouteTableAssociation(CloudFormationLintRule):
+    """Check only one route table association defined per subnet"""
+    id = 'E3022'
+    shortdesc = 'Resource SubnetRouteTableAssociation Properties'
+    description = 'Validate there is only one SubnetRouteTableAssociation per subnet'
+    source_url = 'https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-subnet-route-table-assoc.html'
+    tags = ['resources', 'subnet', 'route table']
+
+    # Namespace for unique associated subnets in the form condition::value
+    resource_values = {}
+    associated_resources = defaultdict(list)
+
+    def get_values(self, subnetid, resource_condition, property_condition):
+        """Get string literal(s) from value of SubnetId"""
+        values = []
+        if isinstance(subnetid, dict):
+            if len(subnetid) == 1:
+                for key, value in subnetid.items():
+                    if key in cfnlint.helpers.CONDITION_FUNCTIONS:
+                        if isinstance(value, list):
+                            if len(value) == 3:
+                                property_condition = value[0]
+                                values.extend(self.get_values(value[1], resource_condition, property_condition))
+                                values.extend(self.get_values(value[2], resource_condition, property_condition))
+                    if key == 'Ref':
+                        values.extend(self.get_values(value, resource_condition, property_condition))
+                    if key == 'Fn::GetAtt':
+                        if isinstance(value[1], (six.string_types)):
+                            sub_value = '.'.join(value)
+                            values.append((resource_condition, property_condition, sub_value))
+        else:
+            values.append((resource_condition, property_condition, subnetid))
+        return values
+
+    def check_values(self, subnetid, resource_condition, resource_name):
+        """Check subnet value is not associated with other route tables"""
+        property_condition = None
+        values = self.get_values(subnetid, resource_condition, property_condition)
+        self.resource_values[resource_name] = values
+        for value in values:
+            self.associated_resources[value].append(resource_name)
+
+    def match(self, cfn):
+        """Check SubnetRouteTableAssociation Resource Properties"""
+        matches = []
+        resources = cfn.get_resources(['AWS::EC2::SubnetRouteTableAssociation'])
+        for resource_name, resource in resources.items():
+            properties = resource.get('Properties')
+            if properties:
+                resource_condition = resource.get('Condition')
+                subnetid = properties.get('SubnetId')
+                self.check_values(subnetid, resource_condition, resource_name)
+        for resource_name in self.resource_values:
+            for value in self.resource_values[resource_name]:
+                bare_value = (None, None, value[2])
+                other_resources = []
+
+                if len(self.associated_resources[value]) > 1:
+                    for resource in self.associated_resources[value]:
+                        if resource != resource_name:
+                            other_resources.append(resource)
+
+                if value != bare_value and self.associated_resources[bare_value]:
+                    other_resources.extend(self.associated_resources[bare_value])
+
+                if other_resources:
+                    path = ['Resources', resource_name, 'Properties', 'SubnetId']
+                    message = 'SubnetId in {0} is also associated with {1}'
+                    matches.append(
+                        RuleMatch(path, message.format(resource_name, ', '.join(other_resources))))
+
+        return matches

--- a/test/fixtures/templates/bad/properties_rt_association.yaml
+++ b/test/fixtures/templates/bad/properties_rt_association.yaml
@@ -1,0 +1,75 @@
+---
+AWSTemplateFormatVersion: '2010-09-09'
+Description: 'Bad SubnetRouteTableAssociation'
+
+Parameters:
+  PublicRouteTable:
+    Type: String
+  PrivateRouteTable:
+    Type: String
+  PublicSubnet01:
+    Type: String
+  PrivateSubnet01:
+    Type: String
+  AppType:
+    Type: String
+    AllowedValues: ['Public', 'Public']
+
+Conditions:
+  isPublic: !Equals [ !Ref AppType, 'Public' ]
+
+Resources:
+  PublicSubnetRouteTableAssociation1:
+      Type: AWS::EC2::SubnetRouteTableAssociation
+      Properties:
+        RouteTableId:
+          Ref: PublicRouteTable
+        SubnetId:
+          Ref: PublicSubnet01
+
+  PrivateSubnetRouteTableAssociation1:
+      Type: AWS::EC2::SubnetRouteTableAssociation
+      Properties:
+        RouteTableId:
+          Ref: PrivateRouteTable
+        SubnetId:
+          Ref: PublicSubnet01
+
+  AuxiliaryPublicSubnetRouteTableAssociation1:
+      Type: AWS::EC2::SubnetRouteTableAssociation
+      Condition: CreateAuxiliaryNetworks
+      Properties:
+        RouteTableId:
+          Ref: PublicRouteTable
+        SubnetId:
+          Ref: PublicSubnet01
+
+  ProxySubnetRouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+        RouteTableId:
+          Ref: PublicRouteTable
+        SubnetId:
+          Fn::If: [ isPublic, Ref: PublicSubnet01 , Ref: PrivateSubnet01 ]
+
+  CustomResource:
+      Type: AWS::CloudFormation::CustomResource
+      Properties:
+        ServiceToken: arn:aws:sns:region:account-id:topicname
+
+  CustomSubnetRouteTableAssociation:
+      Type: AWS::EC2::SubnetRouteTableAssociation
+      Properties:
+        RouteTableId: 
+          Ref: PublicRouteTable
+        SubnetId: 
+          !GetAtt CustomResource.PublicSubnet
+
+  AuxilliaryCustomSubnetRouteTableAssociation:
+      Type: AWS::EC2::SubnetRouteTableAssociation
+      Condition: CreateAuxiliaryNetworks
+      Properties:
+        RouteTableId: 
+          Ref: PublicRouteTable
+        SubnetId: 
+          !GetAtt CustomResource.PublicSubnet

--- a/test/fixtures/templates/good/properties_rt_association.yaml
+++ b/test/fixtures/templates/good/properties_rt_association.yaml
@@ -1,0 +1,72 @@
+---
+AWSTemplateFormatVersion: '2010-09-09'
+Description: 'Good SubnetRouteTableAssociation'
+
+Parameters:
+  PublicRouteTable:
+    Type: String
+  PrivateRouteTable:
+    Type: String
+  AppSubnet01:
+    Type: String
+  PublicSubnet01:
+    Type: String
+  PublicProxySubnet:
+    Type: String
+  PrivateProxySubnet:
+    Type: String
+  AppType:
+    Type: String
+    AllowedValues: ['Public', 'Public']
+
+Conditions:
+  isPublic: !Equals [ !Ref AppType, 'Public' ]
+  isPrivate: !Equals [ !Ref AppType, 'Private' ]
+
+Resources:
+  AppSubnetPublicRouteTableAssociation:
+    Condition: isPublic
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+        RouteTableId: 
+          Ref: PublicRouteTable
+        SubnetId: 
+          Ref: AppSubnet01
+
+  AppSubnetPrivateRouteTableAssociation:
+    Condition: isPrivate
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+        RouteTableId: 
+          Ref: PrivateRouteTable
+        SubnetId: 
+          Ref: AppSubnet01
+
+  ProxySubnetRouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+        RouteTableId: 
+          Ref: PublicRouteTable
+        SubnetId: 
+          Fn::If: [ isPublic, Ref: PublicProxySubnet , Ref: PrivateProxySubnet ]
+  
+  PublicSubnetRouteTableAssociation:
+      Type: AWS::EC2::SubnetRouteTableAssociation
+      Properties:
+        RouteTableId: 
+          Ref: PublicRouteTable
+        SubnetId: 
+          Ref: PublicSubnet01
+
+  CustomResource:
+      Type: AWS::CloudFormation::CustomResource
+      Properties:
+        ServiceToken: arn:aws:sns:region:account-id:topicname
+
+  CustomSubnetRouteTableAssociation:
+      Type: AWS::EC2::SubnetRouteTableAssociation
+      Properties:
+        RouteTableId: 
+          Ref: PublicRouteTable
+        SubnetId: 
+          !GetAtt CustomResource.PublicSubnet

--- a/test/rules/resources/ec2/test_rt_association.py
+++ b/test/rules/resources/ec2/test_rt_association.py
@@ -1,0 +1,34 @@
+"""
+  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this
+  software and associated documentation files (the "Software"), to deal in the Software
+  without restriction, including without limitation the rights to use, copy, modify,
+  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+from cfnlint.rules.resources.ectwo.RouteTableAssociation import RouteTableAssociation  # pylint: disable=E0401
+from ... import BaseRuleTestCase
+
+
+class TestPropertyRtAssociation(BaseRuleTestCase):
+    """Test Route Table Association"""
+    def setUp(self):
+        """Setup"""
+        super(TestPropertyRtAssociation, self).setUp()
+        self.collection.register(RouteTableAssociation())
+
+    def test_file_positive(self):
+        """Test Positive"""
+        self.helper_file_positive()
+
+    def test_file_negative(self):
+        """Test failure"""
+        self.helper_file_negative('fixtures/templates/bad/properties_rt_association.yaml', 5)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Subnets can only have a single route table association. If there are two associations to the same subnet things will go poorly.  This tries to find dups across conditions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
