### PR TITLE
Update specs to better handle GetAtt empty and not specified

### DIFF
--- a/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
@@ -30638,6 +30638,7 @@
       }
     },
     "AvailabilityZones": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings",
@@ -30693,6 +30694,7 @@
       ]
     },
     "IamInstanceProfile": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -30713,6 +30715,7 @@
       }
     },
     "IamRole": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -30743,6 +30746,7 @@
       }
     },
     "ImageId": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String",
@@ -30751,6 +30755,7 @@
       }
     },
     "KeyPair": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String",
@@ -30769,6 +30774,7 @@
       }
     },
     "KmsKey.Id": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -30811,6 +30817,7 @@
       ]
     },
     "LaunchConfigurationName": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -30821,6 +30828,7 @@
       }
     },
     "LoadBalancerName": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -30831,6 +30839,7 @@
       }
     },
     "LoadBalancerNames": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings"
@@ -30838,6 +30847,7 @@
       }
     },
     "LoadBalancerV2Arn": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -30848,6 +30858,7 @@
       }
     },
     "PlacementGroup": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -30901,6 +30912,7 @@
       ]
     },
     "SecurityGroup": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String",
@@ -30938,6 +30950,7 @@
       }
     },
     "SecurityGroups": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings",
@@ -30949,6 +30962,7 @@
       }
     },
     "SsmDocumentName": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -30959,6 +30973,7 @@
       }
     },
     "String": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -30966,6 +30981,7 @@
       }
     },
     "SubnetId": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String",
@@ -30977,6 +30993,7 @@
       }
     },
     "SubnetIds": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings",
@@ -30985,6 +31002,7 @@
       }
     },
     "TargetGroupArn": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -30995,6 +31013,7 @@
       }
     },
     "TargetGroupArns": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings"

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
@@ -28110,6 +28110,7 @@
       }
     },
     "AvailabilityZones": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings",
@@ -28165,6 +28166,7 @@
       ]
     },
     "IamInstanceProfile": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -28185,6 +28187,7 @@
       }
     },
     "IamRole": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -28215,6 +28218,7 @@
       }
     },
     "ImageId": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String",
@@ -28223,6 +28227,7 @@
       }
     },
     "KeyPair": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String",
@@ -28241,6 +28246,7 @@
       }
     },
     "KmsKey.Id": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -28283,6 +28289,7 @@
       ]
     },
     "LaunchConfigurationName": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -28293,6 +28300,7 @@
       }
     },
     "LoadBalancerName": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -28303,6 +28311,7 @@
       }
     },
     "LoadBalancerNames": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings"
@@ -28310,6 +28319,7 @@
       }
     },
     "LoadBalancerV2Arn": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -28320,6 +28330,7 @@
       }
     },
     "PlacementGroup": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -28373,6 +28384,7 @@
       ]
     },
     "SecurityGroup": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String",
@@ -28410,6 +28422,7 @@
       }
     },
     "SecurityGroups": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings",
@@ -28421,6 +28434,7 @@
       }
     },
     "SsmDocumentName": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -28431,6 +28445,7 @@
       }
     },
     "String": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -28438,6 +28453,7 @@
       }
     },
     "SubnetId": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String",
@@ -28449,6 +28465,7 @@
       }
     },
     "SubnetIds": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings",
@@ -28457,6 +28474,7 @@
       }
     },
     "TargetGroupArn": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -28467,6 +28485,7 @@
       }
     },
     "TargetGroupArns": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings"

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
@@ -20542,6 +20542,7 @@
       }
     },
     "AvailabilityZones": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings",
@@ -20597,6 +20598,7 @@
       ]
     },
     "IamInstanceProfile": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -20617,6 +20619,7 @@
       }
     },
     "IamRole": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -20647,6 +20650,7 @@
       }
     },
     "ImageId": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String",
@@ -20655,6 +20659,7 @@
       }
     },
     "KeyPair": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String",
@@ -20673,6 +20678,7 @@
       }
     },
     "KmsKey.Id": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -20715,6 +20721,7 @@
       ]
     },
     "LaunchConfigurationName": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -20725,6 +20732,7 @@
       }
     },
     "LoadBalancerName": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -20735,6 +20743,7 @@
       }
     },
     "LoadBalancerNames": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings"
@@ -20742,6 +20751,7 @@
       }
     },
     "LoadBalancerV2Arn": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -20752,6 +20762,7 @@
       }
     },
     "PlacementGroup": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -20805,6 +20816,7 @@
       ]
     },
     "SecurityGroup": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String",
@@ -20842,6 +20854,7 @@
       }
     },
     "SecurityGroups": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings",
@@ -20853,6 +20866,7 @@
       }
     },
     "SsmDocumentName": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -20863,6 +20877,7 @@
       }
     },
     "String": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -20870,6 +20885,7 @@
       }
     },
     "SubnetId": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String",
@@ -20881,6 +20897,7 @@
       }
     },
     "SubnetIds": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings",
@@ -20889,6 +20906,7 @@
       }
     },
     "TargetGroupArn": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -20899,6 +20917,7 @@
       }
     },
     "TargetGroupArns": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings"

--- a/src/cfnlint/data/CloudSpecs/ap-south-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-south-1.json
@@ -27016,6 +27016,7 @@
       }
     },
     "AvailabilityZones": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings",
@@ -27071,6 +27072,7 @@
       ]
     },
     "IamInstanceProfile": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -27091,6 +27093,7 @@
       }
     },
     "IamRole": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -27121,6 +27124,7 @@
       }
     },
     "ImageId": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String",
@@ -27129,6 +27133,7 @@
       }
     },
     "KeyPair": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String",
@@ -27147,6 +27152,7 @@
       }
     },
     "KmsKey.Id": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -27189,6 +27195,7 @@
       ]
     },
     "LaunchConfigurationName": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -27199,6 +27206,7 @@
       }
     },
     "LoadBalancerName": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -27209,6 +27217,7 @@
       }
     },
     "LoadBalancerNames": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings"
@@ -27216,6 +27225,7 @@
       }
     },
     "LoadBalancerV2Arn": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -27226,6 +27236,7 @@
       }
     },
     "PlacementGroup": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -27279,6 +27290,7 @@
       ]
     },
     "SecurityGroup": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String",
@@ -27316,6 +27328,7 @@
       }
     },
     "SecurityGroups": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings",
@@ -27327,6 +27340,7 @@
       }
     },
     "SsmDocumentName": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -27337,6 +27351,7 @@
       }
     },
     "String": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -27344,6 +27359,7 @@
       }
     },
     "SubnetId": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String",
@@ -27355,6 +27371,7 @@
       }
     },
     "SubnetIds": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings",
@@ -27363,6 +27380,7 @@
       }
     },
     "TargetGroupArn": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -27373,6 +27391,7 @@
       }
     },
     "TargetGroupArns": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings"

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
@@ -28384,6 +28384,7 @@
       }
     },
     "AvailabilityZones": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings",
@@ -28439,6 +28440,7 @@
       ]
     },
     "IamInstanceProfile": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -28459,6 +28461,7 @@
       }
     },
     "IamRole": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -28489,6 +28492,7 @@
       }
     },
     "ImageId": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String",
@@ -28497,6 +28501,7 @@
       }
     },
     "KeyPair": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String",
@@ -28515,6 +28520,7 @@
       }
     },
     "KmsKey.Id": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -28557,6 +28563,7 @@
       ]
     },
     "LaunchConfigurationName": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -28567,6 +28574,7 @@
       }
     },
     "LoadBalancerName": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -28577,6 +28585,7 @@
       }
     },
     "LoadBalancerNames": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings"
@@ -28584,6 +28593,7 @@
       }
     },
     "LoadBalancerV2Arn": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -28594,6 +28604,7 @@
       }
     },
     "PlacementGroup": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -28647,6 +28658,7 @@
       ]
     },
     "SecurityGroup": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String",
@@ -28684,6 +28696,7 @@
       }
     },
     "SecurityGroups": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings",
@@ -28695,6 +28708,7 @@
       }
     },
     "SsmDocumentName": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -28705,6 +28719,7 @@
       }
     },
     "String": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -28712,6 +28727,7 @@
       }
     },
     "SubnetId": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String",
@@ -28723,6 +28739,7 @@
       }
     },
     "SubnetIds": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings",
@@ -28731,6 +28748,7 @@
       }
     },
     "TargetGroupArn": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -28741,6 +28759,7 @@
       }
     },
     "TargetGroupArns": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings"

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
@@ -28946,6 +28946,7 @@
       }
     },
     "AvailabilityZones": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings",
@@ -29001,6 +29002,7 @@
       ]
     },
     "IamInstanceProfile": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -29021,6 +29023,7 @@
       }
     },
     "IamRole": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -29051,6 +29054,7 @@
       }
     },
     "ImageId": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String",
@@ -29059,6 +29063,7 @@
       }
     },
     "KeyPair": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String",
@@ -29077,6 +29082,7 @@
       }
     },
     "KmsKey.Id": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -29119,6 +29125,7 @@
       ]
     },
     "LaunchConfigurationName": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -29129,6 +29136,7 @@
       }
     },
     "LoadBalancerName": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -29139,6 +29147,7 @@
       }
     },
     "LoadBalancerNames": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings"
@@ -29146,6 +29155,7 @@
       }
     },
     "LoadBalancerV2Arn": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -29156,6 +29166,7 @@
       }
     },
     "PlacementGroup": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -29209,6 +29220,7 @@
       ]
     },
     "SecurityGroup": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String",
@@ -29246,6 +29258,7 @@
       }
     },
     "SecurityGroups": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings",
@@ -29257,6 +29270,7 @@
       }
     },
     "SsmDocumentName": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -29267,6 +29281,7 @@
       }
     },
     "String": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -29274,6 +29289,7 @@
       }
     },
     "SubnetId": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String",
@@ -29285,6 +29301,7 @@
       }
     },
     "SubnetIds": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings",
@@ -29293,6 +29310,7 @@
       }
     },
     "TargetGroupArn": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -29303,6 +29321,7 @@
       }
     },
     "TargetGroupArns": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings"

--- a/src/cfnlint/data/CloudSpecs/ca-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/ca-central-1.json
@@ -25382,6 +25382,7 @@
       }
     },
     "AvailabilityZones": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings",
@@ -25437,6 +25438,7 @@
       ]
     },
     "IamInstanceProfile": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -25457,6 +25459,7 @@
       }
     },
     "IamRole": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -25487,6 +25490,7 @@
       }
     },
     "ImageId": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String",
@@ -25495,6 +25499,7 @@
       }
     },
     "KeyPair": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String",
@@ -25513,6 +25518,7 @@
       }
     },
     "KmsKey.Id": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -25555,6 +25561,7 @@
       ]
     },
     "LaunchConfigurationName": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -25565,6 +25572,7 @@
       }
     },
     "LoadBalancerName": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -25575,6 +25583,7 @@
       }
     },
     "LoadBalancerNames": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings"
@@ -25582,6 +25591,7 @@
       }
     },
     "LoadBalancerV2Arn": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -25592,6 +25602,7 @@
       }
     },
     "PlacementGroup": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -25645,6 +25656,7 @@
       ]
     },
     "SecurityGroup": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String",
@@ -25682,6 +25694,7 @@
       }
     },
     "SecurityGroups": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings",
@@ -25693,6 +25706,7 @@
       }
     },
     "SsmDocumentName": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -25703,6 +25717,7 @@
       }
     },
     "String": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -25710,6 +25725,7 @@
       }
     },
     "SubnetId": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String",
@@ -25721,6 +25737,7 @@
       }
     },
     "SubnetIds": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings",
@@ -25729,6 +25746,7 @@
       }
     },
     "TargetGroupArn": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -25739,6 +25757,7 @@
       }
     },
     "TargetGroupArns": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings"

--- a/src/cfnlint/data/CloudSpecs/eu-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-central-1.json
@@ -29791,6 +29791,7 @@
       }
     },
     "AvailabilityZones": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings",
@@ -29846,6 +29847,7 @@
       ]
     },
     "IamInstanceProfile": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -29866,6 +29868,7 @@
       }
     },
     "IamRole": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -29896,6 +29899,7 @@
       }
     },
     "ImageId": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String",
@@ -29904,6 +29908,7 @@
       }
     },
     "KeyPair": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String",
@@ -29922,6 +29927,7 @@
       }
     },
     "KmsKey.Id": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -29964,6 +29970,7 @@
       ]
     },
     "LaunchConfigurationName": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -29974,6 +29981,7 @@
       }
     },
     "LoadBalancerName": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -29984,6 +29992,7 @@
       }
     },
     "LoadBalancerNames": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings"
@@ -29991,6 +30000,7 @@
       }
     },
     "LoadBalancerV2Arn": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -30001,6 +30011,7 @@
       }
     },
     "PlacementGroup": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -30054,6 +30065,7 @@
       ]
     },
     "SecurityGroup": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String",
@@ -30091,6 +30103,7 @@
       }
     },
     "SecurityGroups": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings",
@@ -30102,6 +30115,7 @@
       }
     },
     "SsmDocumentName": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -30112,6 +30126,7 @@
       }
     },
     "String": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -30119,6 +30134,7 @@
       }
     },
     "SubnetId": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String",
@@ -30130,6 +30146,7 @@
       }
     },
     "SubnetIds": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings",
@@ -30138,6 +30155,7 @@
       }
     },
     "TargetGroupArn": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -30148,6 +30166,7 @@
       }
     },
     "TargetGroupArns": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings"

--- a/src/cfnlint/data/CloudSpecs/eu-north-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-north-1.json
@@ -20894,6 +20894,7 @@
       }
     },
     "AvailabilityZones": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings",
@@ -20949,6 +20950,7 @@
       ]
     },
     "IamInstanceProfile": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -20969,6 +20971,7 @@
       }
     },
     "IamRole": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -20999,6 +21002,7 @@
       }
     },
     "ImageId": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String",
@@ -21007,6 +21011,7 @@
       }
     },
     "KeyPair": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String",
@@ -21025,6 +21030,7 @@
       }
     },
     "KmsKey.Id": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -21067,6 +21073,7 @@
       ]
     },
     "LaunchConfigurationName": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -21077,6 +21084,7 @@
       }
     },
     "LoadBalancerName": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -21087,6 +21095,7 @@
       }
     },
     "LoadBalancerNames": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings"
@@ -21094,6 +21103,7 @@
       }
     },
     "LoadBalancerV2Arn": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -21104,6 +21114,7 @@
       }
     },
     "PlacementGroup": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -21157,6 +21168,7 @@
       ]
     },
     "SecurityGroup": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String",
@@ -21194,6 +21206,7 @@
       }
     },
     "SecurityGroups": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings",
@@ -21205,6 +21218,7 @@
       }
     },
     "SsmDocumentName": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -21215,6 +21229,7 @@
       }
     },
     "String": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -21222,6 +21237,7 @@
       }
     },
     "SubnetId": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String",
@@ -21233,6 +21249,7 @@
       }
     },
     "SubnetIds": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings",
@@ -21241,6 +21258,7 @@
       }
     },
     "TargetGroupArn": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -21251,6 +21269,7 @@
       }
     },
     "TargetGroupArns": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings"

--- a/src/cfnlint/data/CloudSpecs/eu-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-1.json
@@ -33015,6 +33015,7 @@
       }
     },
     "AvailabilityZones": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings",
@@ -33070,6 +33071,7 @@
       ]
     },
     "IamInstanceProfile": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -33090,6 +33092,7 @@
       }
     },
     "IamRole": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -33120,6 +33123,7 @@
       }
     },
     "ImageId": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String",
@@ -33128,6 +33132,7 @@
       }
     },
     "KeyPair": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String",
@@ -33146,6 +33151,7 @@
       }
     },
     "KmsKey.Id": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -33188,6 +33194,7 @@
       ]
     },
     "LaunchConfigurationName": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -33198,6 +33205,7 @@
       }
     },
     "LoadBalancerName": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -33208,6 +33216,7 @@
       }
     },
     "LoadBalancerNames": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings"
@@ -33215,6 +33224,7 @@
       }
     },
     "LoadBalancerV2Arn": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -33225,6 +33235,7 @@
       }
     },
     "PlacementGroup": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -33278,6 +33289,7 @@
       ]
     },
     "SecurityGroup": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String",
@@ -33315,6 +33327,7 @@
       }
     },
     "SecurityGroups": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings",
@@ -33326,6 +33339,7 @@
       }
     },
     "SsmDocumentName": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -33336,6 +33350,7 @@
       }
     },
     "String": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -33343,6 +33358,7 @@
       }
     },
     "SubnetId": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String",
@@ -33354,6 +33370,7 @@
       }
     },
     "SubnetIds": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings",
@@ -33362,6 +33379,7 @@
       }
     },
     "TargetGroupArn": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -33372,6 +33390,7 @@
       }
     },
     "TargetGroupArns": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings"

--- a/src/cfnlint/data/CloudSpecs/eu-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-2.json
@@ -26683,6 +26683,7 @@
       }
     },
     "AvailabilityZones": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings",
@@ -26738,6 +26739,7 @@
       ]
     },
     "IamInstanceProfile": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -26758,6 +26760,7 @@
       }
     },
     "IamRole": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -26788,6 +26791,7 @@
       }
     },
     "ImageId": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String",
@@ -26796,6 +26800,7 @@
       }
     },
     "KeyPair": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String",
@@ -26814,6 +26819,7 @@
       }
     },
     "KmsKey.Id": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -26856,6 +26862,7 @@
       ]
     },
     "LaunchConfigurationName": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -26866,6 +26873,7 @@
       }
     },
     "LoadBalancerName": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -26876,6 +26884,7 @@
       }
     },
     "LoadBalancerNames": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings"
@@ -26883,6 +26892,7 @@
       }
     },
     "LoadBalancerV2Arn": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -26893,6 +26903,7 @@
       }
     },
     "PlacementGroup": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -26946,6 +26957,7 @@
       ]
     },
     "SecurityGroup": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String",
@@ -26983,6 +26995,7 @@
       }
     },
     "SecurityGroups": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings",
@@ -26994,6 +27007,7 @@
       }
     },
     "SsmDocumentName": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -27004,6 +27018,7 @@
       }
     },
     "String": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -27011,6 +27026,7 @@
       }
     },
     "SubnetId": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String",
@@ -27022,6 +27038,7 @@
       }
     },
     "SubnetIds": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings",
@@ -27030,6 +27047,7 @@
       }
     },
     "TargetGroupArn": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -27040,6 +27058,7 @@
       }
     },
     "TargetGroupArns": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings"

--- a/src/cfnlint/data/CloudSpecs/eu-west-3.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-3.json
@@ -24083,6 +24083,7 @@
       }
     },
     "AvailabilityZones": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings",
@@ -24138,6 +24139,7 @@
       ]
     },
     "IamInstanceProfile": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -24158,6 +24160,7 @@
       }
     },
     "IamRole": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -24188,6 +24191,7 @@
       }
     },
     "ImageId": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String",
@@ -24196,6 +24200,7 @@
       }
     },
     "KeyPair": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String",
@@ -24214,6 +24219,7 @@
       }
     },
     "KmsKey.Id": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -24256,6 +24262,7 @@
       ]
     },
     "LaunchConfigurationName": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -24266,6 +24273,7 @@
       }
     },
     "LoadBalancerName": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -24276,6 +24284,7 @@
       }
     },
     "LoadBalancerNames": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings"
@@ -24283,6 +24292,7 @@
       }
     },
     "LoadBalancerV2Arn": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -24293,6 +24303,7 @@
       }
     },
     "PlacementGroup": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -24346,6 +24357,7 @@
       ]
     },
     "SecurityGroup": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String",
@@ -24383,6 +24395,7 @@
       }
     },
     "SecurityGroups": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings",
@@ -24394,6 +24407,7 @@
       }
     },
     "SsmDocumentName": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -24404,6 +24418,7 @@
       }
     },
     "String": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -24411,6 +24426,7 @@
       }
     },
     "SubnetId": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String",
@@ -24422,6 +24438,7 @@
       }
     },
     "SubnetIds": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings",
@@ -24430,6 +24447,7 @@
       }
     },
     "TargetGroupArn": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -24440,6 +24458,7 @@
       }
     },
     "TargetGroupArns": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings"

--- a/src/cfnlint/data/CloudSpecs/sa-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/sa-east-1.json
@@ -24995,6 +24995,7 @@
       }
     },
     "AvailabilityZones": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings",
@@ -25050,6 +25051,7 @@
       ]
     },
     "IamInstanceProfile": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -25070,6 +25072,7 @@
       }
     },
     "IamRole": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -25100,6 +25103,7 @@
       }
     },
     "ImageId": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String",
@@ -25108,6 +25112,7 @@
       }
     },
     "KeyPair": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String",
@@ -25126,6 +25131,7 @@
       }
     },
     "KmsKey.Id": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -25168,6 +25174,7 @@
       ]
     },
     "LaunchConfigurationName": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -25178,6 +25185,7 @@
       }
     },
     "LoadBalancerName": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -25188,6 +25196,7 @@
       }
     },
     "LoadBalancerNames": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings"
@@ -25195,6 +25204,7 @@
       }
     },
     "LoadBalancerV2Arn": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -25205,6 +25215,7 @@
       }
     },
     "PlacementGroup": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -25258,6 +25269,7 @@
       ]
     },
     "SecurityGroup": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String",
@@ -25295,6 +25307,7 @@
       }
     },
     "SecurityGroups": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings",
@@ -25306,6 +25319,7 @@
       }
     },
     "SsmDocumentName": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -25316,6 +25330,7 @@
       }
     },
     "String": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -25323,6 +25338,7 @@
       }
     },
     "SubnetId": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String",
@@ -25334,6 +25350,7 @@
       }
     },
     "SubnetIds": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings",
@@ -25342,6 +25359,7 @@
       }
     },
     "TargetGroupArn": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -25352,6 +25370,7 @@
       }
     },
     "TargetGroupArns": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings"

--- a/src/cfnlint/data/CloudSpecs/us-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-1.json
@@ -33044,6 +33044,7 @@
       }
     },
     "AvailabilityZones": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings",
@@ -33099,6 +33100,7 @@
       ]
     },
     "IamInstanceProfile": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -33119,6 +33121,7 @@
       }
     },
     "IamRole": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -33149,6 +33152,7 @@
       }
     },
     "ImageId": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String",
@@ -33157,6 +33161,7 @@
       }
     },
     "KeyPair": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String",
@@ -33175,6 +33180,7 @@
       }
     },
     "KmsKey.Id": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -33217,6 +33223,7 @@
       ]
     },
     "LaunchConfigurationName": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -33227,6 +33234,7 @@
       }
     },
     "LoadBalancerName": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -33237,6 +33245,7 @@
       }
     },
     "LoadBalancerNames": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings"
@@ -33244,6 +33253,7 @@
       }
     },
     "LoadBalancerV2Arn": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -33254,6 +33264,7 @@
       }
     },
     "PlacementGroup": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -33307,6 +33318,7 @@
       ]
     },
     "SecurityGroup": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String",
@@ -33344,6 +33356,7 @@
       }
     },
     "SecurityGroups": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings",
@@ -33355,6 +33368,7 @@
       }
     },
     "SsmDocumentName": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -33365,6 +33379,7 @@
       }
     },
     "String": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -33372,6 +33387,7 @@
       }
     },
     "SubnetId": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String",
@@ -33383,6 +33399,7 @@
       }
     },
     "SubnetIds": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings",
@@ -33391,6 +33408,7 @@
       }
     },
     "TargetGroupArn": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -33401,6 +33419,7 @@
       }
     },
     "TargetGroupArns": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings"

--- a/src/cfnlint/data/CloudSpecs/us-east-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-2.json
@@ -31050,6 +31050,7 @@
       }
     },
     "AvailabilityZones": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings",
@@ -31105,6 +31106,7 @@
       ]
     },
     "IamInstanceProfile": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -31125,6 +31127,7 @@
       }
     },
     "IamRole": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -31155,6 +31158,7 @@
       }
     },
     "ImageId": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String",
@@ -31163,6 +31167,7 @@
       }
     },
     "KeyPair": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String",
@@ -31181,6 +31186,7 @@
       }
     },
     "KmsKey.Id": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -31223,6 +31229,7 @@
       ]
     },
     "LaunchConfigurationName": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -31233,6 +31240,7 @@
       }
     },
     "LoadBalancerName": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -31243,6 +31251,7 @@
       }
     },
     "LoadBalancerNames": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings"
@@ -31250,6 +31259,7 @@
       }
     },
     "LoadBalancerV2Arn": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -31260,6 +31270,7 @@
       }
     },
     "PlacementGroup": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -31313,6 +31324,7 @@
       ]
     },
     "SecurityGroup": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String",
@@ -31350,6 +31362,7 @@
       }
     },
     "SecurityGroups": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings",
@@ -31361,6 +31374,7 @@
       }
     },
     "SsmDocumentName": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -31371,6 +31385,7 @@
       }
     },
     "String": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -31378,6 +31393,7 @@
       }
     },
     "SubnetId": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String",
@@ -31389,6 +31405,7 @@
       }
     },
     "SubnetIds": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings",
@@ -31397,6 +31414,7 @@
       }
     },
     "TargetGroupArn": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -31407,6 +31425,7 @@
       }
     },
     "TargetGroupArns": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings"

--- a/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
@@ -20317,6 +20317,7 @@
       }
     },
     "AvailabilityZones": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings",
@@ -20372,6 +20373,7 @@
       ]
     },
     "IamInstanceProfile": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -20392,6 +20394,7 @@
       }
     },
     "IamRole": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -20422,6 +20425,7 @@
       }
     },
     "ImageId": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String",
@@ -20430,6 +20434,7 @@
       }
     },
     "KeyPair": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String",
@@ -20448,6 +20453,7 @@
       }
     },
     "KmsKey.Id": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -20490,6 +20496,7 @@
       ]
     },
     "LaunchConfigurationName": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -20500,6 +20507,7 @@
       }
     },
     "LoadBalancerName": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -20510,6 +20518,7 @@
       }
     },
     "LoadBalancerNames": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings"
@@ -20517,6 +20526,7 @@
       }
     },
     "LoadBalancerV2Arn": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -20527,6 +20537,7 @@
       }
     },
     "PlacementGroup": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -20580,6 +20591,7 @@
       ]
     },
     "SecurityGroup": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String",
@@ -20617,6 +20629,7 @@
       }
     },
     "SecurityGroups": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings",
@@ -20628,6 +20641,7 @@
       }
     },
     "SsmDocumentName": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -20638,6 +20652,7 @@
       }
     },
     "String": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -20645,6 +20660,7 @@
       }
     },
     "SubnetId": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String",
@@ -20656,6 +20672,7 @@
       }
     },
     "SubnetIds": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings",
@@ -20664,6 +20681,7 @@
       }
     },
     "TargetGroupArn": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -20674,6 +20692,7 @@
       }
     },
     "TargetGroupArns": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings"

--- a/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
@@ -20475,6 +20475,7 @@
       }
     },
     "AvailabilityZones": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings",
@@ -20530,6 +20531,7 @@
       ]
     },
     "IamInstanceProfile": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -20550,6 +20552,7 @@
       }
     },
     "IamRole": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -20580,6 +20583,7 @@
       }
     },
     "ImageId": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String",
@@ -20588,6 +20592,7 @@
       }
     },
     "KeyPair": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String",
@@ -20606,6 +20611,7 @@
       }
     },
     "KmsKey.Id": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -20648,6 +20654,7 @@
       ]
     },
     "LaunchConfigurationName": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -20658,6 +20665,7 @@
       }
     },
     "LoadBalancerName": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -20668,6 +20676,7 @@
       }
     },
     "LoadBalancerNames": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings"
@@ -20675,6 +20684,7 @@
       }
     },
     "LoadBalancerV2Arn": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -20685,6 +20695,7 @@
       }
     },
     "PlacementGroup": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -20738,6 +20749,7 @@
       ]
     },
     "SecurityGroup": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String",
@@ -20775,6 +20787,7 @@
       }
     },
     "SecurityGroups": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings",
@@ -20786,6 +20799,7 @@
       }
     },
     "SsmDocumentName": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -20796,6 +20810,7 @@
       }
     },
     "String": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -20803,6 +20818,7 @@
       }
     },
     "SubnetId": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String",
@@ -20814,6 +20830,7 @@
       }
     },
     "SubnetIds": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings",
@@ -20822,6 +20839,7 @@
       }
     },
     "TargetGroupArn": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -20832,6 +20850,7 @@
       }
     },
     "TargetGroupArns": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings"

--- a/src/cfnlint/data/CloudSpecs/us-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-1.json
@@ -26046,6 +26046,7 @@
       }
     },
     "AvailabilityZones": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings",
@@ -26101,6 +26102,7 @@
       ]
     },
     "IamInstanceProfile": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -26121,6 +26123,7 @@
       }
     },
     "IamRole": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -26151,6 +26154,7 @@
       }
     },
     "ImageId": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String",
@@ -26159,6 +26163,7 @@
       }
     },
     "KeyPair": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String",
@@ -26177,6 +26182,7 @@
       }
     },
     "KmsKey.Id": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -26219,6 +26225,7 @@
       ]
     },
     "LaunchConfigurationName": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -26229,6 +26236,7 @@
       }
     },
     "LoadBalancerName": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -26239,6 +26247,7 @@
       }
     },
     "LoadBalancerNames": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings"
@@ -26246,6 +26255,7 @@
       }
     },
     "LoadBalancerV2Arn": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -26256,6 +26266,7 @@
       }
     },
     "PlacementGroup": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -26309,6 +26320,7 @@
       ]
     },
     "SecurityGroup": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String",
@@ -26346,6 +26358,7 @@
       }
     },
     "SecurityGroups": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings",
@@ -26357,6 +26370,7 @@
       }
     },
     "SsmDocumentName": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -26367,6 +26381,7 @@
       }
     },
     "String": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -26374,6 +26389,7 @@
       }
     },
     "SubnetId": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String",
@@ -26385,6 +26401,7 @@
       }
     },
     "SubnetIds": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings",
@@ -26393,6 +26410,7 @@
       }
     },
     "TargetGroupArn": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -26403,6 +26421,7 @@
       }
     },
     "TargetGroupArns": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings"

--- a/src/cfnlint/data/CloudSpecs/us-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-2.json
@@ -33074,6 +33074,7 @@
       }
     },
     "AvailabilityZones": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings",
@@ -33129,6 +33130,7 @@
       ]
     },
     "IamInstanceProfile": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -33149,6 +33151,7 @@
       }
     },
     "IamRole": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -33179,6 +33182,7 @@
       }
     },
     "ImageId": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String",
@@ -33187,6 +33191,7 @@
       }
     },
     "KeyPair": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String",
@@ -33205,6 +33210,7 @@
       }
     },
     "KmsKey.Id": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -33247,6 +33253,7 @@
       ]
     },
     "LaunchConfigurationName": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -33257,6 +33264,7 @@
       }
     },
     "LoadBalancerName": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -33267,6 +33275,7 @@
       }
     },
     "LoadBalancerNames": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings"
@@ -33274,6 +33283,7 @@
       }
     },
     "LoadBalancerV2Arn": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -33284,6 +33294,7 @@
       }
     },
     "PlacementGroup": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -33337,6 +33348,7 @@
       ]
     },
     "SecurityGroup": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String",
@@ -33374,6 +33386,7 @@
       }
     },
     "SecurityGroups": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings",
@@ -33385,6 +33398,7 @@
       }
     },
     "SsmDocumentName": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -33395,6 +33409,7 @@
       }
     },
     "String": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -33402,6 +33417,7 @@
       }
     },
     "SubnetId": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String",
@@ -33413,6 +33429,7 @@
       }
     },
     "SubnetIds": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings",
@@ -33421,6 +33438,7 @@
       }
     },
     "TargetGroupArn": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "String"
@@ -33431,6 +33449,7 @@
       }
     },
     "TargetGroupArns": {
+      "GetAtt": {},
       "Ref": {
         "Parameters": [
           "Strings"

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
@@ -32,7 +32,8 @@
             "Strings",
             "AvailabilityZones"
           ]
-        }
+        },
+        "GetAtt": {}
       },
       "DmsEndpointEngineName": {
         "AllowedValues": [
@@ -89,7 +90,8 @@
           "Resources": [
             "AWS::IAM::InstanceProfile"
           ]
-        }
+        },
+        "GetAtt": {}
       },
       "IamInstanceProfile.Arn": {
         "GetAtt": {
@@ -109,7 +111,8 @@
           "Resources": [
             "AWS::IAM::Role"
           ]
-        }
+        },
+        "GetAtt": {}
       },
       "IamRole.Arn": {
         "GetAtt": {
@@ -137,7 +140,8 @@
             "String",
             "ImageId"
           ]
-        }
+        },
+        "GetAtt": {}
       },
       "KeyPair": {
         "Ref": {
@@ -145,7 +149,8 @@
             "String",
             "KeyPair"
           ]
-        }
+        },
+        "GetAtt": {}
       },
       "KmsKey.IdOrArn": {
         "GetAtt": {
@@ -178,7 +183,8 @@
           "Resources": [
             "AWS::KMS::Key"
           ]
-        }
+        },
+        "GetAtt": {}
       },
       "LambdaRuntime": {
         "AllowedValues": [
@@ -207,7 +213,8 @@
           "Resources": [
             "AWS::AutoScaling::LaunchConfiguration"
           ]
-        }
+        },
+        "GetAtt": {}
       },
       "LoadBalancerName": {
         "Ref": {
@@ -217,14 +224,16 @@
           "Resources": [
             "AWS::ElasticLoadBalancing::LoadBalancer"
           ]
-        }
+        },
+        "GetAtt": {}
       },
       "LoadBalancerNames": {
         "Ref": {
           "Parameters": [
             "Strings"
           ]
-        }
+        },
+        "GetAtt": {}
       },
       "LoadBalancerV2Arn": {
         "Ref": {
@@ -234,7 +243,8 @@
           "Resources": [
             "AWS::ElasticLoadBalancingV2::LoadBalancer"
           ]
-        }
+        },
+        "GetAtt": {}
       },
       "PlacementGroup": {
         "Ref": {
@@ -244,7 +254,8 @@
           "Resources": [
             "AWS::EC2::PlacementGroup"
           ]
-        }
+        },
+        "GetAtt": {}
       },
       "PrivateIpAddress": {
         "GetAtt": {
@@ -298,7 +309,8 @@
           "Resources": [
             "AWS::EC2::SecurityGroup"
           ]
-        }
+        },
+        "GetAtt": {}
       },
       "SecurityGroupId": {
         "GetAtt": {
@@ -335,7 +347,8 @@
           "Resources": [
             "AWS::EC2::SecurityGroup"
           ]
-        }
+        },
+        "GetAtt": {}
       },
       "SsmDocumentName": {
         "Ref": {
@@ -345,14 +358,16 @@
           "Resources": [
             "AWS::SSM::Document"
           ]
-        }
+        },
+        "GetAtt": {}
       },
       "String": {
         "Ref": {
           "Parameters": [
             "String"
           ]
-        }
+        },
+        "GetAtt": {}
       },
       "SubnetId": {
         "Ref": {
@@ -363,7 +378,8 @@
           "Resources": [
             "AWS::EC2::Subnet"
           ]
-        }
+        },
+        "GetAtt": {}
       },
       "SubnetIds": {
         "Ref": {
@@ -371,7 +387,8 @@
             "Strings",
             "SubnetIds"
           ]
-        }
+        },
+        "GetAtt": {}
       },
       "TargetGroupArn": {
         "Ref": {
@@ -381,14 +398,16 @@
           "Resources": [
             "AWS::ElasticLoadBalancingV2::TargetGroup"
           ]
-        }
+        },
+        "GetAtt": {}
       },
       "TargetGroupArns": {
         "Ref": {
           "Parameters": [
             "Strings"
           ]
-        }
+        },
+        "GetAtt": {}
       },
       "VpcId": {
         "GetAtt": {

--- a/src/cfnlint/rules/resources/properties/ValueRefGetAtt.py
+++ b/src/cfnlint/rules/resources/properties/ValueRefGetAtt.py
@@ -68,6 +68,8 @@ class ValueRefGetAtt(CloudFormationLintRule):
 
         if not specs:
             # If no Ref's are specified, just skip
+            # Opposite of GetAtt you will always have a Ref to a Parameter so if this is
+            # None it just hasn't been defined and we can skip
             return matches
 
         if value in cfn.template.get('Parameters', {}):
@@ -112,8 +114,8 @@ class ValueRefGetAtt(CloudFormationLintRule):
         """Check GetAtt"""
         matches = []
         cfn = kwargs.get('cfn')
-        value_specs = kwargs.get('value_specs', {}).get('GetAtt', {})
-        list_value_specs = kwargs.get('list_value_specs', {}).get('GetAtt', {})
+        value_specs = kwargs.get('value_specs', {}).get('GetAtt')
+        list_value_specs = kwargs.get('list_value_specs', {}).get('GetAtt')
         property_type = kwargs.get('property_type')
         property_name = kwargs.get('property_name')
         # You can sometimes get a list or a string with . in it
@@ -146,7 +148,11 @@ class ValueRefGetAtt(CloudFormationLintRule):
 
             return matches
 
+        if specs is None:
+            # GetAtt specs aren't specified skip
+            return matches
         if not specs:
+            # GetAtt is specified but empty so there are no valid options
             message = 'Property "{0}" has no valid Fn::GetAtt options at {1}'
             matches.append(RuleMatch(path, message.format(property_name, '/'.join(map(str, path)))))
             return matches

--- a/test/fixtures/templates/bad/resources/properties/value.yaml
+++ b/test/fixtures/templates/bad/resources/properties/value.yaml
@@ -29,7 +29,13 @@ Resources:
       CidrBlock: 10.0.1.0/24
   Instance:
     Type: AWS::EC2::Instance
-    Properties: {}
+    Properties:
+      ImageId: ami-123456
+      KeyName: !GetAtt LoadBalancer.DNSName
+      BlockDeviceMappings:
+      - DeviceName: /dev/sda
+        Ebs:
+          VolumeType: !Ref LoadBalancer
   LoadBalancer:
     Type: AWS::ElasticLoadBalancing::LoadBalancer
     Properties:

--- a/test/rules/resources/properties/test_value_ref_getatt.py
+++ b/test/rules/resources/properties/test_value_ref_getatt.py
@@ -38,4 +38,4 @@ class TestValueRefGetAtt(BaseRuleTestCase):
 
     def test_file_negative_value(self):
         """Test failure"""
-        self.helper_file_negative('test/fixtures/templates/bad/resources/properties/value.yaml', 5)
+        self.helper_file_negative('test/fixtures/templates/bad/resources/properties/value.yaml', 6)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Specify empty GetAtt when a resource doesn't support a GetAtt
- Test for when GetAtt is None and silently continue and error when {}

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
