### PR TITLE
 Support validating custom resource types with --override-spec

### DIFF
--- a/src/cfnlint/rules/resources/properties/Properties.py
+++ b/src/cfnlint/rules/resources/properties/Properties.py
@@ -267,7 +267,7 @@ class Properties(CloudFormationLintRule):
         for resourcename, resourcevalue in cfn.get_resources().items():
             if 'Properties' in resourcevalue and 'Type' in resourcevalue:
                 resourcetype = resourcevalue.get('Type', None)
-                if resourcetype.startswith('Custom::'):
+                if resourcetype.startswith('Custom::') and resourcetype not in self.resourcetypes:
                     resourcetype = 'AWS::CloudFormation::CustomResource'
                 if resourcetype in self.resourcetypes:
                     path = ['Resources', resourcename, 'Properties']

--- a/src/cfnlint/rules/resources/properties/Required.py
+++ b/src/cfnlint/rules/resources/properties/Required.py
@@ -129,7 +129,7 @@ class Required(CloudFormationLintRule):
         for resourcename, resourcevalue in cfn.get_resources().items():
             if 'Properties' in resourcevalue and 'Type' in resourcevalue:
                 resourcetype = resourcevalue['Type']
-                if resourcetype.startswith('Custom::'):
+                if resourcetype.startswith('Custom::') and resourcetype not in self.resourcetypes:
                     resourcetype = 'AWS::CloudFormation::CustomResource'
                 if resourcetype in self.resourcetypes:
                     tree = ['Resources', resourcename, 'Properties']

--- a/test/fixtures/templates/bad/properties_required.yaml
+++ b/test/fixtures/templates/bad/properties_required.yaml
@@ -733,3 +733,8 @@ Resources:
     Properties:
       # ServiceToken: arn
       StackName: StackName
+  CustomResource3:
+    Type: 'Custom::SpecifiedCustomResource'
+    Properties:
+      ServiceToken: arn
+      # RequiredString: present

--- a/test/fixtures/templates/bad/resources/properties/custom.yaml
+++ b/test/fixtures/templates/bad/resources/properties/custom.yaml
@@ -1,0 +1,8 @@
+Resources:
+  CustomResource4:
+    Type: 'Custom::SpecifiedCustomResource'
+    Properties:
+      ServiceToken: arn
+      # RequiredString: present
+      OptionalBoolean: ['not-a-boolean']
+      NotAProperty: this-is-not-in-the-custom-spec

--- a/test/fixtures/templates/good/resource_properties.yaml
+++ b/test/fixtures/templates/good/resource_properties.yaml
@@ -600,6 +600,12 @@ Resources:
     Properties:
       ServiceToken: arn
       StackName: StackName
+  CustomResource3:
+    Type: 'Custom::SpecifiedCustomResource'
+    Properties:
+      ServiceToken: arn
+      RequiredString: present
+      OptionalBoolean: true
   Distribution:
     Type: "AWS::CloudFront::Distribution"
     Properties:

--- a/test/fixtures/templates/good/resources/properties/custom.yaml
+++ b/test/fixtures/templates/good/resources/properties/custom.yaml
@@ -1,0 +1,7 @@
+Resources:
+  CustomResource4:
+    Type: 'Custom::SpecifiedCustomResource'
+    Properties:
+      ServiceToken: arn
+      RequiredString: present
+      OptionalBoolean: true

--- a/test/fixtures/templates/override_spec/custom.json
+++ b/test/fixtures/templates/override_spec/custom.json
@@ -1,0 +1,24 @@
+{
+  "ResourceTypes": {
+    "Custom::SpecifiedCustomResource": {
+      "Properties": {
+        "ServiceToken": {
+          "PrimitiveType": "String",
+          "Required": true,
+          "UpdateType": "Immutable"
+        },
+        "RequiredString": {
+          "PrimitiveType": "String",
+          "Required": true,
+          "UpdateType": "Immutable"
+        },
+        "OptionalBoolean": {
+          "PrimitiveType": "Boolean",
+          "Required": false,
+          "UpdateType": "Mutable"
+        }
+      }
+    }
+  },
+  "ResourceSpecificationVersion": "2.11.0"
+}

--- a/test/rules/resources/properties/test_properties.py
+++ b/test/rules/resources/properties/test_properties.py
@@ -14,6 +14,8 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
+import cfnlint.helpers
+import json
 from cfnlint.rules.resources.properties.Properties import Properties  # pylint: disable=E0401
 from ... import BaseRuleTestCase
 
@@ -44,3 +46,22 @@ class TestResourceProperties(BaseRuleTestCase):
     def test_file_negative_3(self):
         """Failure test"""
         self.helper_file_negative('fixtures/templates/bad/resource_properties.yaml', 4)
+
+
+class TestSpecifiedCustomResourceProperties(TestResourceProperties):
+    """Repeat Resource Properties tests with Custom Resource override spec provided"""
+    def setUp(self):
+        """Setup"""
+        super(TestSpecifiedCustomResourceProperties, self).setUp()
+        # Add a Spec override that specifies the Custom::SpecifiedCustomResource type
+        with open('fixtures/templates/override_spec/custom.json') as fp:
+            custom_spec = json.load(fp)
+        cfnlint.helpers.set_specs(custom_spec)
+        # Reset Spec override after test
+        self.addCleanup(cfnlint.helpers.initialize_specs)
+
+    # ... all TestResourceProperties test cases are re-run with override spec ...
+
+    def test_file_negative_custom(self):
+        """Additional failure test for specified Custom Resource validation"""
+        self.helper_file_negative('fixtures/templates/bad/resources/properties/custom.yaml', 2)

--- a/test/rules/resources/properties/test_required.py
+++ b/test/rules/resources/properties/test_required.py
@@ -14,6 +14,8 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
+import cfnlint.helpers
+import json
 from cfnlint.rules.resources.properties.Required import Required  # pylint: disable=E0401
 from ... import BaseRuleTestCase
 
@@ -36,3 +38,23 @@ class TestResourceConfiguration(BaseRuleTestCase):
     def test_file_negative_generic(self):
         """Generic Test failure"""
         self.helper_file_negative('fixtures/templates/bad/generic.yaml', 7)
+
+
+class TestSpecifiedCustomResourceRequiredProperties(TestResourceConfiguration):
+    """Test Custom Resource Required Properties when override spec is provided"""
+    def setUp(self):
+        """Setup"""
+        super(TestSpecifiedCustomResourceRequiredProperties, self).setUp()
+        # Add a Spec override that specifies the Custom::SpecifiedCustomResource type
+        with open('fixtures/templates/override_spec/custom.json') as fp:
+            custom_spec = json.load(fp)
+        cfnlint.helpers.set_specs(custom_spec)
+        # Reset Spec override after test
+        self.addCleanup(cfnlint.helpers.initialize_specs)
+
+    # ... all TestResourceConfiguration test cases are re-run with override spec ...
+
+    def test_file_negative(self):
+        """Test failure"""
+        # Additional Custom::SpecifiedCustomResource failure detected with custom spec
+        self.helper_file_negative('fixtures/templates/bad/properties_required.yaml', 13)


### PR DESCRIPTION
Fixes #445.

*Description of changes:*

If a custom resource type is specified via `--override-spec`, use that for validation (rather than the generic `AWS::CloudFormation::CustomResource` default for `Custom::___` resources).

[Fix is straightforward; it was less clear to me where best to add the tests and fixtures. Please feel free to reorganize tests as you prefer—I kept them a separate commit.]

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
