### PR TITLE
In the JSON formatter, output Informational as Informational

### DIFF
--- a/src/cfnlint/formatters/__init__.py
+++ b/src/cfnlint/formatters/__init__.py
@@ -52,6 +52,8 @@ class JsonFormatter(BaseFormatter):
             if isinstance(o, Match):
                 if o.rule.id[0] == 'W':
                     level = 'Warning'
+                elif o.rule.id[0] == 'I':
+                    level = 'Informational'
                 else:
                     level = 'Error'
 


### PR DESCRIPTION
The JSON formatter is unaware of the (new) Informational level rules, causing these to be outputted as `Error`.

This PR outputs the Informational level rules as `Informational`.

(tbh, no clue how all the Editor plugins will handle this... 🤔 )

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
