### PR TITLE
Check for lists in Outputs

### DIFF
--- a/src/cfnlint/rules/outputs/Value.py
+++ b/src/cfnlint/rules/outputs/Value.py
@@ -80,4 +80,17 @@ class Value(CloudFormationLintRule):
                                             message.format(ref[1], obj)
                                         ))
 
+        # Check if the output values are not lists
+        outputs = cfn.template.get('Outputs', {})
+        for output_name, output in outputs.items():
+
+            value_obj = output.get('Value')
+            if value_obj:
+                if isinstance(value_obj, list):
+                    message = 'Output {0} value is of type list'
+                    matches.append(RuleMatch(
+                        output_name,
+                        message.format(output_name)
+                    ))
+
         return matches

--- a/test/fixtures/templates/bad/outputs.yaml
+++ b/test/fixtures/templates/bad/outputs.yaml
@@ -26,8 +26,12 @@ Outputs:
     Value: !Ref myInstance
     Export:
       BadName: instance
-  myBadArrayOutput:
+  myBadGetAttArrayOutput:
     Value: !GetAtt [ myVpc, CidrBlockAssociations ]
+  myBadArrayOutput:
+    Value:
+      - !Ref RouteTablePrivate1
+      - !Ref RouteTablePrivate2
   myGoodArrayOutput:
     Value:
       Fn::Join: [ ',', !GetAtt [ myVpc, CidrBlockAssociations ]]

--- a/test/rules/outputs/test_value.py
+++ b/test/rules/outputs/test_value.py
@@ -31,4 +31,4 @@ class TestOutputValue(BaseRuleTestCase):
 
     def test_file_negative(self):
         """Test failure"""
-        self.helper_file_negative('fixtures/templates/bad/outputs.yaml', 2)
+        self.helper_file_negative('fixtures/templates/bad/outputs.yaml', 3)


### PR DESCRIPTION
*Issue https://github.com/awslabs/cfn-python-lint/issues/485, if available:*

Add an additional check for lists in outputs. Lists are already checked if they originate from a `!Ref` or `Fn:GetAtt`. Added an explicit check on lists in the values. It's a separate loop/check in existing Rule [E6003](https://github.com/awslabs/cfn-python-lint/blob/master/docs/rules.md#E6003). 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
