### PR TITLE
Catch AttributeError when rules to try to access the wrong attribute

### DIFF
--- a/src/cfnlint/decode/node.py
+++ b/src/cfnlint/decode/node.py
@@ -15,8 +15,11 @@
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 import sys
+import logging
 from copy import deepcopy
 import six
+
+LOGGER = logging.getLogger(__name__)
 
 
 def create_str_node_class(cls):

--- a/src/cfnlint/rules/outputs/Configuration.py
+++ b/src/cfnlint/rules/outputs/Configuration.py
@@ -40,13 +40,16 @@ class Configuration(CloudFormationLintRule):
 
         outputs = cfn.template.get('Outputs', {})
         if outputs:
-            for output_name, output_value in outputs.items():
-                for prop in output_value:
-                    if prop not in self.valid_keys:
-                        message = 'Output {0} has invalid property {1}'
-                        matches.append(RuleMatch(
-                            ['Outputs', output_name, prop],
-                            message.format(output_name, prop)
-                        ))
+            if isinstance(outputs, dict):
+                for output_name, output_value in outputs.items():
+                    for prop in output_value:
+                        if prop not in self.valid_keys:
+                            message = 'Output {0} has invalid property {1}'
+                            matches.append(RuleMatch(
+                                ['Outputs', output_name, prop],
+                                message.format(output_name, prop)
+                            ))
+            else:
+                matches.append(RuleMatch(['Outputs'], 'Outputs do not follow correct format.'))
 
         return matches


### PR DESCRIPTION
*Issue #, if available:*
Fix #403

*Description of changes:*
- Create an items class in the cfn-lint str node object that has items defined but returns nothing.  The assumption being rules should exist to catch the configuration errors but this prevents really improperly configured templates from breaking rules.
- Update rule E6001 so it provides an error when Outputs isn't an object/dict

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
