### PR TITLE
When looking for a list have success with FindInMap and custom resources

### DIFF
--- a/test/fixtures/templates/good/resource_properties.yaml
+++ b/test/fixtures/templates/good/resource_properties.yaml
@@ -623,3 +623,24 @@ Resources:
       CacheNodeType: String
       Engine: String
       NumCacheNodes: 1
+  ### Testing relationships for lists to Custom and Maps
+  Custom:
+    Type: AWS::CloudFormation::CustomResource
+    Properties:
+      ServiceToken: arn.example
+
+  LB1:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Properties:
+      SecurityGroups: !GetAtt Custom.ExampleListOfStrings
+      # LoadBalancerAttributes: {Type: List, ItemType: LoadBalancerAttribute}
+      # should be allowed as the custom resource can return a list of objects
+      LoadBalancerAttributes: !GetAtt Custom.ExampleListOfKeyValuePairs
+  LB2:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Properties:
+      SecurityGroups: !GetAtt Custom.ExampleListOfStrings
+      # LoadBalancerAttributes: {Type: List, ItemType: LoadBalancerAttribute}
+      # Should be allowed because mappings can have a list of objects
+      # This mapping isn't correct but validation of the actually mapping is more difficult
+      LoadBalancerAttributes: !FindInMap [ AWSInstanceType2Arch, c1.medium, Arch ]


### PR DESCRIPTION
*Issue #, if available:*
Fixes #444
*Description of changes:*
- Don't fail on rule E3002 when looking for lists when then function is a FindInMap or a GetAtt to a custom resource

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
