### PR TITLE
Fix JSON dumps adding spaces after the comma

### DIFF
--- a/src/cfnlint/maintenance.py
+++ b/src/cfnlint/maintenance.py
@@ -57,7 +57,7 @@ def update_resource_specs():
         content = json.loads(req.content)
         content = patch_spec(content, region)
         with open(filename, 'w') as f:
-            json.dump(content, f, indent=2, sort_keys=True)
+            json.dump(content, f, indent=2, sort_keys=True, separators=(',', ': '))
 
 
 def update_documentation(rules):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Don't dump spaces after the comma

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
