### PR TITLE
Add basic linting on Route53 MX records

### DIFF
--- a/test/fixtures/templates/bad/route53.yaml
+++ b/test/fixtures/templates/bad/route53.yaml
@@ -71,6 +71,16 @@ Resources:
       ResourceRecords: # Multiple records
         - "cname1.example.com"
         - "cname2.example.com"
+  MyMXRecordSet:
+    Type: "AWS::Route53::RecordSet"
+    Properties:
+      HostedZoneId: !Ref "MyHostedZone"
+      Name: "example.com."
+      Type: "MX"
+      TTL: "300"
+      ResourceRecords:
+        - "127.0.0.1"
+        - "10 my domain"
   MyRecordSetGroup:
     Type: "AWS::Route53::RecordSetGroup"
     Properties:
@@ -117,6 +127,12 @@ Resources:
           TTL: "300"
           ResourceRecords:
             - "No valid domain name" # No valid domain name
+        - Name: "example.com."
+          Type: "MX"
+          TTL: "300"
+          ResourceRecords:
+            - "mx1.example.com"
+            - "65536 mx2.example.com"
   MySecondRecordSetGroup:
     Type: "AWS::Route53::RecordSetGroup"
     Properties:

--- a/test/fixtures/templates/good/route53.yaml
+++ b/test/fixtures/templates/good/route53.yaml
@@ -91,6 +91,16 @@ Resources:
       TTL: "300"
       ResourceRecords:
         - !Sub "www.${DomainName}"
+  MyMXRecordSet:
+    Type: "AWS::Route53::RecordSet"
+    Properties:
+      HostedZoneId: !Ref "MyHostedZone"
+      Name: "example.com."
+      Type: "MX"
+      TTL: "300"
+      ResourceRecords:
+        - "10 mx1.example.com"
+        - "10 mx1.example.com"
   MyRecordSetGroup:
     Type: "AWS::Route53::RecordSetGroup"
     Properties:
@@ -124,3 +134,9 @@ Resources:
           TTL: "300"
           ResourceRecords:
             - "\"MS=ms123123123\""
+        - Name: "example.com."
+          Type: "MX"
+          TTL: "300"
+          ResourceRecords:
+            - "0 mx.example.com"
+            - "65535 mx2.example.com"

--- a/test/rules/resources/route53/test_recordsets.py
+++ b/test/rules/resources/route53/test_recordsets.py
@@ -34,4 +34,4 @@ class TestRoute53RecordSets(BaseRuleTestCase):
 
     def test_file_negative(self):
         """Test failure"""
-        self.helper_file_negative('test/fixtures/templates/bad/route53.yaml', 24)
+        self.helper_file_negative('test/fixtures/templates/bad/route53.yaml', 28)


### PR DESCRIPTION
*Issue https://github.com/awslabs/cfn-python-lint/issues/94, if available:*

Added check to MX records


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
