### PR TITLE
Improve Allowed Values test and add values

### DIFF
--- a/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
@@ -10392,7 +10392,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-connection-connectioninput.html#cfn-glue-connection-connectioninput-connectiontype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "GlueConnectionInputType"
+          }
         },
         "Description": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-connection-connectioninput.html#cfn-glue-connection-connectioninput-description",
@@ -30536,6 +30539,12 @@
         "sc1",
         "st1",
         "standard"
+      ]
+    },
+    "GlueConnectionInputType": {
+      "AllowedValues": [
+        "JDBC",
+        "SFTP"
       ]
     },
     "IamInstanceProfile": {

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
@@ -10082,7 +10082,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-connection-connectioninput.html#cfn-glue-connection-connectioninput-connectiontype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "GlueConnectionInputType"
+          }
         },
         "Description": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-connection-connectioninput.html#cfn-glue-connection-connectioninput-description",
@@ -28011,6 +28014,12 @@
         "sc1",
         "st1",
         "standard"
+      ]
+    },
+    "GlueConnectionInputType": {
+      "AllowedValues": [
+        "JDBC",
+        "SFTP"
       ]
     },
     "IamInstanceProfile": {

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
@@ -20457,6 +20457,12 @@
         "standard"
       ]
     },
+    "GlueConnectionInputType": {
+      "AllowedValues": [
+        "JDBC",
+        "SFTP"
+      ]
+    },
     "IamInstanceProfile": {
       "Ref": {
         "Parameters": [

--- a/src/cfnlint/data/CloudSpecs/ap-south-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-south-1.json
@@ -9556,7 +9556,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-connection-connectioninput.html#cfn-glue-connection-connectioninput-connectiontype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "GlueConnectionInputType"
+          }
         },
         "Description": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-connection-connectioninput.html#cfn-glue-connection-connectioninput-description",
@@ -26917,6 +26920,12 @@
         "sc1",
         "st1",
         "standard"
+      ]
+    },
+    "GlueConnectionInputType": {
+      "AllowedValues": [
+        "JDBC",
+        "SFTP"
       ]
     },
     "IamInstanceProfile": {

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
@@ -10180,7 +10180,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-connection-connectioninput.html#cfn-glue-connection-connectioninput-connectiontype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "GlueConnectionInputType"
+          }
         },
         "Description": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-connection-connectioninput.html#cfn-glue-connection-connectioninput-description",
@@ -28285,6 +28288,12 @@
         "sc1",
         "st1",
         "standard"
+      ]
+    },
+    "GlueConnectionInputType": {
+      "AllowedValues": [
+        "JDBC",
+        "SFTP"
       ]
     },
     "IamInstanceProfile": {

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
@@ -10381,7 +10381,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-connection-connectioninput.html#cfn-glue-connection-connectioninput-connectiontype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "GlueConnectionInputType"
+          }
         },
         "Description": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-connection-connectioninput.html#cfn-glue-connection-connectioninput-description",
@@ -28847,6 +28850,12 @@
         "sc1",
         "st1",
         "standard"
+      ]
+    },
+    "GlueConnectionInputType": {
+      "AllowedValues": [
+        "JDBC",
+        "SFTP"
       ]
     },
     "IamInstanceProfile": {

--- a/src/cfnlint/data/CloudSpecs/ca-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/ca-central-1.json
@@ -25288,6 +25288,12 @@
         "standard"
       ]
     },
+    "GlueConnectionInputType": {
+      "AllowedValues": [
+        "JDBC",
+        "SFTP"
+      ]
+    },
     "IamInstanceProfile": {
       "Ref": {
         "Parameters": [

--- a/src/cfnlint/data/CloudSpecs/eu-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-central-1.json
@@ -10306,7 +10306,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-connection-connectioninput.html#cfn-glue-connection-connectioninput-connectiontype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "GlueConnectionInputType"
+          }
         },
         "Description": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-connection-connectioninput.html#cfn-glue-connection-connectioninput-description",
@@ -29692,6 +29695,12 @@
         "sc1",
         "st1",
         "standard"
+      ]
+    },
+    "GlueConnectionInputType": {
+      "AllowedValues": [
+        "JDBC",
+        "SFTP"
       ]
     },
     "IamInstanceProfile": {

--- a/src/cfnlint/data/CloudSpecs/eu-north-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-north-1.json
@@ -20800,6 +20800,12 @@
         "standard"
       ]
     },
+    "GlueConnectionInputType": {
+      "AllowedValues": [
+        "JDBC",
+        "SFTP"
+      ]
+    },
     "IamInstanceProfile": {
       "Ref": {
         "Parameters": [

--- a/src/cfnlint/data/CloudSpecs/eu-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-1.json
@@ -11046,7 +11046,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-connection-connectioninput.html#cfn-glue-connection-connectioninput-connectiontype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "GlueConnectionInputType"
+          }
         },
         "Description": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-connection-connectioninput.html#cfn-glue-connection-connectioninput-description",
@@ -32913,6 +32916,12 @@
         "sc1",
         "st1",
         "standard"
+      ]
+    },
+    "GlueConnectionInputType": {
+      "AllowedValues": [
+        "JDBC",
+        "SFTP"
       ]
     },
     "IamInstanceProfile": {

--- a/src/cfnlint/data/CloudSpecs/eu-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-2.json
@@ -26589,6 +26589,12 @@
         "standard"
       ]
     },
+    "GlueConnectionInputType": {
+      "AllowedValues": [
+        "JDBC",
+        "SFTP"
+      ]
+    },
     "IamInstanceProfile": {
       "Ref": {
         "Parameters": [

--- a/src/cfnlint/data/CloudSpecs/eu-west-3.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-3.json
@@ -23998,6 +23998,12 @@
         "standard"
       ]
     },
+    "GlueConnectionInputType": {
+      "AllowedValues": [
+        "JDBC",
+        "SFTP"
+      ]
+    },
     "IamInstanceProfile": {
       "Ref": {
         "Parameters": [

--- a/src/cfnlint/data/CloudSpecs/sa-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/sa-east-1.json
@@ -24901,6 +24901,12 @@
         "standard"
       ]
     },
+    "GlueConnectionInputType": {
+      "AllowedValues": [
+        "JDBC",
+        "SFTP"
+      ]
+    },
     "IamInstanceProfile": {
       "Ref": {
         "Parameters": [

--- a/src/cfnlint/data/CloudSpecs/us-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-1.json
@@ -11065,7 +11065,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-connection-connectioninput.html#cfn-glue-connection-connectioninput-connectiontype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "GlueConnectionInputType"
+          }
         },
         "Description": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-connection-connectioninput.html#cfn-glue-connection-connectioninput-description",
@@ -32942,6 +32945,12 @@
         "sc1",
         "st1",
         "standard"
+      ]
+    },
+    "GlueConnectionInputType": {
+      "AllowedValues": [
+        "JDBC",
+        "SFTP"
       ]
     },
     "IamInstanceProfile": {

--- a/src/cfnlint/data/CloudSpecs/us-east-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-2.json
@@ -10573,7 +10573,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-connection-connectioninput.html#cfn-glue-connection-connectioninput-connectiontype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "GlueConnectionInputType"
+          }
         },
         "Description": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-connection-connectioninput.html#cfn-glue-connection-connectioninput-description",
@@ -30951,6 +30954,12 @@
         "sc1",
         "st1",
         "standard"
+      ]
+    },
+    "GlueConnectionInputType": {
+      "AllowedValues": [
+        "JDBC",
+        "SFTP"
       ]
     },
     "IamInstanceProfile": {

--- a/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
@@ -20232,6 +20232,12 @@
         "standard"
       ]
     },
+    "GlueConnectionInputType": {
+      "AllowedValues": [
+        "JDBC",
+        "SFTP"
+      ]
+    },
     "IamInstanceProfile": {
       "Ref": {
         "Parameters": [

--- a/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
@@ -20390,6 +20390,12 @@
         "standard"
       ]
     },
+    "GlueConnectionInputType": {
+      "AllowedValues": [
+        "JDBC",
+        "SFTP"
+      ]
+    },
     "IamInstanceProfile": {
       "Ref": {
         "Parameters": [

--- a/src/cfnlint/data/CloudSpecs/us-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-1.json
@@ -25952,6 +25952,12 @@
         "standard"
       ]
     },
+    "GlueConnectionInputType": {
+      "AllowedValues": [
+        "JDBC",
+        "SFTP"
+      ]
+    },
     "IamInstanceProfile": {
       "Ref": {
         "Parameters": [

--- a/src/cfnlint/data/CloudSpecs/us-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-2.json
@@ -11065,7 +11065,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-connection-connectioninput.html#cfn-glue-connection-connectioninput-connectiontype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "GlueConnectionInputType"
+          }
         },
         "Description": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-connection-connectioninput.html#cfn-glue-connection-connectioninput-description",
@@ -32972,6 +32975,12 @@
         "sc1",
         "st1",
         "standard"
+      ]
+    },
+    "GlueConnectionInputType": {
+      "AllowedValues": [
+        "JDBC",
+        "SFTP"
       ]
     },
     "IamInstanceProfile": {

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
@@ -43,6 +43,12 @@
           "standard"
         ]
       },
+      "GlueConnectionInputType": {
+        "AllowedValues": [
+          "JDBC",
+          "SFTP"
+        ]
+      },
       "IamInstanceProfile": {
         "Ref": {
           "Parameters": [

--- a/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
@@ -29,6 +29,13 @@
   },
   {
     "op": "add",
+    "path": "/PropertyTypes/AWS::Glue::Connection.ConnectionInput/Properties/ConnectionType/Value",
+    "value": {
+      "ValueType": "GlueConnectionInputType"
+    }
+  },
+  {
+    "op": "add",
     "path": "/PropertyTypes/AWS::OpsWorks::Layer.VolumeConfiguration/Properties/VolumeType/Value",
     "value": {
       "ValueType": "EbsVolumeType"

--- a/src/cfnlint/rules/resources/route53/RecordSet.py
+++ b/src/cfnlint/rules/resources/route53/RecordSet.py
@@ -156,8 +156,12 @@ class RecordSet(CloudFormationLintRule):
         # Skip Intrinsic functions
         if not isinstance(recordset_type, dict):
             if not recordset.get('AliasTarget'):
+                # If no Alias is specified, ResourceRecords has to be specified
+                if not recordset.get('ResourceRecords'):
+                    message = 'Property ResourceRecords missing at {}'
+                    matches.append(RuleMatch(path, message.format('/'.join(map(str, path)))))
                 # Record type specific checks
-                if recordset_type == 'A':
+                elif recordset_type == 'A':
                     matches.extend(self.check_a_record(path, recordset))
                 elif recordset_type == 'AAAA':
                     matches.extend(self.check_aaaa_record(path, recordset))

--- a/test/fixtures/templates/bad/resources/properties/allowed_values.yaml
+++ b/test/fixtures/templates/bad/resources/properties/allowed_values.yaml
@@ -1,0 +1,37 @@
+---
+AWSTemplateFormatVersion: '2010-09-09'
+Description: >
+  Template with all the resources that are covered by the AllowedValues.
+  Minimal configuration for each resource to be "valid", apart from the properties
+  that are part of the AllowedValues check.
+Resources:
+  GlueConnection:
+    Type: "AWS::Glue::Connection"
+    Properties:
+      CatalogId: !Ref "AWS::AccountId"
+      ConnectionInput:
+        ConnectionProperties: "{}"
+        ConnectionType: "FTP" # Invalid AllowedValue
+  RecordSet:
+    Type: "AWS::Route53::RecordSet"
+    Properties:
+      Name: "www.example.com"
+      Type: "X" # AllowedValue
+      ResourceRecords:
+        - ''
+  EC2Instance:
+    Type: "AWS::EC2::Instance"
+    Properties:
+      ImageId: "ami-2f726546"
+      InstanceType: t1.micro
+      KeyName: ""
+      BlockDeviceMappings:
+        -
+          DeviceName: /dev/sdm
+          Ebs:
+            VolumeType: "magnetic" # Invalid AllowedValue
+  Vpc:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: "10.0.0.0/8"
+      InstanceTenancy: "Default" # Invalid AllowedValue

--- a/test/fixtures/templates/good/resources/properties/allowed_values.yaml
+++ b/test/fixtures/templates/good/resources/properties/allowed_values.yaml
@@ -1,0 +1,37 @@
+---
+AWSTemplateFormatVersion: '2010-09-09'
+Description: >
+  Template with all the resources that are covered by the AllowedValues.
+  Minimal configuration for each resource to be "valid". Properties that are part
+  of the AllowedValues check are marked for transparancy
+Resources:
+  EC2Instance:
+    Type: "AWS::EC2::Instance"
+    Properties:
+      ImageId: "ami-2f726546"
+      InstanceType: t1.micro
+      KeyName: ""
+      BlockDeviceMappings:
+        -
+          DeviceName: /dev/sdm
+          Ebs:
+            VolumeType: "gp2" # Valid AllowedValue
+  GlueConnection:
+    Type: "AWS::Glue::Connection"
+    Properties:
+      CatalogId: !Ref "AWS::AccountId"
+      ConnectionInput:
+        ConnectionProperties: "{}"
+        ConnectionType: "SFTP" # Valid AllowedValue
+  RecordSet:
+    Type: "AWS::Route53::RecordSet"
+    Properties:
+      Name: "www.example.com"
+      Type: "A" # Valid AllowedValue
+      ResourceRecords:
+        - '127.0.0.1'
+  Vpc:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: "10.0.0.0/8"
+      InstanceTenancy: "default" # Valid AllowedValue

--- a/test/rules/resources/properties/test_allowed_value.py
+++ b/test/rules/resources/properties/test_allowed_value.py
@@ -25,25 +25,13 @@ class TestAllowedValue(BaseRuleTestCase):
         super(TestAllowedValue, self).setUp()
         self.collection.register(AllowedValue())
         self.success_templates = [
-            'test/fixtures/templates/good/resources_lambda.yaml'
+            'test/fixtures/templates/good/resources/properties/allowed_values.yaml'
         ]
 
     def test_file_positive(self):
         """Test Positive"""
         self.helper_file_positive()
 
-    def test_file_negative_runtime(self):
+    def test_file_negative(self):
         """Test failure"""
-        self.helper_file_negative('test/fixtures/templates/bad/resources_lambda.yaml', 3)
-
-    def test_file_negative_recordset(self):
-        """Test failure"""
-        self.helper_file_negative('test/fixtures/templates/bad/route53.yaml', 1)
-
-    def test_file_negative_ebsvolume(self):
-        """Test failure"""
-        self.helper_file_negative('test/fixtures/templates/bad/properties_ebs.yaml', 1)
-
-    def test_file_negative_vpctenancy(self):
-        """Test failure"""
-        self.helper_file_negative('test/fixtures/templates/bad/properties_ec2_network.yaml', 2)
+        self.helper_file_negative('test/fixtures/templates/bad/resources/properties/allowed_values.yaml', 4)


### PR DESCRIPTION
*Issue https://github.com/awslabs/cfn-python-lint/issues/50, if available:*

Tweaks and improvements on the Allowed Values:

- Added [GlueConnection Connection Input type](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-connection-connectioninput.html#cfn-glue-connection-connectioninput-connectiontype)
- Create separate, specific fixtures for the allowed Values. Every Allowed Value now a correct and incorrect test data
- Made a hotfix in the RecordSet rule along the way. It broke if no `RecourceRecords` are specified (allowed if an Alias is specifie), discovered this while building the (minimal) test fixtures

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
