### PR TITLE
Fix dictionary object converters so they use str_node for the keys

### DIFF
--- a/src/cfnlint/helpers.py
+++ b/src/cfnlint/helpers.py
@@ -216,13 +216,14 @@ def convert_dict(template, start_mark=(0, 0), end_mark=(0, 0)):
     if isinstance(template, dict):
         if not isinstance(template, dict_node):
             template = dict_node(template, start_mark, end_mark)
-        for k, v in template.items():
+        for k, v in template.copy().items():
             k_start_mark = start_mark
             k_end_mark = end_mark
             if isinstance(k, str_node):
                 k_start_mark = k.start_mark
                 k_end_mark = k.end_mark
             new_k = str_node(k, k_start_mark, k_end_mark)
+            del template[k]
             template[new_k] = convert_dict(v, k_start_mark, k_end_mark)
     elif isinstance(template, list):
         if not isinstance(template, list_node):

--- a/src/cfnlint/helpers.py
+++ b/src/cfnlint/helpers.py
@@ -23,7 +23,7 @@ import logging
 import re
 import inspect
 import pkg_resources
-from cfnlint.decode.node import dict_node, list_node
+from cfnlint.decode.node import dict_node, list_node, str_node
 
 LOGGER = logging.getLogger(__name__)
 
@@ -217,12 +217,18 @@ def convert_dict(template, start_mark=(0, 0), end_mark=(0, 0)):
         if not isinstance(template, dict_node):
             template = dict_node(template, start_mark, end_mark)
         for k, v in template.items():
-            template[k] = convert_dict(v)
+            k_start_mark = start_mark
+            k_end_mark = end_mark
+            if isinstance(k, str_node):
+                k_start_mark = k.start_mark
+                k_end_mark = k.end_mark
+            new_k = str_node(k, k_start_mark, k_end_mark)
+            template[new_k] = convert_dict(v, k_start_mark, k_end_mark)
     elif isinstance(template, list):
         if not isinstance(template, list_node):
             template = list_node(template, start_mark, end_mark)
         for i, v in enumerate(template):
-            template[i] = convert_dict(v)
+            template[i] = convert_dict(v, start_mark, end_mark)
 
     return template
 

--- a/test/module/helpers/__init__.py
+++ b/test/module/helpers/__init__.py
@@ -1,0 +1,16 @@
+"""
+  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this
+  software and associated documentation files (the "Software"), to deal in the Software
+  without restriction, including without limitation the rights to use, copy, modify,
+  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""

--- a/test/module/helpers/test_convert_dict.py
+++ b/test/module/helpers/test_convert_dict.py
@@ -1,0 +1,45 @@
+"""
+  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this
+  software and associated documentation files (the "Software"), to deal in the Software
+  without restriction, including without limitation the rights to use, copy, modify,
+  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+import json
+from cfnlint.helpers import convert_dict
+from cfnlint.decode.node import dict_node, list_node, str_node
+from cfnlint import Runner
+import cfnlint.decode.cfn_yaml
+from testlib.testcase import BaseTestCase
+
+
+class TestConvertDict(BaseTestCase):
+    """Test Converting regular dicts into CFN Dicts """
+
+    def test_success_run(self):
+        """Test success run"""
+        obj = {
+            'Key': {
+                'SubKey': 'Value'
+            },
+            'List': [
+                {'SubKey': 'AnotherValue'}
+            ]
+        }
+
+        results = convert_dict(obj)
+        self.assertTrue(isinstance(results, dict_node))
+        self.assertTrue(isinstance(results.get('Key'), dict_node))
+        self.assertTrue(isinstance(results.get('List')[0], dict_node))
+        self.assertTrue(isinstance(results.get('List'), list_node))
+        for k, _ in results.items():
+            self.assertTrue(isinstance(k, str_node))


### PR DESCRIPTION
*Issue #, if available:*
Fix #243
*Description of changes:*
- Fix strings inside objects were not converted to str_node from str

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
