### PR TITLE
Move arrays into init function to prevent copying of settings between rules

### DIFF
--- a/src/cfnlint/__init__.py
+++ b/src/cfnlint/__init__.py
@@ -38,8 +38,10 @@ class CloudFormationLintRule(object):
     tags = []
 
     logger = logging.getLogger(__name__)
-    resource_property_types = []
-    resource_sub_property_types = []
+
+    def __init__(self):
+        self.resource_property_types = []
+        self.resource_sub_property_types = []
 
     def __repr__(self):
         return '%s: %s' % (self.id, self.shortdesc)

--- a/src/cfnlint/rules/functions/DynamicReferenceSecureString.py
+++ b/src/cfnlint/rules/functions/DynamicReferenceSecureString.py
@@ -34,6 +34,7 @@ class DynamicReferenceSecureString(CloudFormationLintRule):
 
     def __init__(self, ):
         """Init """
+        super(DynamicReferenceSecureString, self).__init__()
         specs = cfnlint.helpers.RESOURCE_SPECS.get('us-east-1')
         self.property_specs = specs.get('PropertyTypes')
         self.resource_specs = specs.get('ResourceTypes')

--- a/src/cfnlint/rules/functions/GetAtt.py
+++ b/src/cfnlint/rules/functions/GetAtt.py
@@ -29,6 +29,7 @@ class GetAtt(CloudFormationLintRule):
     tags = ['functions', 'getatt']
 
     def __init__(self):
+        super(GetAtt, self).__init__()
         resourcespecs = cfnlint.helpers.RESOURCE_SPECS['us-east-1']
         self.resourcetypes = resourcespecs['ResourceTypes']
         self.propertytypes = resourcespecs['PropertyTypes']

--- a/src/cfnlint/rules/outputs/Value.py
+++ b/src/cfnlint/rules/outputs/Value.py
@@ -29,6 +29,7 @@ class Value(CloudFormationLintRule):
     tags = ['outputs']
 
     def __init__(self):
+        super(Value, self).__init__()
         resourcespecs = RESOURCE_SPECS['us-east-1']
         self.resourcetypes = resourcespecs['ResourceTypes']
 

--- a/src/cfnlint/rules/parameters/AvailabilityZone.py
+++ b/src/cfnlint/rules/parameters/AvailabilityZone.py
@@ -29,6 +29,7 @@ class AvailabilityZone(CloudFormationLintRule):
 
     def __init__(self):
         """Init"""
+        super(AvailabilityZone, self).__init__()
         self.multiple_resource_type_specs = [
             'AWS::DAX::Cluster',
             'AWS::AutoScaling::AutoScalingGroup',
@@ -40,6 +41,7 @@ class AvailabilityZone(CloudFormationLintRule):
             'AWS::OpsWorks::Instance',
             'AWS::RDS::DBInstance',
             'AWS::EC2::Host',
+            'AWS::EC2::Subnet',
             'AWS::DMS::ReplicationInstance',
             'AWS::EC2::Instance'
         ]

--- a/src/cfnlint/rules/parameters/Cidr.py
+++ b/src/cfnlint/rules/parameters/Cidr.py
@@ -31,9 +31,10 @@ class Cidr(CloudFormationLintRule):
 
     def __init__(self):
         """Init"""
+        super(Cidr, self).__init__()
         resource_type_specs = [
             'AWS::EC2::Subnet',
-            'AWS::EC2::Vpc',
+            'AWS::EC2::VPC',
             'AWS::RDS::DBSecurityGroupIngress',
             'AWS::EC2::NetworkAclEntry',
             'AWS::EC2::SecurityGroupIngress',

--- a/src/cfnlint/rules/parameters/CidrAllowedValues.py
+++ b/src/cfnlint/rules/parameters/CidrAllowedValues.py
@@ -32,9 +32,10 @@ class CidrAllowedValues(CloudFormationLintRule):
 
     def __init__(self):
         """Init"""
+        super(CidrAllowedValues, self).__init__()
         resource_type_specs = [
             'AWS::EC2::Subnet',
-            'AWS::EC2::Vpc',
+            'AWS::EC2::VPC',
             'AWS::RDS::DBSecurityGroupIngress',
             'AWS::EC2::NetworkAclEntry',
             'AWS::EC2::SecurityGroupIngress',

--- a/src/cfnlint/rules/parameters/LambdaMemorySize.py
+++ b/src/cfnlint/rules/parameters/LambdaMemorySize.py
@@ -29,6 +29,7 @@ class LambdaMemorySize(CloudFormationLintRule):
 
     def __init__(self):
         """Init"""
+        super(LambdaMemorySize, self).__init__()
         resource_type_specs = [
             'AWS::Lambda::Function',
         ]

--- a/src/cfnlint/rules/parameters/LambdaRuntime.py
+++ b/src/cfnlint/rules/parameters/LambdaRuntime.py
@@ -29,6 +29,7 @@ class LambdaRuntime(CloudFormationLintRule):
 
     def __init__(self):
         """Init"""
+        super(LambdaRuntime, self).__init__()
         resource_type_specs = [
             'AWS::Lambda::Function',
         ]

--- a/src/cfnlint/rules/parameters/SecurityGroup.py
+++ b/src/cfnlint/rules/parameters/SecurityGroup.py
@@ -30,6 +30,7 @@ class SecurityGroup(CloudFormationLintRule):
 
     def __init__(self):
         """Init"""
+        super(SecurityGroup, self).__init__()
         resource_type_specs = [
             'AWS::ElasticLoadBalancingV2::LoadBalancer',
             'AWS::AutoScaling::LaunchConfiguration',

--- a/src/cfnlint/rules/resources/events/RuleTargetsLimit.py
+++ b/src/cfnlint/rules/resources/events/RuleTargetsLimit.py
@@ -29,16 +29,19 @@ class RuleTargetsLimit(CloudFormationLintRule):
 
     def __init__(self):
         """Init"""
-        self.resource_property_types.append('AWS::Events::Rule')
+        super(RuleTargetsLimit, self).__init__()
+        self.resource_property_types = ['AWS::Events::Rule']
         self.limits = {}
 
     # pylint: disable=W0613
     def check_value(self, value, path):
         """Count them up """
-        if path[4] == 'Fn::If':
-            resource_name = '%s.%s' % (path[1], path[5])
-        else:
-            resource_name = path[1]
+
+        resource_name = path[1]
+        if len(path) > 4:
+            if path[4] == 'Fn::If':
+                resource_name = '%s.%s' % (path[1], path[5])
+
         if resource_name not in self.limits:
             self.limits[resource_name] = {
                 'count': 0,
@@ -51,7 +54,6 @@ class RuleTargetsLimit(CloudFormationLintRule):
     def match_resource_properties(self, properties, _, path, cfn):
         """Check CloudFormation Properties"""
         matches = []
-
         matches.extend(
             cfn.check_value(
                 obj=properties, key='Targets',

--- a/src/cfnlint/rules/resources/iam/Policy.py
+++ b/src/cfnlint/rules/resources/iam/Policy.py
@@ -33,6 +33,7 @@ class Policy(CloudFormationLintRule):
 
     def __init__(self):
         """Init"""
+        super(Policy, self).__init__()
         self.resource_exceptions = {
             'AWS::ECR::Repository': 'RepositoryPolicyText',
         }

--- a/src/cfnlint/rules/resources/iam/PolicyVersion.py
+++ b/src/cfnlint/rules/resources/iam/PolicyVersion.py
@@ -30,6 +30,7 @@ class PolicyVersion(CloudFormationLintRule):
 
     def __init__(self):
         """Init"""
+        super(PolicyVersion, self).__init__()
         self.resources_and_keys = {
             'AWS::SNS::TopicPolicy': 'PolicyDocument',
             'AWS::S3::BucketPolicy': 'PolicyDocument',

--- a/src/cfnlint/rules/resources/properties/AtLeastOne.py
+++ b/src/cfnlint/rules/resources/properties/AtLeastOne.py
@@ -31,6 +31,7 @@ class AtLeastOne(CloudFormationLintRule):
 
     def __init__(self):
         """Init"""
+        super(AtLeastOne, self).__init__()
         atleastonespec = cfnlint.helpers.load_resources('data/AdditionalSpecs/AtLeastOne.json')
         self.resource_types_specs = atleastonespec['ResourceTypes']
         self.property_types_specs = atleastonespec['PropertyTypes']

--- a/src/cfnlint/rules/resources/properties/AvailabilityZone.py
+++ b/src/cfnlint/rules/resources/properties/AvailabilityZone.py
@@ -28,6 +28,7 @@ class AvailabilityZone(CloudFormationLintRule):
 
     def __init__(self):
         """Init"""
+        super(AvailabilityZone, self).__init__()
         resource_type_specs = [
             'AWS::DAX::Cluster',
             'AWS::AutoScaling::AutoScalingGroup',
@@ -36,6 +37,7 @@ class AvailabilityZone(CloudFormationLintRule):
             'AWS::OpsWorks::Instance',
             'AWS::RDS::DBInstance',
             'AWS::EC2::Host',
+            'AWS::EC2::Subnet',
             'AWS::DMS::ReplicationInstance',
             'AWS::EC2::Instance'
         ]

--- a/src/cfnlint/rules/resources/properties/Exclusive.py
+++ b/src/cfnlint/rules/resources/properties/Exclusive.py
@@ -30,6 +30,7 @@ class Exclusive(CloudFormationLintRule):
 
     def __init__(self):
         """Init"""
+        super(Exclusive, self).__init__()
         exclusivespec = cfnlint.helpers.load_resources('data/AdditionalSpecs/Exclusive.json')
         self.resource_types_specs = exclusivespec['ResourceTypes']
         self.property_types_specs = exclusivespec['PropertyTypes']

--- a/src/cfnlint/rules/resources/properties/Inclusive.py
+++ b/src/cfnlint/rules/resources/properties/Inclusive.py
@@ -30,6 +30,7 @@ class Inclusive(CloudFormationLintRule):
 
     def __init__(self):
         """Init"""
+        super(Inclusive, self).__init__()
         inclusivespec = cfnlint.helpers.load_resources('data/AdditionalSpecs/Inclusive.json')
         self.resource_types_specs = inclusivespec['ResourceTypes']
         self.property_types_specs = inclusivespec['PropertyTypes']

--- a/src/cfnlint/rules/resources/properties/OnlyOne.py
+++ b/src/cfnlint/rules/resources/properties/OnlyOne.py
@@ -31,6 +31,7 @@ class OnlyOne(CloudFormationLintRule):
 
     def __init__(self):
         """Init"""
+        super(OnlyOne, self).__init__()
         onlyonespec = cfnlint.helpers.load_resources('data/AdditionalSpecs/OnlyOne.json')
         self.resource_types_specs = onlyonespec['ResourceTypes']
         self.property_types_specs = onlyonespec['PropertyTypes']

--- a/src/cfnlint/rules/resources/properties/Properties.py
+++ b/src/cfnlint/rules/resources/properties/Properties.py
@@ -30,6 +30,7 @@ class Properties(CloudFormationLintRule):
     tags = ['resources']
 
     def __init__(self):
+        super(Properties, self).__init__()
         self.cfn = {}
         self.resourcetypes = {}
         self.propertytypes = {}

--- a/src/cfnlint/rules/resources/properties/PropertiesTemplated.py
+++ b/src/cfnlint/rules/resources/properties/PropertiesTemplated.py
@@ -29,6 +29,7 @@ class PropertiesTemplated(CloudFormationLintRule):
     tags = ['resources']
 
     def __init__(self):
+        super(PropertiesTemplated, self).__init__()
         self.resource_property_types.extend([
             'AWS::ApiGateway::RestApi',
             'AWS::Lambda::Function',

--- a/src/cfnlint/rules/resources/properties/Required.py
+++ b/src/cfnlint/rules/resources/properties/Required.py
@@ -31,6 +31,7 @@ class Required(CloudFormationLintRule):
     cfn = {}
 
     def __init__(self):
+        super(Required, self).__init__()
         resourcespecs = cfnlint.helpers.RESOURCE_SPECS['us-east-1']
         self.resourcetypes = resourcespecs['ResourceTypes']
         self.propertytypes = resourcespecs['PropertyTypes']

--- a/src/cfnlint/rules/resources/properties/ValuePrimitiveType.py
+++ b/src/cfnlint/rules/resources/properties/ValuePrimitiveType.py
@@ -32,6 +32,7 @@ class ValuePrimitiveType(CloudFormationLintRule):
 
     def __init__(self, ):
         """Init """
+        super(ValuePrimitiveType, self).__init__()
         specs = cfnlint.helpers.RESOURCE_SPECS.get('us-east-1')
         self.property_specs = specs.get('PropertyTypes')
         self.resource_specs = specs.get('ResourceTypes')

--- a/src/cfnlint/rules/resources/stepfunctions/StateMachine.py
+++ b/src/cfnlint/rules/resources/stepfunctions/StateMachine.py
@@ -31,6 +31,7 @@ class StateMachine(CloudFormationLintRule):
 
     def __init__(self):
         """Init"""
+        super(StateMachine, self).__init__()
         self.resource_property_types.append('AWS::StepFunctions::StateMachine')
 
     def _check_state_json(self, def_json, state_name, path):


### PR DESCRIPTION
*Issue #, if available:*
Fix #421
*Description of changes:*
- When setting parent class attributes in the init using self they would be stored and copied to the next rule.  

This rule should have never been triggered with the supplied template and that is because of this copying.  This will force empty lists on initialization. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
