### PR TITLE
Update Lambda Runtimes to include provided and ruby

### DIFF
--- a/src/cfnlint/rules/resources/lmbd/FunctionRuntime.py
+++ b/src/cfnlint/rules/resources/lmbd/FunctionRuntime.py
@@ -29,7 +29,7 @@ class FunctionRuntime(CloudFormationLintRule):
     runtimes = [
         'nodejs', 'nodejs4.3', 'nodejs6.10', 'nodejs8.10', 'java8', 'python2.7',
         'python3.6', 'python3.7', 'dotnetcore1.0', 'dotnetcore2.0', 'dotnetcore2.1',
-        'nodejs4.3-edge', 'go1.x'
+        'nodejs4.3-edge', 'go1.x', 'ruby2.5', 'provided'
     ]
 
     def check_value(self, value, path):


### PR DESCRIPTION
*Issue #, if available:*
#497

*Description of changes:*
- Update Lambda rule to include Ruby and provided

https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html#SSS-CreateFunction-request-Runtime

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
