### PR TITLE
Use the custom objects when doing a deepcopy

### DIFF
--- a/src/cfnlint/decode/node.py
+++ b/src/cfnlint/decode/node.py
@@ -81,8 +81,7 @@ def create_dict_node_class(cls):
             self.condition_functions = ['Fn::If']
 
         def __deepcopy__(self, memo):
-            cls = self.__class__
-            result = cls.__new__(cls, self.start_mark, self.end_mark)
+            result = dict_node(self, self.start_mark, self.end_mark)
             memo[id(self)] = result
             for k, v in self.items():
                 result[deepcopy(k)] = deepcopy(v, memo)
@@ -160,8 +159,7 @@ def create_dict_list_class(cls):
             self.condition_functions = ['Fn::If']
 
         def __deepcopy__(self, memo):
-            cls = self.__class__
-            result = cls.__new__(cls, self.start_mark, self.end_mark)
+            result = list_node([], self.start_mark, self.end_mark)
             memo[id(self)] = result
             for _, v in enumerate(self):
                 result.append(deepcopy(v, memo))


### PR DESCRIPTION
*Issue #, if available:*
Fix #459

*Description of changes:*
- When doing a deepcopy use the custom objects to create new instances and remove the use of __new__

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
