### PR TITLE
Support stdin for processing a template

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ Multiple files can be linted by either specifying multiple specific files:
 - `cfn-lint template1.yaml template2.yaml`
 - `cfn-lint -t template1.yaml template2.yaml`
 
-
 Multiple files can also be specified using wildcards (globbing):
 
 Lint all `yaml` files in `path`:
@@ -56,6 +55,12 @@ Lint all `yaml` files in `path`:
 
 Lint all `yaml` files in `path` and all subdirectories (recursive):
 - `cfn-lint path/to/templates/**/*.yaml`
+
+##### Specifying the template as an input stream
+The template to be linted can also be passed using standard input:
+
+- `cat path/template.yaml | cfn-lint -`
+
 
 ##### Specifying the template with other parameters
 - `cfn-lint -r us-east-1 ap-south-1 -- template.yaml`

--- a/setup.py
+++ b/setup.py
@@ -82,5 +82,6 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
 )

--- a/src/cfnlint/decode/__init__.py
+++ b/src/cfnlint/decode/__init__.py
@@ -16,7 +16,6 @@
 """
 import sys
 import logging
-import json
 import six
 try:
     from json.decoder import JSONDecodeError
@@ -64,8 +63,7 @@ def decode(filename, ignore_bad_template):
     except ScannerError as err:
         if err.problem == 'found character \'\\t\' that cannot start any token':
             try:
-                with open(filename) as fp:
-                    template = json.load(fp, cls=cfnlint.decode.cfn_json.CfnJSONDecoder)
+                template = cfnlint.decode.cfn_json.load(filename)
             except cfnlint.decode.cfn_json.JSONDecodeError as json_err:
                 json_err.match.filename = filename
                 matches = [json_err.match]

--- a/src/cfnlint/decode/cfn_json.py
+++ b/src/cfnlint/decode/cfn_json.py
@@ -349,6 +349,15 @@ def get_beg_end_mark(s, start, end):
 
     return beg_mark, end_mark
 
+def load(filename):
+    """
+    Load the given JSON file
+    """
+
+    with open(filename) as fp:
+        template = json.load(fp, cls=CfnJSONDecoder)
+
+    return template
 
 class CfnJSONDecoder(json.JSONDecoder):
     """

--- a/src/cfnlint/decode/cfn_json.py
+++ b/src/cfnlint/decode/cfn_json.py
@@ -14,6 +14,7 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
+import fileinput
 import sys
 import logging
 import json
@@ -354,10 +355,16 @@ def load(filename):
     Load the given JSON file
     """
 
-    with open(filename) as fp:
-        template = json.load(fp, cls=CfnJSONDecoder)
+    content = ''
 
-    return template
+    if not sys.stdin.isatty():
+        for line in fileinput.input(files=filename):
+            content = content + line
+    else:
+        with open(filename) as fp:
+            content = fp.read()
+
+    return json.loads(content, cls=CfnJSONDecoder)
 
 class CfnJSONDecoder(json.JSONDecoder):
     """

--- a/src/cfnlint/decode/cfn_yaml.py
+++ b/src/cfnlint/decode/cfn_yaml.py
@@ -30,8 +30,6 @@ from yaml.constructor import ConstructorError
 import cfnlint
 from cfnlint.decode.node import str_node, dict_node, list_node
 
-import fileinput
-import sys
 try:
     from yaml.cyaml import CParser as Parser  # pylint: disable=ungrouped-imports
     cyaml = True

--- a/src/cfnlint/decode/cfn_yaml.py
+++ b/src/cfnlint/decode/cfn_yaml.py
@@ -14,7 +14,9 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
+import fileinput
 import logging
+import sys
 import six
 from yaml.composer import Composer
 from yaml.reader import Reader
@@ -28,8 +30,6 @@ from yaml.constructor import ConstructorError
 import cfnlint
 from cfnlint.decode.node import str_node, dict_node, list_node
 
-import fileinput
-import sys
 try:
     from yaml.cyaml import CParser as Parser  # pylint: disable=ungrouped-imports
     cyaml = True
@@ -206,7 +206,7 @@ def load(filename):
     Load the given YAML file
     """
 
-    content = ""
+    content = ''
 
     if not sys.stdin.isatty():
         for line in fileinput.input(files=filename):

--- a/src/cfnlint/decode/cfn_yaml.py
+++ b/src/cfnlint/decode/cfn_yaml.py
@@ -28,6 +28,8 @@ from yaml.constructor import ConstructorError
 import cfnlint
 from cfnlint.decode.node import str_node, dict_node, list_node
 
+import fileinput
+import sys
 try:
     from yaml.cyaml import CParser as Parser  # pylint: disable=ungrouped-imports
     cyaml = True
@@ -203,5 +205,14 @@ def load(filename):
     """
     Load the given YAML file
     """
-    with open(filename) as fp:
-        return loads(fp.read(), filename)
+
+    content = ""
+
+    if not sys.stdin.isatty():
+        for line in fileinput.input(files=filename):
+            content = content + line
+    else:
+        with open(filename) as fp:
+            content = fp.read()
+
+    return loads(content, filename)

--- a/src/cfnlint/decode/cfn_yaml.py
+++ b/src/cfnlint/decode/cfn_yaml.py
@@ -30,6 +30,8 @@ from yaml.constructor import ConstructorError
 import cfnlint
 from cfnlint.decode.node import str_node, dict_node, list_node
 
+import fileinput
+import sys
 try:
     from yaml.cyaml import CParser as Parser  # pylint: disable=ungrouped-imports
     cyaml = True

--- a/src/cfnlint/rules/templates/LimitSize.py
+++ b/src/cfnlint/rules/templates/LimitSize.py
@@ -18,6 +18,11 @@ import os
 from cfnlint import CloudFormationLintRule
 from cfnlint import RuleMatch
 from cfnlint.helpers import LIMITS
+try:  # pragma: no cover
+    from pathlib import Path
+except ImportError:  # pragma: no cover
+    from pathlib2 import Path
+
 
 
 class LimitSize(CloudFormationLintRule):
@@ -34,9 +39,12 @@ class LimitSize(CloudFormationLintRule):
 
         # Check number of resources against the defined limit
         filename = cfn.filename
-        statinfo = os.stat(filename)
-        if statinfo.st_size > LIMITS['template']['body']:
-            message = 'The template file size ({0} bytes) exceeds the limit ({1} bytes)'
-            matches.append(RuleMatch(['Template'], message.format(statinfo.st_size, LIMITS['template']['body'])))
+
+        # Only check if the file exists. The template could be passed in using stdIn
+        if Path(filename).is_file():
+            statinfo = os.stat(filename)
+            if statinfo.st_size > LIMITS['template']['body']:
+                message = 'The template file size ({0} bytes) exceeds the limit ({1} bytes)'
+                matches.append(RuleMatch(['Template'], message.format(statinfo.st_size, LIMITS['template']['body'])))
 
         return matches

--- a/test/module/cfn_json/test_cfn_json.py
+++ b/test/module/cfn_json/test_cfn_json.py
@@ -91,8 +91,7 @@ class TestCfnJson(BaseTestCase):
         filename = 'fixtures/templates/bad/json_parse.json'
 
         try:
-            with open(filename) as fp:
-                json.load(fp, cls=cfnlint.decode.cfn_json.CfnJSONDecoder)
+            template = cfnlint.decode.cfn_json.load(filename)
         except cfnlint.decode.cfn_json.JSONDecodeError:
             assert(True)
             return

--- a/test/module/cfn_json/test_cfn_json.py
+++ b/test/module/cfn_json/test_cfn_json.py
@@ -14,7 +14,7 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-import json
+import sys
 from cfnlint import Template, RulesCollection  # pylint: disable=E0401
 from cfnlint.core import DEFAULT_RULESDIR  # pylint: disable=E0401
 import cfnlint.decode.cfn_json  # pylint: disable=E0401
@@ -63,6 +63,20 @@ class TestCfnJson(BaseTestCase):
         for _, values in self.filenames.items():
             filename = values.get('filename')
             failures = values.get('failures')
+
+            template = cfnlint.decode.cfn_json.load(filename)
+            cfn = Template(filename, template, ['us-east-1'])
+
+            matches = []
+            matches.extend(self.rules.run(filename, cfn))
+            assert len(matches) == failures, 'Expected {} failures, got {} on {}'.format(failures, len(matches), filename)
+
+    def test_success_parse_stdin(self):
+        """Test Successful JSON Parsing through stdin"""
+        for _, values in self.filenames.items():
+            filename = '-'
+            failures = values.get('failures')
+            sys.stdin = open(values.get('filename'), 'r')
 
             template = cfnlint.decode.cfn_json.load(filename)
             cfn = Template(filename, template, ['us-east-1'])

--- a/test/module/cfn_json/test_cfn_json.py
+++ b/test/module/cfn_json/test_cfn_json.py
@@ -63,8 +63,8 @@ class TestCfnJson(BaseTestCase):
         for _, values in self.filenames.items():
             filename = values.get('filename')
             failures = values.get('failures')
-            with open(filename) as fp:
-                template = json.load(fp, cls=cfnlint.decode.cfn_json.CfnJSONDecoder)
+
+            template = cfnlint.decode.cfn_json.load(filename)
             cfn = Template(filename, template, ['us-east-1'])
 
             matches = []


### PR DESCRIPTION
*Issue https://github.com/awslabs/cfn-python-lint/issues/414, if available:*

Allow the processing of a template passed through stdin. while loading the yaml, based on `sys.stdin.isatty()` (Is there data on the stdin) the content is loaded from stdin.

Altered the Template Size rule ('E1002') to check if the file exists. The "original" file content is not availablle anymore after it's loaded as a `dict`. Could be alternative ways to keep track of the file size, but went for this approach to keep it as simple as possible.

*Usage:*

```
cat test/fixtures/templates/bad/generic.yaml | cfn-lint -
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
