### PR TITLE
Clean up file open errors in py3x and only with testing

### DIFF
--- a/test/module/cfn_json/test_cfn_json.py
+++ b/test/module/cfn_json/test_cfn_json.py
@@ -15,6 +15,8 @@
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 import sys
+from mock import patch
+from six import StringIO
 from cfnlint import Template, RulesCollection  # pylint: disable=E0401
 from cfnlint.core import DEFAULT_RULESDIR  # pylint: disable=E0401
 import cfnlint.decode.cfn_json  # pylint: disable=E0401
@@ -76,14 +78,16 @@ class TestCfnJson(BaseTestCase):
         for _, values in self.filenames.items():
             filename = '-'
             failures = values.get('failures')
-            sys.stdin = open(values.get('filename'), 'r')
+            with open(values.get('filename'), 'r') as fp:
+                file_content = fp.read()
+            with patch('sys.stdin', StringIO(file_content)):
 
-            template = cfnlint.decode.cfn_json.load(filename)
-            cfn = Template(filename, template, ['us-east-1'])
+                template = cfnlint.decode.cfn_json.load(filename)
+                cfn = Template(filename, template, ['us-east-1'])
 
-            matches = []
-            matches.extend(self.rules.run(filename, cfn))
-            assert len(matches) == failures, 'Expected {} failures, got {} on {}'.format(failures, len(matches), filename)
+                matches = []
+                matches.extend(self.rules.run(filename, cfn))
+                assert len(matches) == failures, 'Expected {} failures, got {} on {}'.format(failures, len(matches), filename)
 
     def test_fail_run(self):
         """Test failure run"""


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Fix tests to not print the following error in Py3x
```
/home/travis/build/awslabs/cfn-python-lint/test/module/cfn_json/test_cfn_json.py:79: ResourceWarning: unclosed file <_io.TextIOWrapper name='fixtures/templates/quickstart/nat-instance.json' mode='r' encoding='UTF-8'>
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
