### PR TITLE
Fix E2502 triggering on AWS::EC2::LaunchTemplate

### DIFF
--- a/src/cfnlint/rules/resources/iam/InstanceProfile.py
+++ b/src/cfnlint/rules/resources/iam/InstanceProfile.py
@@ -53,7 +53,7 @@ class InstanceProfile(CloudFormationLintRule):
                                 message = 'Property IamInstanceProfile should relate to AWS::IAM::InstanceProfile for %s' % (
                                     '/'.join(map(str, tree[:-1])))
                                 matches.append(RuleMatch(tree[:-1], message))
-                        elif cfn.template.get('Resources', {}).get(tree[1], {}).get('Type') in ['AWS::EC2::SpotFleet']:
+                        elif cfn.template.get('Resources', {}).get(tree[1], {}).get('Type') in ['AWS::EC2::SpotFleet', 'AWS::EC2::LaunchTemplate']:
                             if obj[1] != 'Arn':
                                 message = 'Property IamInstanceProfile should be an ARN for %s' % (
                                     '/'.join(map(str, tree[:-1])))

--- a/src/cfnlint/rules/resources/iam/InstanceProfile.py
+++ b/src/cfnlint/rules/resources/iam/InstanceProfile.py
@@ -53,9 +53,14 @@ class InstanceProfile(CloudFormationLintRule):
                                 message = 'Property IamInstanceProfile should relate to AWS::IAM::InstanceProfile for %s' % (
                                     '/'.join(map(str, tree[:-1])))
                                 matches.append(RuleMatch(tree[:-1], message))
-                        elif cfn.template.get('Resources', {}).get(tree[1], {}).get('Type') in ['AWS::EC2::SpotFleet', 'AWS::EC2::LaunchTemplate']:
+                        elif cfn.template.get('Resources', {}).get(tree[1], {}).get('Type') in ['AWS::EC2::SpotFleet']:
                             if obj[1] != 'Arn':
                                 message = 'Property IamInstanceProfile should be an ARN for %s' % (
+                                    '/'.join(map(str, tree[:-1])))
+                                matches.append(RuleMatch(tree[:-1], message))
+                        elif cfn.template.get('Resources', {}).get(tree[1], {}).get('Type') in ['AWS::EC2::LaunchTemplate']:
+                            if not obj[1] in ['Arn', 'Name']:
+                                message = 'Property IamInstanceProfile should be an ARN or Name for %s' % (
                                     '/'.join(map(str, tree[:-1])))
                                 matches.append(RuleMatch(tree[:-1], message))
                         else:


### PR DESCRIPTION
E2502 is triggering for `AWS::EC2::LaunchTemplate` as well.

Question: could it ignore AWS::EC2::*?

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
