### PR TITLE
Support recursive searching in Python 3.5 and higher

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ Lint all `yaml` files in `path`:
 Lint all `yaml` files in `path` and all subdirectories (recursive):
 - `cfn-lint path/to/templates/**/*.yaml`
 
+*Note*: Glob in Python 3.5 supports recursive searching `**/*.yaml`.  If you are using an earlier version of Python you will have to handle this manually (`folder1/*.yaml`, `folder2/*.yaml`, etc).
+
 ##### Specifying the template as an input stream
 The template to be linted can also be passed using standard input:
 

--- a/src/cfnlint/config.py
+++ b/src/cfnlint/config.py
@@ -436,7 +436,11 @@ class ConfigMixIn(TemplateArgs, CliArgs, ConfigFileArgs, object):
         # some shells don't expand * and configparser won't expand wildcards
         all_filenames = []
         for filename in filenames:
-            add_filenames = glob.glob(filename)
+            if sys.version_info >= (3, 5):
+                # pylint: disable=E1123
+                add_filenames = glob.glob(filename, recursive=True)
+            else:
+                add_filenames = glob.glob(filename)
             # only way to know of the glob failed is to test it
             # then add the filename as requested
             if not add_filenames:


### PR DESCRIPTION
*Issue #, if available:*
Fix #546 for python 3.5 and higher
*Description of changes:*
- Support recursive searching for files in Python 3.5 and higher

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
