### PR TITLE
Support SSM lists when evaluating refs for lists in E3002

### DIFF
--- a/src/cfnlint/rules/resources/properties/Properties.py
+++ b/src/cfnlint/rules/resources/properties/Properties.py
@@ -225,7 +225,7 @@ class Properties(CloudFormationLintRule):
                                     if ref in parameternames:
                                         param_type = self.cfn.template['Parameters'][ref]['Type']
                                         if param_type:
-                                            if not param_type.startswith('List<') and not param_type == 'CommaDelimitedList':
+                                            if 'List<' not in param_type and '<List' not in param_type and not param_type == 'CommaDelimitedList':
                                                 message = 'Property {0} should be of type List or Parameter should ' \
                                                           'be a list for resource {1}'
                                                 matches.append(

--- a/test/fixtures/templates/good/resource_properties.yaml
+++ b/test/fixtures/templates/good/resource_properties.yaml
@@ -218,6 +218,10 @@ Outputs:
           - ElasticLoadBalancer
           - DNSName
 Parameters:
+  azList:
+    Type: "AWS::SSM::Parameter::Value<List<String>>"
+    Description: "The list of AZs from Parameter Store"
+    Default: '/regionSettings/azList'
   InstanceType:
     AllowedValues:
     - t1.micro
@@ -606,3 +610,10 @@ Resources:
       DistributionConfig:
         Aliases: !Ref Aliases
         Enabled: True
+  cacheForumRedisV1:
+    Type: AWS::ElastiCache::CacheCluster
+    Properties:
+      PreferredAvailabilityZones: !Ref azList
+      CacheNodeType: String
+      Engine: String
+      NumCacheNodes: 1


### PR DESCRIPTION
*Issue #, if available:*
Fix #439 

*Description of changes:*
- Handle SSM List Parameters when evaluating rule E3002 and Refs to parameters.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
