### PR TITLE
Move VPC Tenancy check to AllowedValues

### DIFF
--- a/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
@@ -22212,7 +22212,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpc.html#cfn-aws-ec2-vpc-instancetenancy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "VpcTenancy"
+          }
         },
         "Tags": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpc.html#cfn-aws-ec2-vpc-tags",
@@ -30839,6 +30842,17 @@
         ],
         "Resources": [
           "AWS::EC2::VPC"
+        ]
+      }
+    },
+    "VpcTenancy": {
+      "AllowedValues": [
+        "dedicated",
+        "default"
+      ],
+      "Ref": {
+        "Parameters": [
+          "String"
         ]
       }
     }

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
@@ -20325,7 +20325,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpc.html#cfn-aws-ec2-vpc-instancetenancy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "VpcTenancy"
+          }
         },
         "Tags": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpc.html#cfn-aws-ec2-vpc-tags",
@@ -28314,6 +28317,17 @@
         ],
         "Resources": [
           "AWS::EC2::VPC"
+        ]
+      }
+    },
+    "VpcTenancy": {
+      "AllowedValues": [
+        "dedicated",
+        "default"
+      ],
+      "Ref": {
+        "Parameters": [
+          "String"
         ]
       }
     }

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
@@ -14545,7 +14545,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpc.html#cfn-aws-ec2-vpc-instancetenancy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "VpcTenancy"
+          }
         },
         "Tags": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpc.html#cfn-aws-ec2-vpc-tags",
@@ -20758,6 +20761,17 @@
         ],
         "Resources": [
           "AWS::EC2::VPC"
+        ]
+      }
+    },
+    "VpcTenancy": {
+      "AllowedValues": [
+        "dedicated",
+        "default"
+      ],
+      "Ref": {
+        "Parameters": [
+          "String"
         ]
       }
     }

--- a/src/cfnlint/data/CloudSpecs/ap-south-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-south-1.json
@@ -19231,7 +19231,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpc.html#cfn-aws-ec2-vpc-instancetenancy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "VpcTenancy"
+          }
         },
         "Tags": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpc.html#cfn-aws-ec2-vpc-tags",
@@ -27220,6 +27223,17 @@
         ],
         "Resources": [
           "AWS::EC2::VPC"
+        ]
+      }
+    },
+    "VpcTenancy": {
+      "AllowedValues": [
+        "dedicated",
+        "default"
+      ],
+      "Ref": {
+        "Parameters": [
+          "String"
         ]
       }
     }

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
@@ -20551,7 +20551,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpc.html#cfn-aws-ec2-vpc-instancetenancy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "VpcTenancy"
+          }
         },
         "Tags": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpc.html#cfn-aws-ec2-vpc-tags",
@@ -28588,6 +28591,17 @@
         ],
         "Resources": [
           "AWS::EC2::VPC"
+        ]
+      }
+    },
+    "VpcTenancy": {
+      "AllowedValues": [
+        "dedicated",
+        "default"
+      ],
+      "Ref": {
+        "Parameters": [
+          "String"
         ]
       }
     }

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
@@ -21150,7 +21150,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpc.html#cfn-aws-ec2-vpc-instancetenancy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "VpcTenancy"
+          }
         },
         "Tags": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpc.html#cfn-aws-ec2-vpc-tags",
@@ -29150,6 +29153,17 @@
         ],
         "Resources": [
           "AWS::EC2::VPC"
+        ]
+      }
+    },
+    "VpcTenancy": {
+      "AllowedValues": [
+        "dedicated",
+        "default"
+      ],
+      "Ref": {
+        "Parameters": [
+          "String"
         ]
       }
     }

--- a/src/cfnlint/data/CloudSpecs/ca-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/ca-central-1.json
@@ -18066,7 +18066,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpc.html#cfn-aws-ec2-vpc-instancetenancy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "VpcTenancy"
+          }
         },
         "Tags": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpc.html#cfn-aws-ec2-vpc-tags",
@@ -25589,6 +25592,17 @@
         ],
         "Resources": [
           "AWS::EC2::VPC"
+        ]
+      }
+    },
+    "VpcTenancy": {
+      "AllowedValues": [
+        "dedicated",
+        "default"
+      ],
+      "Ref": {
+        "Parameters": [
+          "String"
         ]
       }
     }

--- a/src/cfnlint/data/CloudSpecs/eu-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-central-1.json
@@ -21575,7 +21575,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpc.html#cfn-aws-ec2-vpc-instancetenancy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "VpcTenancy"
+          }
         },
         "Tags": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpc.html#cfn-aws-ec2-vpc-tags",
@@ -29995,6 +29998,17 @@
         ],
         "Resources": [
           "AWS::EC2::VPC"
+        ]
+      }
+    },
+    "VpcTenancy": {
+      "AllowedValues": [
+        "dedicated",
+        "default"
+      ],
+      "Ref": {
+        "Parameters": [
+          "String"
         ]
       }
     }

--- a/src/cfnlint/data/CloudSpecs/eu-north-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-north-1.json
@@ -14810,7 +14810,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpc.html#cfn-aws-ec2-vpc-instancetenancy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "VpcTenancy"
+          }
         },
         "Tags": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpc.html#cfn-aws-ec2-vpc-tags",
@@ -21101,6 +21104,17 @@
         ],
         "Resources": [
           "AWS::EC2::VPC"
+        ]
+      }
+    },
+    "VpcTenancy": {
+      "AllowedValues": [
+        "dedicated",
+        "default"
+      ],
+      "Ref": {
+        "Parameters": [
+          "String"
         ]
       }
     }

--- a/src/cfnlint/data/CloudSpecs/eu-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-1.json
@@ -24062,7 +24062,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpc.html#cfn-aws-ec2-vpc-instancetenancy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "VpcTenancy"
+          }
         },
         "Tags": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpc.html#cfn-aws-ec2-vpc-tags",
@@ -33216,6 +33219,17 @@
         ],
         "Resources": [
           "AWS::EC2::VPC"
+        ]
+      }
+    },
+    "VpcTenancy": {
+      "AllowedValues": [
+        "dedicated",
+        "default"
+      ],
+      "Ref": {
+        "Parameters": [
+          "String"
         ]
       }
     }

--- a/src/cfnlint/data/CloudSpecs/eu-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-2.json
@@ -18982,7 +18982,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpc.html#cfn-aws-ec2-vpc-instancetenancy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "VpcTenancy"
+          }
         },
         "Tags": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpc.html#cfn-aws-ec2-vpc-tags",
@@ -26890,6 +26893,17 @@
         ],
         "Resources": [
           "AWS::EC2::VPC"
+        ]
+      }
+    },
+    "VpcTenancy": {
+      "AllowedValues": [
+        "dedicated",
+        "default"
+      ],
+      "Ref": {
+        "Parameters": [
+          "String"
         ]
       }
     }

--- a/src/cfnlint/data/CloudSpecs/eu-west-3.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-3.json
@@ -17057,7 +17057,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpc.html#cfn-aws-ec2-vpc-instancetenancy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "VpcTenancy"
+          }
         },
         "Tags": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpc.html#cfn-aws-ec2-vpc-tags",
@@ -24299,6 +24302,17 @@
         ],
         "Resources": [
           "AWS::EC2::VPC"
+        ]
+      }
+    },
+    "VpcTenancy": {
+      "AllowedValues": [
+        "dedicated",
+        "default"
+      ],
+      "Ref": {
+        "Parameters": [
+          "String"
         ]
       }
     }

--- a/src/cfnlint/data/CloudSpecs/sa-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/sa-east-1.json
@@ -17825,7 +17825,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpc.html#cfn-aws-ec2-vpc-instancetenancy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "VpcTenancy"
+          }
         },
         "Tags": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpc.html#cfn-aws-ec2-vpc-tags",
@@ -25202,6 +25205,17 @@
         ],
         "Resources": [
           "AWS::EC2::VPC"
+        ]
+      }
+    },
+    "VpcTenancy": {
+      "AllowedValues": [
+        "dedicated",
+        "default"
+      ],
+      "Ref": {
+        "Parameters": [
+          "String"
         ]
       }
     }

--- a/src/cfnlint/data/CloudSpecs/us-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-1.json
@@ -24063,7 +24063,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpc.html#cfn-aws-ec2-vpc-instancetenancy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "VpcTenancy"
+          }
         },
         "Tags": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpc.html#cfn-aws-ec2-vpc-tags",
@@ -33245,6 +33248,17 @@
         ],
         "Resources": [
           "AWS::EC2::VPC"
+        ]
+      }
+    },
+    "VpcTenancy": {
+      "AllowedValues": [
+        "dedicated",
+        "default"
+      ],
+      "Ref": {
+        "Parameters": [
+          "String"
         ]
       }
     }

--- a/src/cfnlint/data/CloudSpecs/us-east-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-2.json
@@ -22363,7 +22363,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpc.html#cfn-aws-ec2-vpc-instancetenancy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "VpcTenancy"
+          }
         },
         "Tags": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpc.html#cfn-aws-ec2-vpc-tags",
@@ -31254,6 +31257,17 @@
         ],
         "Resources": [
           "AWS::EC2::VPC"
+        ]
+      }
+    },
+    "VpcTenancy": {
+      "AllowedValues": [
+        "dedicated",
+        "default"
+      ],
+      "Ref": {
+        "Parameters": [
+          "String"
         ]
       }
     }

--- a/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
@@ -14292,7 +14292,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpc.html#cfn-aws-ec2-vpc-instancetenancy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "VpcTenancy"
+          }
         },
         "Tags": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpc.html#cfn-aws-ec2-vpc-tags",
@@ -20533,6 +20536,17 @@
         ],
         "Resources": [
           "AWS::EC2::VPC"
+        ]
+      }
+    },
+    "VpcTenancy": {
+      "AllowedValues": [
+        "dedicated",
+        "default"
+      ],
+      "Ref": {
+        "Parameters": [
+          "String"
         ]
       }
     }

--- a/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
@@ -14339,7 +14339,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpc.html#cfn-aws-ec2-vpc-instancetenancy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "VpcTenancy"
+          }
         },
         "Tags": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpc.html#cfn-aws-ec2-vpc-tags",
@@ -20691,6 +20694,17 @@
         ],
         "Resources": [
           "AWS::EC2::VPC"
+        ]
+      }
+    },
+    "VpcTenancy": {
+      "AllowedValues": [
+        "dedicated",
+        "default"
+      ],
+      "Ref": {
+        "Parameters": [
+          "String"
         ]
       }
     }

--- a/src/cfnlint/data/CloudSpecs/us-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-1.json
@@ -18595,7 +18595,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpc.html#cfn-aws-ec2-vpc-instancetenancy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "VpcTenancy"
+          }
         },
         "Tags": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpc.html#cfn-aws-ec2-vpc-tags",
@@ -26253,6 +26256,17 @@
         ],
         "Resources": [
           "AWS::EC2::VPC"
+        ]
+      }
+    },
+    "VpcTenancy": {
+      "AllowedValues": [
+        "dedicated",
+        "default"
+      ],
+      "Ref": {
+        "Parameters": [
+          "String"
         ]
       }
     }

--- a/src/cfnlint/data/CloudSpecs/us-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-2.json
@@ -24081,7 +24081,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpc.html#cfn-aws-ec2-vpc-instancetenancy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "VpcTenancy"
+          }
         },
         "Tags": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpc.html#cfn-aws-ec2-vpc-tags",
@@ -33275,6 +33278,17 @@
         ],
         "Resources": [
           "AWS::EC2::VPC"
+        ]
+      }
+    },
+    "VpcTenancy": {
+      "AllowedValues": [
+        "dedicated",
+        "default"
+      ],
+      "Ref": {
+        "Parameters": [
+          "String"
         ]
       }
     }

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
@@ -349,6 +349,17 @@
             "AWS::EC2::VPC"
           ]
         }
+      },
+      "VpcTenancy": {
+        "Ref": {
+          "Parameters": [
+            "String"
+          ]
+        },
+        "AllowedValues": [
+          "dedicated",
+          "default"
+        ]
       }
     }
   }

--- a/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
@@ -288,6 +288,13 @@
   },
   {
     "op": "add",
+    "path": "/ResourceTypes/AWS::EC2::VPC/Properties/InstanceTenancy/Value",
+    "value": {
+      "ValueType": "VpcTenancy"
+    }
+  },
+  {
+    "op": "add",
     "path": "/ResourceTypes/AWS::ECS::Service/Properties/Role/Value",
     "value": {
       "ValueType": "IamRole.Arn"

--- a/src/cfnlint/rules/resources/ectwo/Vpc.py
+++ b/src/cfnlint/rules/resources/ectwo/Vpc.py
@@ -18,8 +18,7 @@ import re
 from cfnlint import CloudFormationLintRule
 from cfnlint import RuleMatch
 
-from cfnlint.helpers import REGEX_CIDR
-
+import cfnlint.helpers
 
 class Vpc(CloudFormationLintRule):
     """Check if EC2 VPC Resource Properties"""
@@ -30,44 +29,11 @@ class Vpc(CloudFormationLintRule):
     source_url = 'https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpc.html'
     tags = ['properties', 'vpc']
 
-    def check_vpc_value(self, value, path):
-        """Check VPC Values"""
-        matches = []
-
-        if value not in ('default', 'dedicated'):
-            message = 'DefaultTenancy needs to be default or dedicated for {0}'
-            matches.append(RuleMatch(path, message.format(('/'.join(map(str, path))))))
-        return matches
-
-    def check_vpc_ref(self, value, path, parameters, resources):
-        """Check ref for VPC"""
-        matches = []
-        allowed_types = [
-            'String',
-            'AWS::SSM::Parameter::Value<String>',
-        ]
-        if value in resources:
-            message = 'DefaultTenancy can\'t use a Ref to a resource for {0}'
-            matches.append(RuleMatch(path, message.format(('/'.join(map(str, path))))))
-        elif value in parameters:
-            parameter = parameters.get(value, {})
-            parameter_type = parameter.get('Type', None)
-            if parameter_type not in allowed_types:
-                path_error = ['Parameters', value, 'Type']
-                message = 'DefaultTenancy parameter should be of type [{0}] for {1}'
-                matches.append(
-                    RuleMatch(
-                        path_error,
-                        message.format(
-                            ', '.join(map(str, allowed_types)),
-                            '/'.join(map(str, path_error)))))
-        return matches
-
     def check_cidr_value(self, value, path):
         """Check CIDR Strings"""
         matches = []
 
-        if not re.match(REGEX_CIDR, value):
+        if not re.match(cfnlint.helpers.REGEX_CIDR, value):
             message = 'CidrBlock needs to be of x.x.x.x/y at {0}'
             matches.append(RuleMatch(path, message.format(('/'.join(['Parameters', value])))))
         return matches
@@ -84,7 +50,7 @@ class Vpc(CloudFormationLintRule):
             resource_obj = resources.get(value, {})
             if resource_obj:
                 resource_type = resource_obj.get('Type', '')
-                if not resource_type.startswith('Custom::'):
+                if not cfnlint.helpers.is_custom_resource(resource_type):
                     message = 'CidrBlock needs to be a valid Cidr Range at {0}'
                     matches.append(RuleMatch(path, message.format(('/'.join(['Parameters', value])))))
         if value in parameters:
@@ -105,13 +71,6 @@ class Vpc(CloudFormationLintRule):
         """Check EC2 VPC Resource Parameters"""
 
         matches = []
-        matches.extend(
-            cfn.check_resource_property(
-                'AWS::EC2::VPC', 'InstanceTenancy',
-                check_value=self.check_vpc_value,
-                check_ref=self.check_vpc_ref,
-            )
-        )
         matches.extend(
             cfn.check_resource_property(
                 'AWS::EC2::VPC', 'CidrBlock',

--- a/test/fixtures/templates/bad/properties_ec2_network.yaml
+++ b/test/fixtures/templates/bad/properties_ec2_network.yaml
@@ -14,7 +14,7 @@ Parameters:
   vpcTenancy:
     Type: String
     AllowedValues:
-      - default
+      - default2
       - dedicated
   myAz:
     Type: Number
@@ -27,7 +27,7 @@ Resources:
   myVpc2:
     Type: AWS::EC2::VPC
     Properties:
-      InstanceTenancy: !Ref vpcTenancy
+      InstanceTenancy: !Ref myVpc1
       CidrBlock: 10.0.0.3
   myVpc3:
     Type: AWS::EC2::VPC

--- a/test/rules/resources/ec2/test_ec2_vpc.py
+++ b/test/rules/resources/ec2/test_ec2_vpc.py
@@ -34,4 +34,4 @@ class TestPropertyEc2Vpc(BaseRuleTestCase):
 
     def test_file_negative(self):
         """Test failure"""
-        self.helper_file_negative('test/fixtures/templates/bad/properties_ec2_network.yaml', 3)
+        self.helper_file_negative('test/fixtures/templates/bad/properties_ec2_network.yaml', 2)

--- a/test/rules/resources/properties/test_allowed_value.py
+++ b/test/rules/resources/properties/test_allowed_value.py
@@ -43,3 +43,7 @@ class TestAllowedValue(BaseRuleTestCase):
     def test_file_negative_ebsvolume(self):
         """Test failure"""
         self.helper_file_negative('test/fixtures/templates/bad/properties_ebs.yaml', 1)
+
+    def test_file_negative_vpctenancy(self):
+        """Test failure"""
+        self.helper_file_negative('test/fixtures/templates/bad/properties_ec2_network.yaml', 2)


### PR DESCRIPTION
*Issue https://github.com/awslabs/cfn-python-lint/issues/50, if available:*

Moved over the VPC Tenancy value check to the generic Allowed Values setup. Along the way:

- Corrected/improved Custom Resource check
- Moved the Ref check into the `ValueRefGetAtt` (`E3008`) rule
- Added move test values in the "bad" template

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
