### PR TITLE
Enumerating Lambda runtimes in error message

### DIFF
--- a/src/cfnlint/rules/resources/lmbd/FunctionRuntime.py
+++ b/src/cfnlint/rules/resources/lmbd/FunctionRuntime.py
@@ -35,10 +35,10 @@ class FunctionRuntime(CloudFormationLintRule):
     def check_value(self, value, path):
         """ Check runtime value """
         matches = []
-        message = 'You must specify a valid value for runtime ({0}) at {1}'
+        message = 'You must specify a valid value for runtime ({0}) at {1}.\nValid values are {2}'
 
         if value not in self.runtimes:
-            matches.append(RuleMatch(path, message.format(value, ('/'.join(map(str, path))))))
+            matches.append(RuleMatch(path, message.format(value, ('/'.join(map(str, path))), self.runtimes)))
 
         return matches
 


### PR DESCRIPTION
*Description of changes:* Currently, when specifying an invalid `AWS::Lambda::Function.Runtime` the failure message is `E2531 You must specify a valid value for runtime (_YourBadValue_) at Resources/Func/Properties/Runtime.`

Thought it would be nicer is this message (and others like it that I find) to enumerate the allowed options. Then user doesn't have to go hunting for what their typo was.

Message will now state;

`E2531 You must specify a valid value for runtime (_YourBadValue_) at Resources/Func/Properties/Runtime.
Valid values are ['nodejs', 'nodejs4.3', 'nodejs6.10', 'nodejs8.10', 'java8', 'python2.7', 'python3.6', 'dotnetcore1.0', 'dotnetcore2.0', 'dotnetcore2.1', 'nodejs4.3-edge', 'go1.x']`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
