### PR TITLE
Add a rule to test RDS instance sizes against the engine and licensemodel

### DIFF
--- a/src/cfnlint/data/AdditionalSpecs/RdsProperties.json
+++ b/src/cfnlint/data/AdditionalSpecs/RdsProperties.json
@@ -1,0 +1,566 @@
+[
+  {
+    "engines": [
+      "aurora",
+      "aurora-mysql"
+    ],
+    "instance_types": [
+      "db.t2.small",
+      "db.t2.medium",
+      "db.r4.large",
+      "db.r4.xlarge",
+      "db.r4.2xlarge",
+      "db.r4.4xlarge",
+      "db.r4.8xlarge",
+      "db.r4.16xlarge"
+    ],
+    "regions": [
+      "us-east-1",
+      "us-east-2",
+      "us-west-1",
+      "us-west-2",
+      "ca-central-1",
+      "eu-central-1",
+      "eu-west-1",
+      "eu-west-2",
+      "eu-west-3",
+      "ap-northeast-1",
+      "ap-northeast-2",
+      "ap-southeast-1",
+      "ap-southeast-2",
+      "ap-south-1",
+      "sa-east-1"
+    ]
+  },
+  {
+    "engines": [
+      "aurora-postgresql"
+    ],
+    "instance_types": [
+      "db.r4.large",
+      "db.r4.xlarge",
+      "db.r4.2xlarge",
+      "db.r4.4xlarge",
+      "db.r4.8xlarge",
+      "db.r4.16xlarge"
+    ],
+    "regions": [
+      "us-east-1",
+      "us-east-2",
+      "us-west-1",
+      "us-west-2",
+      "ca-central-1",
+      "eu-central-1",
+      "eu-west-1",
+      "eu-west-2",
+      "eu-west-3",
+      "ap-northeast-1",
+      "ap-northeast-2",
+      "ap-southeast-1",
+      "ap-southeast-2",
+      "ap-south-1",
+      "sa-east-1"
+    ]
+  },
+  {
+    "engines": [
+      "oracle-se1"
+    ],
+    "instance_types": [
+      "db.t2.micro",
+      "db.t2.small",
+      "db.t2.medium",
+      "db.t2.large",
+      "db.m5.large",
+      "db.m5.xlarge",
+      "db.m5.2xlarge",
+      "db.m5.4xlarge",
+      "db.m4.large",
+      "db.m4.xlarge",
+      "db.m4.2xlarge",
+      "db.m4.4xlarge"
+    ],
+    "license": [
+      "license-included"
+    ],
+    "regions": [
+      "us-east-1",
+      "us-east-2",
+      "us-west-1",
+      "us-west-2",
+      "ca-central-1",
+      "eu-central-1",
+      "eu-west-1",
+      "eu-west-2",
+      "ap-northeast-1",
+      "ap-northeast-2",
+      "ap-southeast-1",
+      "ap-southeast-2",
+      "ap-south-1",
+      "sa-east-1"
+    ]
+  },
+  {
+    "engines": [
+      "oracle-se1"
+    ],
+    "instance_types": [
+      "db.t2.micro",
+      "db.t2.small",
+      "db.t2.medium",
+      "db.t2.large",
+      "db.t2.xlarge",
+      "db.t2.2xlarge",
+      "db.m5.large",
+      "db.m5.xlarge",
+      "db.m5.2xlarge",
+      "db.m5.4xlarge",
+      "db.m5.12xlarge",
+      "db.m5.24xlarge",
+      "db.r4.large",
+      "db.r4.xlarge",
+      "db.r4.2xlarge",
+      "db.r4.4xlarge",
+      "db.r4.8xlarge",
+      "db.r4.16xlarge"
+    ],
+    "license": [
+      "license-included"
+    ],
+    "regions": [
+      "eu-west-3"
+    ]
+  },
+  {
+    "engines": [
+      "oracle-se1"
+    ],
+    "instance_types": [
+      "db.t2.micro",
+      "db.t2.small",
+      "db.t2.medium",
+      "db.t2.large",
+      "db.t2.xlarge",
+      "db.t2.2xlarge",
+      "db.m4.large",
+      "db.m4.xlarge",
+      "db.m4.2xlarge",
+      "db.m4.4xlarge",
+      "db.m4.10xlarge",
+      "db.m4.16xlarge",
+      "db.r4.large",
+      "db.r4.xlarge",
+      "db.r4.2xlarge",
+      "db.r4.4xlarge",
+      "db.r4.8xlarge",
+      "db.r4.16xlarge"
+    ],
+    "license": [
+      "license-included"
+    ],
+    "regions": [
+      "ap-northeast-3"
+    ]
+  },
+  {
+    "engines": [
+      "oracle-se2"
+    ],
+    "instance_types": [
+      "db.t2.micro",
+      "db.t2.small",
+      "db.t2.medium",
+      "db.t2.large",
+      "db.t2.xlarge",
+      "db.t2.2xlarge",
+      "db.m5.large",
+      "db.m5.xlarge",
+      "db.m5.2xlarge",
+      "db.m5.4xlarge",
+      "db.m4.large",
+      "db.m4.xlarge",
+      "db.m4.2xlarge",
+      "db.m4.4xlarge",
+      "db.r4.large",
+      "db.r4.xlarge",
+      "db.r4.2xlarge",
+      "db.r4.4xlarge"
+    ],
+    "license": [
+      "license-included"
+    ],
+    "regions": [
+      "us-east-1",
+      "us-east-2",
+      "us-west-1",
+      "us-west-2",
+      "ca-central-1",
+      "eu-central-1",
+      "eu-west-1",
+      "eu-west-2",
+      "ap-northeast-1",
+      "ap-northeast-2",
+      "ap-southeast-1",
+      "ap-southeast-2",
+      "ap-south-1",
+      "sa-east-1"
+    ]
+  },
+  {
+    "engines": [
+      "oracle-se2"
+    ],
+    "instance_types": [
+      "db.t2.micro",
+      "db.t2.small",
+      "db.t2.medium",
+      "db.t2.large",
+      "db.t2.xlarge",
+      "db.t2.2xlarge",
+      "db.m5.large",
+      "db.m5.xlarge",
+      "db.m5.2xlarge",
+      "db.m5.4xlarge",
+      "db.m5.12xlarge",
+      "db.m5.24xlarge",
+      "db.r4.large",
+      "db.r4.xlarge",
+      "db.r4.2xlarge",
+      "db.r4.4xlarge",
+      "db.r4.8xlarge",
+      "db.r4.16xlarge"
+    ],
+    "license": [
+      "license-included"
+    ],
+    "regions": [
+      "eu-west-3"
+    ]
+  },
+  {
+    "engines": [
+      "oracle-se2"
+    ],
+    "instance_types": [
+      "db.t2.micro",
+      "db.t2.small",
+      "db.t2.medium",
+      "db.t2.large",
+      "db.t2.xlarge",
+      "db.t2.2xlarge",
+      "db.m4.large",
+      "db.m4.xlarge",
+      "db.m4.2xlarge",
+      "db.m4.4xlarge",
+      "db.m4.10xlarge",
+      "db.m4.16xlarge",
+      "db.r4.large",
+      "db.r4.xlarge",
+      "db.r4.2xlarge",
+      "db.r4.4xlarge",
+      "db.r4.8xlarge",
+      "db.r4.16xlarge"
+    ],
+    "license": [
+      "license-included"
+    ],
+    "regions": [
+      "ap-northeast-3"
+    ]
+  },
+  {
+    "engines": [
+      "oracle-se2",
+      "oracle-ee",
+      "oracle-se1",
+      "oracle-se"
+    ],
+    "instance_types": [
+      "db.t2.micro",
+      "db.t2.small",
+      "db.t2.medium",
+      "db.t2.large",
+      "db.t2.xlarge",
+      "db.t2.2xlarge",
+      "db.m5.large",
+      "db.m5.xlarge",
+      "db.m5.2xlarge",
+      "db.m5.4xlarge",
+      "db.m5.12xlarge",
+      "db.m5.24xlarge",
+      "db.m4.large",
+      "db.m4.xlarge",
+      "db.m4.2xlarge",
+      "db.m4.4xlarge",
+      "db.m4.10xlarge",
+      "db.m4.16xlarge",
+      "db.x1.16xlarge",
+      "db.x1.32xlarge",
+      "db.x1e.xlarge",
+      "db.x1e.2xlarge",
+      "db.x1e.4xlarge",
+      "db.x1e.8xlarge",
+      "db.x1e.16xlarge",
+      "db.x1e.32xlarge",
+      "db.r4.large",
+      "db.r4.xlarge",
+      "db.r4.2xlarge",
+      "db.r4.4xlarge",
+      "db.r4.8xlarge",
+      "db.r4.16xlarge"
+    ],
+    "license": [
+      "bring-your-own-license"
+    ],
+    "regions": [
+      "us-east-1",
+      "us-west-2",
+      "eu-west-1",
+      "ap-northeast-1",
+      "ap-southeast-2"
+    ]
+  },
+  {
+    "engines": [
+      "oracle-se2",
+      "oracle-ee",
+      "oracle-se1",
+      "oracle-se"
+    ],
+    "instance_types": [
+      "db.t2.micro",
+      "db.t2.small",
+      "db.t2.medium",
+      "db.t2.large",
+      "db.t2.xlarge",
+      "db.t2.2xlarge",
+      "db.m5.large",
+      "db.m5.xlarge",
+      "db.m5.2xlarge",
+      "db.m5.4xlarge",
+      "db.m5.12xlarge",
+      "db.m5.24xlarge",
+      "db.m4.large",
+      "db.m4.xlarge",
+      "db.m4.2xlarge",
+      "db.m4.4xlarge",
+      "db.m4.10xlarge",
+      "db.m4.16xlarge",
+      "db.x1.16xlarge",
+      "db.x1.32xlarge",
+      "db.r4.large",
+      "db.r4.xlarge",
+      "db.r4.2xlarge",
+      "db.r4.4xlarge",
+      "db.r4.8xlarge",
+      "db.r4.16xlarge"
+    ],
+    "license": [
+      "bring-your-own-license"
+    ],
+    "regions": [
+      "ca-central-1",
+      "us-east-2",
+      "us-west-1",
+      "eu-central-1",
+      "eu-west-2",
+      "ap-northeast-2",
+      "ap-southeast-1",
+      "ap-south-1",
+      "sa-east-1"
+    ]
+  },
+  {
+    "engines": [
+      "oracle-se2",
+      "oracle-ee",
+      "oracle-se1",
+      "oracle-se"
+    ],
+    "instance_types": [
+      "db.t2.micro",
+      "db.t2.small",
+      "db.t2.medium",
+      "db.t2.large",
+      "db.t2.xlarge",
+      "db.t2.2xlarge",
+      "db.m5.large",
+      "db.m5.xlarge",
+      "db.m5.2xlarge",
+      "db.m5.4xlarge",
+      "db.m5.12xlarge",
+      "db.m5.24xlarge",
+      "db.x1.16xlarge",
+      "db.x1.32xlarge",
+      "db.r4.large",
+      "db.r4.xlarge",
+      "db.r4.2xlarge",
+      "db.r4.4xlarge",
+      "db.r4.8xlarge",
+      "db.r4.16xlarge"
+    ],
+    "license": [
+      "bring-your-own-license"
+    ],
+    "regions": [
+      "eu-west-3"
+    ]
+  },
+  {
+    "engines": [
+      "oracle-se2",
+      "oracle-ee",
+      "oracle-se1",
+      "oracle-se"
+    ],
+    "instance_types": [
+      "db.t2.micro",
+      "db.t2.small",
+      "db.t2.medium",
+      "db.t2.large",
+      "db.t2.xlarge",
+      "db.t2.2xlarge",
+      "db.m4.large",
+      "db.m4.xlarge",
+      "db.m4.2xlarge",
+      "db.m4.4xlarge",
+      "db.m4.10xlarge",
+      "db.m4.16xlarge",
+      "db.r4.large",
+      "db.r4.xlarge",
+      "db.r4.2xlarge",
+      "db.r4.4xlarge",
+      "db.r4.8xlarge",
+      "db.r4.16xlarge"
+    ],
+    "license": [
+      "bring-your-own-license"
+    ],
+    "regions": [
+      "ap-northeast-3"
+    ]
+  },
+  {
+    "engines": [
+      "mariadb",
+      "mysql",
+      "postgres",
+      "sqlserver-ee",
+      "sqlserver-se",
+      "sqlserver-ex",
+      "sqlserver-web"
+    ],
+    "instance_types": [
+      "db.t2.micro",
+      "db.t2.small",
+      "db.t2.medium",
+      "db.t2.large",
+      "db.t2.xlarge",
+      "db.t2.2xlarge",
+      "db.m5.large",
+      "db.m5.xlarge",
+      "db.m5.2xlarge",
+      "db.m5.4xlarge",
+      "db.m5.12xlarge",
+      "db.m5.24xlarge",
+      "db.m4.large",
+      "db.m4.xlarge",
+      "db.m4.2xlarge",
+      "db.m4.4xlarge",
+      "db.m4.10xlarge",
+      "db.m4.16xlarge",
+      "db.x1.16xlarge",
+      "db.x1.32xlarge",
+      "db.r4.large",
+      "db.r4.xlarge",
+      "db.r4.2xlarge",
+      "db.r4.4xlarge",
+      "db.r4.8xlarge",
+      "db.r4.16xlarge"
+    ],
+    "regions": [
+      "us-east-1",
+      "us-east-2",
+      "us-west-1",
+      "us-west-2",
+      "ca-central-1",
+      "eu-central-1",
+      "eu-west-1",
+      "eu-west-2",
+      "ap-northeast-1",
+      "ap-northeast-2",
+      "ap-southeast-1",
+      "ap-southeast-2",
+      "ap-south-1",
+      "sa-east-1"
+    ]
+  },
+  {
+    "engines": [
+      "mariadb",
+      "mysql",
+      "postgres",
+      "sqlserver-ee",
+      "sqlserver-se",
+      "sqlserver-ex",
+      "sqlserver-web"
+    ],
+    "instance_types": [
+      "db.t2.micro",
+      "db.t2.small",
+      "db.t2.medium",
+      "db.t2.large",
+      "db.t2.xlarge",
+      "db.t2.2xlarge",
+      "db.m4.large",
+      "db.m4.xlarge",
+      "db.m4.2xlarge",
+      "db.m4.4xlarge",
+      "db.m4.10xlarge",
+      "db.m4.16xlarge",
+      "db.r4.large",
+      "db.r4.xlarge",
+      "db.r4.2xlarge",
+      "db.r4.4xlarge",
+      "db.r4.8xlarge",
+      "db.r4.16xlarge"
+    ],
+    "regions": [
+      "ap-northeast-3"
+    ]
+  },
+  {
+    "engines": [
+      "mariadb",
+      "mysql",
+      "postgres",
+      "sqlserver-ee",
+      "sqlserver-se",
+      "sqlserver-ex",
+      "sqlserver-web"
+    ],
+    "instance_types": [
+      "db.t2.micro",
+      "db.t2.small",
+      "db.t2.medium",
+      "db.t2.large",
+      "db.t2.xlarge",
+      "db.t2.2xlarge",
+      "db.m5.large",
+      "db.m5.xlarge",
+      "db.m5.2xlarge",
+      "db.m5.4xlarge",
+      "db.m5.12xlarge",
+      "db.m5.24xlarge",
+      "db.r4.large",
+      "db.r4.xlarge",
+      "db.r4.2xlarge",
+      "db.r4.4xlarge",
+      "db.r4.8xlarge",
+      "db.r4.16xlarge"
+    ],
+    "regions": [
+      "eu-west-3"
+    ]
+  }
+]

--- a/src/cfnlint/rules/resources/rds/InstanceSize.py
+++ b/src/cfnlint/rules/resources/rds/InstanceSize.py
@@ -1,0 +1,94 @@
+"""
+  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this
+  software and associated documentation files (the "Software"), to deal in the Software
+  without restriction, including without limitation the rights to use, copy, modify,
+  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+import six
+import cfnlint.helpers
+from cfnlint import CloudFormationLintRule
+from cfnlint import RuleMatch
+
+
+class InstanceSize(CloudFormationLintRule):
+    """Check if Resources RDS Instance Size is compatible with the RDS type"""
+    id = 'E3025'
+    shortdesc = 'RDS instance type is compatible with the RDS type'
+    description = 'Check the RDS instance types are supported by the type of RDS engine. ' \
+                  'Only if the values are strings will this be checked.'
+    source_url = 'https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.DBInstanceClass.html'
+    tags = ['resources', 'rds']
+
+    valid_instance_types = cfnlint.helpers.load_resources('/data/AdditionalSpecs/RdsProperties.json')
+
+    def get_resources(self, cfn):
+        """ Get resources that can be checked """
+        results = []
+        for resource_name, resource_values in cfn.get_resources('AWS::RDS::DBInstance').items():
+            path = ['Resources', resource_name, 'Properties']
+            properties = resource_values.get('Properties')
+            for prop_safe, prop_path_safe in properties.items_safe(path):
+                engine = prop_safe.get('Engine')
+                inst_class = prop_safe.get('DBInstanceClass')
+                license_model = prop_safe.get('LicenseModel')
+                if isinstance(engine, six.string_types) and isinstance(inst_class, six.string_types):
+                    results.append(
+                        {
+                            'Engine': engine,
+                            'DBInstanceClass': inst_class,
+                            'Path': prop_path_safe,
+                            'LicenseModel': license_model
+                        })
+
+        return results
+
+    def check_db_config(self, properties, region):
+        """ Check db properties """
+        matches = []
+
+        for valid_instance_type in self.valid_instance_types:
+            engine = properties.get('Engine')
+            if engine in valid_instance_type.get('engines'):
+                if region in valid_instance_type.get('regions'):
+                    db_license = properties.get('LicenseModel')
+                    valid_licenses = valid_instance_type.get('license')
+                    db_instance_class = properties.get('DBInstanceClass')
+                    valid_instance_types = valid_instance_type.get('instance_types')
+                    if db_license and valid_licenses:
+                        if db_license not in valid_licenses:
+                            self.logger.debug('Skip evaluation based on license not matching.')
+                            continue
+                    if db_instance_class not in valid_instance_types:
+                        if db_license is None:
+                            message = 'DBInstanceClass "{0}" is not compatible with engine type "{1}" in region "{2}". Use instance types [{3}]'
+                            matches.append(
+                                RuleMatch(
+                                    properties.get('Path') + ['DBInstanceClass'], message.format(
+                                        db_instance_class, engine, region, ', '.join(map(str, valid_instance_types)))))
+                        else:
+                            message = 'DBInstanceClass "{0}" is not compatible with engine type "{1}" and LicenseModel "{2}" in region "{3}". Use instance types [{4}]'
+                            matches.append(
+                                RuleMatch(
+                                    properties.get('Path') + ['DBInstanceClass'], message.format(
+                                        db_instance_class, engine, db_license, region, ', '.join(map(str, valid_instance_types)))))
+        return matches
+
+    def match(self, cfn):
+        """Check RDS Resource Instance Sizes"""
+
+        matches = []
+        resources = self.get_resources(cfn)
+        for resource in resources:
+            for region in cfn.regions:
+                matches.extend(self.check_db_config(resource, region))
+        return matches

--- a/src/cfnlint/rules/resources/rds/__init__.py
+++ b/src/cfnlint/rules/resources/rds/__init__.py
@@ -1,0 +1,16 @@
+"""
+  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this
+  software and associated documentation files (the "Software"), to deal in the Software
+  without restriction, including without limitation the rights to use, copy, modify,
+  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""

--- a/test/fixtures/templates/bad/resources/rds/instance_sizes.yaml
+++ b/test/fixtures/templates/bad/resources/rds/instance_sizes.yaml
@@ -1,0 +1,29 @@
+---
+AWSTemplateFormatVersion: '2010-09-09'
+Resources:
+  # Fails on invalid instance type
+  DBInstance1:
+    Type: AWS::RDS::DBInstance
+    Properties:
+      DBInstanceClass: db.m4.xlarge
+      Engine: aurora-mysql
+  # invalid Instance Type
+  DBInstance2:
+    Type: AWS::RDS::DBInstance
+    Properties:
+      DBInstanceClass: db.x2e.xlarge
+      Engine: oracle-se2
+      LicenseModel: bring-your-own-license
+  # db.x1e.xlarge isn't for license include
+  DBInstance3:
+    Type: AWS::RDS::DBInstance
+    Properties:
+      DBInstanceClass: db.x1e.xlarge
+      Engine: oracle-se2
+      LicenseModel: license-included
+  # Fails in another region
+  DBInstance4:
+    Type: AWS::RDS::DBInstance
+    Properties:
+      DBInstanceClass: db.m4.xlarge
+      Engine: mysql

--- a/test/fixtures/templates/good/resources/rds/instance_sizes.yaml
+++ b/test/fixtures/templates/good/resources/rds/instance_sizes.yaml
@@ -1,0 +1,34 @@
+---
+AWSTemplateFormatVersion: '2010-09-09'
+Parameters:
+  snapshotid:
+    Type: String
+Conditions:
+  snapshot: !Not [!Equals [!Ref snapshotid, ""]]
+Resources:
+  # Doesnt check if conditions are used
+  DBInstance1:
+    Type: AWS::RDS::DBInstance
+    Properties:
+      DBInstanceClass: db.m4.xlarge
+      Engine: !If [snapshot, !Ref snapshotid, aurora-mysql ]
+  # Doesnt fail on valid instance type
+  DBInstance2:
+    Type: AWS::RDS::DBInstance
+    Properties:
+      DBInstanceClass: db.r4.xlarge
+      Engine: aurora-mysql
+  # Doesnt fail on valid instance type with license
+  DBInstance3:
+    Type: AWS::RDS::DBInstance
+    Properties:
+      DBInstanceClass: db.x1e.xlarge
+      Engine: oracle-se2
+      LicenseModel: bring-your-own-license
+  # Doesnt fail on valid instance type with license
+  DBInstance4:
+    Type: AWS::RDS::DBInstance
+    Properties:
+      DBInstanceClass: db.r4.large
+      Engine: oracle-se2
+      LicenseModel: license-included

--- a/test/rules/__init__.py
+++ b/test/rules/__init__.py
@@ -43,10 +43,11 @@ class BaseRuleTestCase(BaseTestCase):
         good_runner.transform()
         self.assertEqual([], good_runner.run())
 
-    def helper_file_negative(self, filename, err_count):
+    def helper_file_negative(self, filename, err_count, regions=None):
         """Failure test"""
+        regions = regions or ['us-east-1']
         template = self.load_template(filename)
-        bad_runner = Runner(self.collection, filename, template, ['us-east-1'], [])
+        bad_runner = Runner(self.collection, filename, template, regions, [])
         bad_runner.transform()
         errs = bad_runner.run()
         self.assertEqual(err_count, len(errs))

--- a/test/rules/resources/rds/__init__.py
+++ b/test/rules/resources/rds/__init__.py
@@ -1,0 +1,16 @@
+"""
+  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this
+  software and associated documentation files (the "Software"), to deal in the Software
+  without restriction, including without limitation the rights to use, copy, modify,
+  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""

--- a/test/rules/resources/rds/test_instance_sizes.py
+++ b/test/rules/resources/rds/test_instance_sizes.py
@@ -1,0 +1,37 @@
+"""
+  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this
+  software and associated documentation files (the "Software"), to deal in the Software
+  without restriction, including without limitation the rights to use, copy, modify,
+  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+from cfnlint.rules.resources.rds.InstanceSize import InstanceSize  # pylint: disable=E0401
+from ... import BaseRuleTestCase
+
+
+class TestInstanceSize(BaseRuleTestCase):
+    """Test RDS Instance Size Configuration"""
+    def setUp(self):
+        """Setup"""
+        super(TestInstanceSize, self).setUp()
+        self.collection.register(InstanceSize())
+        self.success_templates = [
+            'fixtures/templates/good/resources/rds/instance_sizes.yaml'
+        ]
+
+    def test_file_positive(self):
+        """Test Positive"""
+        self.helper_file_positive()
+
+    def test_file_negative_alias(self):
+        """Test failure"""
+        self.helper_file_negative('fixtures/templates/bad/resources/rds/instance_sizes.yaml', 7, ['us-east-1', 'eu-west-3'])


### PR DESCRIPTION
*Issue #, if available:*
Fix #270
*Description of changes:*
- Check RDS instance types against the region, engine, and license model.  Only checks if they are hardcoded values and not REFed or IFed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
