### PR TITLE
Improve is_custom_resource check

### DIFF
--- a/src/cfnlint/helpers.py
+++ b/src/cfnlint/helpers.py
@@ -182,7 +182,7 @@ def set_specs(override_spec_data):
 
 def is_custom_resource(resource_type):
     """ Return True if resource_type is a custom resource """
-    return resource_type == 'AWS::CloudFormation::CustomResource' or resource_type.startswith('Custom::')
+    return resource_type and (resource_type == 'AWS::CloudFormation::CustomResource' or resource_type.startswith('Custom::'))
 
 
 def initialize_specs():


### PR DESCRIPTION
Rule `E3008` breaks if there is a Reference to a non-existing resource:

```
(venv) ➜  cfn-python-lint git:(quick-fixes) cfn-lint test/fixtures/templates/bad/resources_lambda.yaml 
E0002 Unknown exception while processing rule E3008: 'NoneType' object has no attribute 'startswith'
test/fixtures/templates/bad/resources_lambda.yaml:1:1
```

Discovered this when working on another rule. The `is_custom_resource` check now handles `NoneType` (None = Not a custom resource)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
