### PR TITLE
Improve multiple files usage documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,19 @@ There are IDE plugins available to get direct linter feedback from you favorite 
 - `cfn-lint -t template.yaml`
 
 ##### Lint multiple files
+Multiple files can be linted by either specifying multiple specific files:
+
 - `cfn-lint template1.yaml template2.yaml`
 - `cfn-lint -t template1.yaml template2.yaml`
+
+
+Multiple files can also be specified using wildcards (globbing):
+
+Lint all `yaml` files in `path`:
 - `cfn-lint path/*.yaml`
+
+Lint all `yaml` files in `path` and all subdirectories (recursive):
+- `cfn-lint path/to/templates/**/*.yaml`
 
 ##### Specifying the template with other parameters
 - `cfn-lint -r us-east-1 ap-south-1 -- template.yaml`
@@ -54,7 +64,7 @@ There are IDE plugins available to get direct linter feedback from you favorite 
 ## Configuration
 
 ### Command Line
-From a command prompt run `cfn-lint <path to yaml template>` to run standard linting of the template
+From a command prompt run `cfn-lint <path to yaml template>` to run standard linting of the template.
 
 ### Parameters
 


### PR DESCRIPTION
*Issue https://github.com/awslabs/cfn-python-lint/issues/416*

Linting multiple files recursively already works due to the UNIX behaviour with wilcards (globbing). Cross-platform support is imcoming in another PR: https://github.com/awslabs/cfn-python-lint/pull/429/files#diff-17c04994c31a151576724f70895b6d97R275 (since this is default UNIX behaviour)

Just added it explicitly in the documentation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
