### PR TITLE
Force default values to be a string for checking the pattern

### DIFF
--- a/src/cfnlint/config.py
+++ b/src/cfnlint/config.py
@@ -340,9 +340,9 @@ class TemplateArgs(object):
                             defaults['regions'] = config_value
                     if config_name == 'append_rules':
                         if isinstance(config_value, list):
-                            defaults['override_spec'] = config_value
+                            defaults['append_rules'] = config_value
                     if config_name == 'override_spec':
-                        if isinstance(config_value, (six.string_types, six.text_type)):
+                        if isinstance(config_value, (six.string_types)):
                             defaults['override_spec'] = config_value
                     if config_name == 'ignore_bad_template':
                         if isinstance(config_value, bool):
@@ -377,7 +377,6 @@ class ConfigMixIn(TemplateArgs, CliArgs, ConfigFileArgs, object):
             return template_value
         if file_value and is_config_file:
             return file_value
-
         return cli_value
 
     @property

--- a/src/cfnlint/rules/parameters/Default.py
+++ b/src/cfnlint/rules/parameters/Default.py
@@ -33,8 +33,7 @@ class Default(CloudFormationLintRule):
             Check allowed value against allowed pattern
         """
         message = 'Default should be allowed by AllowedPattern'
-
-        if not re.match(allowed_pattern, allowed_value):
+        if not re.match(allowed_pattern, str(allowed_value)):
             return([RuleMatch(path, message)])
 
         return []


### PR DESCRIPTION
*Issue #, if available:*
Fix #456 

*Description of changes:*
- Force the default value for a parameter to be a string when checking the pattern.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
