### PR TITLE
Update package dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,11 +53,13 @@ setup(
     packages=find_packages('src'),
     zip_safe=False,
     install_requires=[
-        'pyyaml', 'six',
+        'pyyaml',
+        'six~=1.11',
         'requests>=2.15.0',
-        'aws-sam-translator>=1.6.0',
-        'jsonpatch', 'jsonschema~=2.6.0',
-        'pathlib2>=2.3.0;python_version<"3.6"'
+        'aws-sam-translator>=1.8.0',
+        'jsonpatch',
+        'jsonschema~=2.6',
+        'pathlib2>=2.3.0;python_version<"3.4"'
     ],
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,13 @@ setup(
     ]},
     packages=find_packages('src'),
     zip_safe=False,
-    install_requires=['pyyaml', 'six', 'requests', 'aws-sam-translator>=1.6.0', 'jsonpatch', 'jsonschema~=2.6.0', 'pathlib2'],
+    install_requires=[
+        'pyyaml', 'six',
+        'requests>=2.15.0',
+        'aws-sam-translator>=1.6.0',
+        'jsonpatch', 'jsonschema~=2.6.0',
+        'pathlib2>=2.3.0;python_version<"3.6"'
+    ],
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
*Issue #, if available:*
Fix #479
Fix #471 

*Description of changes:*
- Only require pathlib2 in versions of python before 3.6
- Update dependencies on sam translator to 1.8 and fix six dependency to match SAM
- Update requests to fix when really old versions of requests are trying to be used.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
