### PR TITLE
Path isn't used in the message so remove it

### DIFF
--- a/src/cfnlint/rules/resources/updatepolicy/Configuration.py
+++ b/src/cfnlint/rules/resources/updatepolicy/Configuration.py
@@ -210,6 +210,6 @@ class Configuration(CloudFormationLintRule):
             else:
                 message = 'UpdatePolicy should be an object'
                 matches.append(
-                    RuleMatch(['Resources', r_name, 'UpdatePolicy'], message.format(path[-1])))
+                    RuleMatch(['Resources', r_name, 'UpdatePolicy'], message.format()))
 
         return matches


### PR DESCRIPTION
*Issue #, if available:*
Fix #422
*Description of changes:*
- In rule E3016 depending on the order of items being returned there was a case where Path was being used before being assigned

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
