### PR TITLE
Fix rule E2532 to not fail when using a Fn::Sub and a number for a param

### DIFF
--- a/test/fixtures/templates/good/resources/stepfunctions/state_machine.yaml
+++ b/test/fixtures/templates/good/resources/stepfunctions/state_machine.yaml
@@ -1,5 +1,8 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Description: An example template for a Step Functions state machine.
+Parameters:
+  timeout:
+    Type: Number
 Resources:
   MyStateMachine:
     Type: AWS::StepFunctions::StateMachine
@@ -29,4 +32,42 @@ Resources:
             }
           }
         }
+      RoleArn: arn:aws:iam::111122223333:role/service-role/StatesExecutionRole-us-east-1
+  # doesn't fail on sub that can't be parsed
+  MyStateMachine2:
+    Type: AWS::StepFunctions::StateMachine
+    Properties:
+      StateMachineName: HelloWorld-StateMachine
+      DefinitionString:
+        Fn::Sub:
+        - |
+          {
+            "StartAt": "HelloWorld",
+            "States": {
+              "HelloWorld": {
+                "Type": "Task",
+                "Resource": "arn:aws:lambda:us-east-1:111122223333:function:HelloFunction",
+                "Next": "CreatePublishedRequest"
+              },
+              "CreatePublishedRequest": {
+                "Type": "Task",
+                "Resource": "{$createPublishedRequest}",
+                "ResultPath":"$.publishedRequest",
+                "OutputPath":"$.publishedRequest",
+                "Next": "PutRequest"
+              },
+              "Sleep": {
+                "Type": "Wait",
+                "Seconds": ${TestParam},
+                "Next": "Stop"
+              },
+              "PutRequest": {
+                "Type": "Task",
+                "Resource": "{$updateKey}",
+                "ResultPath":"$.response",
+                "End": true
+              }
+            }
+          }
+        - TestParam: !Ref timeout
       RoleArn: arn:aws:iam::111122223333:role/service-role/StatesExecutionRole-us-east-1


### PR DESCRIPTION
*Issue #, if available:*
Fix #475 
*Description of changes:*
- Fix rule E2532 so that when a Fn::Sub is used and subbing in a number (not string) the rule doesn't fail.  If it runs into a json parse issue when doing a sub it will proceed and not check the state machine definition as we can't fully understand what is inputted.  An even crazier example would be subbing in chunks of the state machine from a parameter.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
