### PR TITLE
Support functions that could return objects

### DIFF
--- a/src/cfnlint/decode/node.py
+++ b/src/cfnlint/decode/node.py
@@ -91,6 +91,30 @@ def create_dict_node_class(cls):
         def __copy__(self):
             return self
 
+        def is_function_returning_object(self, mappings=None):
+            """
+                Check if an object is using a function that could return an object
+                Return True when
+                    Fn::Select:
+                    - 0  # or any number
+                    - !FindInMap [mapname, key, value] # or any mapname, key, value
+                Otherwise False
+            """
+            mappings = mappings or {}
+            if len(self) == 1:
+                for k, v in self.items():
+                    if k in ['Fn::Select']:
+                        if isinstance(v, list):
+                            if len(v) == 2:
+                                p_v = v[1]
+                                if isinstance(p_v, dict):
+                                    if len(p_v) == 1:
+                                        for l_k in p_v.keys():
+                                            if l_k == 'Fn::FindInMap':
+                                                return True
+
+            return False
+
         def get_safe(self, key, default=None, path=None, type_t=()):
             """
                 Get values in format

--- a/src/cfnlint/rules/resources/properties/Required.py
+++ b/src/cfnlint/rules/resources/properties/Required.py
@@ -60,6 +60,11 @@ class Required(CloudFormationLintRule):
             # Covered with Properties not with Required
             return matches
 
+        # Return empty matches if we run into a function that is being used to get an object
+        # Selects could be used to return an object when used with a FindInMap
+        if text.is_function_returning_object():
+            return matches
+
         # Check if all required properties are specified
         resource_objects = []
         base_object_properties = {}

--- a/test/fixtures/templates/bad/generic.yaml
+++ b/test/fixtures/templates/bad/generic.yaml
@@ -3,6 +3,14 @@ AWSTemplateFormatVersion: "2010-09-09"
 Description: A sample template
 Errors:
   Catch: Missing
+Mappings:
+  runtime:
+    us-east-1:
+      production:
+      - CidrIp: 0.0.0.0/0
+        IpProtocol: tcp
+        ToPort: 80
+        FromPort: 80
 Parameters:
   myParam:
     Type: String
@@ -177,6 +185,21 @@ Resources:
           UnhealthyThreshold: '5'
           Interval: '30'
           Timeout: '5'
+  # Fail when not using FindInMap
+  lambdaMap1:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: test
+      SecurityGroupIngress:
+        Fn::GetAZs: !Ref AWS::Region
+  # fail when using FindInMap for an object
+  # Fail when not using FindInMap
+  lambdaMap2:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: test
+      SecurityGroupIngress:
+      - Fn::FindInMap: [ runtime, !Ref 'AWS::Region', production ]
 Outputs:
   myOutput:
     Value: !GetAtt ElasticLoadBalancer.CanonicalHostedZoneName

--- a/test/fixtures/templates/good/resource_properties.yaml
+++ b/test/fixtures/templates/good/resource_properties.yaml
@@ -207,6 +207,13 @@ Mappings:
       Examples: https://s3-us-west-1.amazonaws.com/cloudformation-examples-us-west-1
     us-west-2:
       Examples: https://s3-us-west-2.amazonaws.com/cloudformation-examples-us-west-2
+  runtime:
+    us-east-1:
+      production:
+      - CidrIp: 0.0.0.0/0
+        IpProtocol: tcp
+        ToPort: 80
+        FromPort: 80
 Outputs:
   URL:
     Description: The URL of the website
@@ -644,3 +651,19 @@ Resources:
       # Should be allowed because mappings can have a list of objects
       # This mapping isn't correct but validation of the actually mapping is more difficult
       LoadBalancerAttributes: !FindInMap [ AWSInstanceType2Arch, c1.medium, Arch ]
+  # Don't fail when we have used a possible map
+  lambdaMap1:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: test
+      SecurityGroupIngress:
+        - Fn::Select:
+          - 0
+          - Fn::FindInMap: [ runtime, us-east-1, production ]
+  # Don't fail when we use the entire list from a map
+  lambdaMap2:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: test
+      SecurityGroupIngress:
+        Fn::FindInMap: [ runtime, us-east-1, production ]

--- a/test/module/decode/test_node.py
+++ b/test/module/decode/test_node.py
@@ -234,3 +234,42 @@ class TestNode(BaseTestCase):
             results.append((v, p))
 
         self.assertEqual(results, [('1', [0]), ('2', [1]), ('4', [2, 'Fn::If', 1])])
+
+    def test_success_dict_select(self):
+        """ Test if select could return an object """
+
+        template = cfnlint.decode.node.dict_node({
+            'Fn::Select': cfnlint.decode.node.list_node([
+                0,
+                cfnlint.decode.node.dict_node({
+                    'Fn::FindInMap': ['mapping', 'key', 'value']
+                }, (0, 1), (2, 3))
+            ], (0, 1), (2, 3))
+        }, (0, 1), (2, 3))
+
+        self.assertTrue(template.is_function_returning_object())
+
+    def test_failure_dict_select(self):
+        """ Test if select could return an object """
+
+        template = cfnlint.decode.node.dict_node({
+            'Key': 'Value',
+            'Fn::Select': cfnlint.decode.node.list_node([
+                0,
+                cfnlint.decode.node.dict_node({
+                    'Fn::FindInMap': ['mapping', 'key', 'value']
+                }, (0, 1), (2, 3))
+            ], (0, 1), (2, 3))
+        }, (0, 1), (2, 3))
+
+        self.assertFalse(template.is_function_returning_object())
+
+        template = cfnlint.decode.node.dict_node({
+            'Key': 'Value',
+            'Fn::Select': cfnlint.decode.node.list_node([
+                0,
+                cfnlint.decode.node.list_node([0, 1, 2], (0, 1), (2, 3))
+            ], (0, 1), (2, 3))
+        }, (0, 1), (2, 3))
+
+        self.assertFalse(template.is_function_returning_object())

--- a/test/module/test_rules_collections.py
+++ b/test/module/test_rules_collections.py
@@ -59,10 +59,10 @@ class TestTemplate(BaseTestCase):
         filename = 'fixtures/templates/bad/generic.yaml'
         template = cfnlint.decode.cfn_yaml.load(filename)
         cfn = Template(filename, template, ['us-east-1'])
-
+        expected_err_count = 35
         matches = []
         matches.extend(self.rules.run(filename, cfn))
-        assert len(matches) == 31, 'Expected {} failures, got {}'.format(31, len(matches))
+        assert len(matches) == expected_err_count, 'Expected {} failures, got {}'.format(expected_err_count, len(matches))
 
     def test_fail_sub_properties_run(self):
         """Test failure run"""

--- a/test/rules/resources/properties/test_properties.py
+++ b/test/rules/resources/properties/test_properties.py
@@ -37,7 +37,7 @@ class TestResourceProperties(BaseRuleTestCase):
 
     def test_file_negative(self):
         """Test failure"""
-        self.helper_file_negative('fixtures/templates/bad/generic.yaml', 6)
+        self.helper_file_negative('fixtures/templates/bad/generic.yaml', 9)
 
     def test_file_negative_2(self):
         """Failure test"""

--- a/test/rules/resources/properties/test_required.py
+++ b/test/rules/resources/properties/test_required.py
@@ -37,7 +37,7 @@ class TestResourceConfiguration(BaseRuleTestCase):
 
     def test_file_negative_generic(self):
         """Generic Test failure"""
-        self.helper_file_negative('fixtures/templates/bad/generic.yaml', 7)
+        self.helper_file_negative('fixtures/templates/bad/generic.yaml', 8)
 
 
 class TestSpecifiedCustomResourceRequiredProperties(TestResourceConfiguration):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- CloudFormation functions can only be used to represent an object if they are the only item in the object.  Example: Fn::If can't be along side ImageId.
- You can use Select to FindInMap to return an object so don't error when you see this
- You can use FindInMap to return a list so don't error when you see this

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
