### PR TITLE
Add AutoScaling Allowed Values

### DIFF
--- a/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
@@ -1368,7 +1368,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-customizedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-customizedmetricspecification-statistic",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingPolicyCustomizedMetricSpecificationStatistic"
+          }
         },
         "Unit": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-customizedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-customizedmetricspecification-unit",
@@ -1402,7 +1405,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-predefinedmetricspecification-predefinedmetrictype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ApplicationAutoScalingPredefinedMetricSpecificationType"
+          }
         },
         "ResourceLabel": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-predefinedmetricspecification-resourcelabel",
@@ -1614,7 +1620,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-lifecyclehookspecification.html#cfn-autoscaling-autoscalinggroup-lifecyclehookspecification-defaultresult",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingLifecycleHookResult"
+          }
         },
         "HeartbeatTimeout": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-lifecyclehookspecification.html#cfn-autoscaling-autoscalinggroup-lifecyclehookspecification-heartbeattimeout",
@@ -1632,7 +1641,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-lifecyclehookspecification.html#cfn-autoscaling-autoscalinggroup-lifecyclehookspecification-lifecycletransition",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingLifecycleTransition"
+          }
         },
         "NotificationMetadata": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-lifecyclehookspecification.html#cfn-autoscaling-autoscalinggroup-lifecyclehookspecification-notificationmetadata",
@@ -1832,7 +1844,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-customizedmetricspecification.html#cfn-autoscaling-scalingpolicy-customizedmetricspecification-statistic",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingPolicyCustomizedMetricSpecificationStatistic"
+          }
         },
         "Unit": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-customizedmetricspecification.html#cfn-autoscaling-scalingpolicy-customizedmetricspecification-unit",
@@ -1866,7 +1881,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-autoscaling-scalingpolicy-predefinedmetricspecification-predefinedmetrictype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "EC2ScalingPolicyPredifinedMetricSpecificationType"
+          }
         },
         "ResourceLabel": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-autoscaling-scalingpolicy-predefinedmetricspecification-resourcelabel",
@@ -2008,7 +2026,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-customizedscalingmetricspecification.html#cfn-autoscalingplans-scalingplan-customizedscalingmetricspecification-statistic",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingPolicyCustomizedMetricSpecificationStatistic"
+          }
         },
         "Unit": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-customizedscalingmetricspecification.html#cfn-autoscalingplans-scalingplan-customizedscalingmetricspecification-unit",
@@ -2059,7 +2080,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-predefinedscalingmetricspecification.html#cfn-autoscalingplans-scalingplan-predefinedscalingmetricspecification-predefinedscalingmetrictype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "EC2ScalingPolicyPredifinedMetricSpecificationType"
+          }
         },
         "ResourceLabel": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-predefinedscalingmetricspecification.html#cfn-autoscalingplans-scalingplan-predefinedscalingmetricspecification-resourcelabel",
@@ -2106,7 +2130,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-predictivescalingmaxcapacitybehavior",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingInstructionPredictiveScalingMaxCapacityBehavior"
+          }
         },
         "PredictiveScalingMaxCapacityBuffer": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-predictivescalingmaxcapacitybuffer",
@@ -2118,7 +2145,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-predictivescalingmode",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingInstructionPredictiveScalingMode"
+          }
         },
         "ResourceId": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-resourceid",
@@ -2130,7 +2160,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-scalabledimension",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingInstructionScalableDimension"
+          }
         },
         "ScalingPolicyUpdateBehavior": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-scalingpolicyupdatebehavior",
@@ -2148,7 +2181,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-servicenamespace",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingInstructionServiceNamespace"
+          }
         },
         "TargetTrackingConfigurations": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-targettrackingconfigurations",
@@ -18419,7 +18455,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-applicationautoscaling-scalingpolicy.html#cfn-applicationautoscaling-scalingpolicy-policytype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ApplicationAutoScalingPolicyType"
+          }
         },
         "ResourceId": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-applicationautoscaling-scalingpolicy.html#cfn-applicationautoscaling-scalingpolicy-resourceid",
@@ -18531,7 +18570,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-group.html#cfn-as-group-healthchecktype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingGroupHealthCheckType"
+          }
         },
         "InstanceId": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-group.html#cfn-as-group-instanceid",
@@ -18760,7 +18802,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-launchconfig.html#cfn-as-launchconfig-placementtenancy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "PlacementTenancy"
+          }
         },
         "RamDiskId": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-launchconfig.html#cfn-as-launchconfig-ramdiskid",
@@ -18807,7 +18852,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-defaultresult",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingLifecycleHookResult"
+          }
         },
         "HeartbeatTimeout": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-heartbeattimeout",
@@ -18825,7 +18873,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-lifecycletransition",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingLifecycleTransition"
+          }
         },
         "NotificationMetadata": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-notificationmetadata",
@@ -18854,7 +18905,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-adjustmenttype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingPolicyAdjustmentType"
+          }
         },
         "AutoScalingGroupName": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-autoscalinggroupname",
@@ -18878,7 +18932,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-metricaggregationtype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingPolicyMetricAggregationType"
+          }
         },
         "MinAdjustmentMagnitude": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-minadjustmentmagnitude",
@@ -18890,7 +18947,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-policytype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingPolicyType"
+          }
         },
         "ScalingAdjustment": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-scalingadjustment",
@@ -22781,7 +22841,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "VpcTenancy"
+            "ValueType": "PlacementTenancy"
           }
         },
         "Tags": {
@@ -31292,6 +31352,66 @@
         "UNIT"
       ]
     },
+    "ApplicationAutoScalingPolicyType": {
+      "AllowedValues": [
+        "StepScaling",
+        "TargetTrackingScaling"
+      ]
+    },
+    "ApplicationAutoScalingPredefinedMetricSpecificationType": {
+      "AllowedValues": [
+        "ALBRequestCountPerTarget",
+        "DynamoDBReadCapacityUtilization",
+        "DynamoDBWriteCapacityUtilization",
+        "EC2SpotFleetRequestAverageCPUUtilization",
+        "EC2SpotFleetRequestAverageNetworkIn",
+        "EC2SpotFleetRequestAverageNetworkOut",
+        "ECSServiceAverageCPUUtilization",
+        "ECSServiceAverageMemoryUtilization",
+        "RDSReaderAverageCPUUtilization",
+        "RDSReaderAverageDatabaseConnections",
+        "SageMakerVariantInvocationsPerInstance"
+      ]
+    },
+    "AutoScalingGroupHealthCheckType": {
+      "AllowedValues": [
+        "EC2",
+        "ELB"
+      ]
+    },
+    "AutoScalingLifecycleHookResult": {
+      "AllowedValues": [
+        "ABANDON",
+        "CONTINUE"
+      ]
+    },
+    "AutoScalingLifecycleTransition": {
+      "AllowedValues": [
+        "autoscaling:EC2_INSTANCE_LAUNCHING",
+        "autoscaling:EC2_INSTANCE_TERMINATING"
+      ]
+    },
+    "AutoScalingPolicyAdjustmentType": {
+      "AllowedValues": [
+        "ChangeInCapacity",
+        "ExactCapacity",
+        "PercentChangeInCapacity"
+      ]
+    },
+    "AutoScalingPolicyMetricAggregationType": {
+      "AllowedValues": [
+        "Average",
+        "Maximum",
+        "Minimum"
+      ]
+    },
+    "AutoScalingPolicyType": {
+      "AllowedValues": [
+        "SimpleScaling",
+        "StepScaling",
+        "TargetTrackingScaling"
+      ]
+    },
     "AvailabilityZone": {
       "GetAtt": {
         "AWS::EC2::Instance": "AvailabilityZone",
@@ -31344,6 +31464,14 @@
       "AllowedValues": [
         "source",
         "target"
+      ]
+    },
+    "EC2ScalingPolicyPredifinedMetricSpecificationType": {
+      "AllowedValues": [
+        "ALBRequestCountPerTarget",
+        "ASGAverageCPUUtilization",
+        "ASGAverageNetworkIn",
+        "ASGAverageNetworkOut"
       ]
     },
     "EbsVolumeType": {
@@ -31536,6 +31664,17 @@
         ]
       }
     },
+    "PlacementTenancy": {
+      "AllowedValues": [
+        "dedicated",
+        "default"
+      ],
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
+    },
     "PredicateType": {
       "AllowedValues": [
         "ByteMatch",
@@ -31577,6 +31716,49 @@
       "AllowedValues": [
         "Enabled",
         "Suspended"
+      ]
+    },
+    "ScalingInstructionPredictiveScalingMaxCapacityBehavior": {
+      "AllowedValues": [
+        "SetForecastCapacityToMaxCapacity",
+        "SetMaxCapacityToForecastCapacity",
+        "SetMaxCapacityAboveForecastCapacity"
+      ]
+    },
+    "ScalingInstructionPredictiveScalingMode": {
+      "AllowedValues": [
+        "ForecastAndScale",
+        "ForecastOnly"
+      ]
+    },
+    "ScalingInstructionScalableDimension": {
+      "AllowedValues": [
+        "autoscaling:autoScalingGroup:DesiredCapacity",
+        "ecs:service:DesiredCount",
+        "ec2:spot-fleet-request:TargetCapacity",
+        "dynamodb:table:ReadCapacityUnits",
+        "dynamodb:table:WriteCapacityUnits",
+        "dynamodb:index:ReadCapacityUnits",
+        "dynamodb:index:WriteCapacityUnits",
+        "rds:cluster:ReadReplicaCount"
+      ]
+    },
+    "ScalingInstructionServiceNamespace": {
+      "AllowedValues": [
+        "autoscaling",
+        "dynamodb",
+        "ecs",
+        "ec2",
+        "rds"
+      ]
+    },
+    "ScalingPolicyCustomizedMetricSpecificationStatistic": {
+      "AllowedValues": [
+        "Average",
+        "Minimum",
+        "Maximum",
+        "SampleCount",
+        "Sum"
       ]
     },
     "SecurityGroup": {
@@ -31699,17 +31881,6 @@
         ],
         "Resources": [
           "AWS::EC2::VPC"
-        ]
-      }
-    },
-    "VpcTenancy": {
-      "AllowedValues": [
-        "dedicated",
-        "default"
-      ],
-      "Ref": {
-        "Parameters": [
-          "String"
         ]
       }
     }

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
@@ -1135,7 +1135,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-customizedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-customizedmetricspecification-statistic",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingPolicyCustomizedMetricSpecificationStatistic"
+          }
         },
         "Unit": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-customizedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-customizedmetricspecification-unit",
@@ -1169,7 +1172,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-predefinedmetricspecification-predefinedmetrictype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ApplicationAutoScalingPredefinedMetricSpecificationType"
+          }
         },
         "ResourceLabel": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-predefinedmetricspecification-resourcelabel",
@@ -1381,7 +1387,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-lifecyclehookspecification.html#cfn-autoscaling-autoscalinggroup-lifecyclehookspecification-defaultresult",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingLifecycleHookResult"
+          }
         },
         "HeartbeatTimeout": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-lifecyclehookspecification.html#cfn-autoscaling-autoscalinggroup-lifecyclehookspecification-heartbeattimeout",
@@ -1399,7 +1408,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-lifecyclehookspecification.html#cfn-autoscaling-autoscalinggroup-lifecyclehookspecification-lifecycletransition",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingLifecycleTransition"
+          }
         },
         "NotificationMetadata": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-lifecyclehookspecification.html#cfn-autoscaling-autoscalinggroup-lifecyclehookspecification-notificationmetadata",
@@ -1599,7 +1611,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-customizedmetricspecification.html#cfn-autoscaling-scalingpolicy-customizedmetricspecification-statistic",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingPolicyCustomizedMetricSpecificationStatistic"
+          }
         },
         "Unit": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-customizedmetricspecification.html#cfn-autoscaling-scalingpolicy-customizedmetricspecification-unit",
@@ -1633,7 +1648,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-autoscaling-scalingpolicy-predefinedmetricspecification-predefinedmetrictype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "EC2ScalingPolicyPredifinedMetricSpecificationType"
+          }
         },
         "ResourceLabel": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-autoscaling-scalingpolicy-predefinedmetricspecification-resourcelabel",
@@ -1775,7 +1793,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-customizedscalingmetricspecification.html#cfn-autoscalingplans-scalingplan-customizedscalingmetricspecification-statistic",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingPolicyCustomizedMetricSpecificationStatistic"
+          }
         },
         "Unit": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-customizedscalingmetricspecification.html#cfn-autoscalingplans-scalingplan-customizedscalingmetricspecification-unit",
@@ -1826,7 +1847,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-predefinedscalingmetricspecification.html#cfn-autoscalingplans-scalingplan-predefinedscalingmetricspecification-predefinedscalingmetrictype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "EC2ScalingPolicyPredifinedMetricSpecificationType"
+          }
         },
         "ResourceLabel": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-predefinedscalingmetricspecification.html#cfn-autoscalingplans-scalingplan-predefinedscalingmetricspecification-resourcelabel",
@@ -1873,7 +1897,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-predictivescalingmaxcapacitybehavior",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingInstructionPredictiveScalingMaxCapacityBehavior"
+          }
         },
         "PredictiveScalingMaxCapacityBuffer": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-predictivescalingmaxcapacitybuffer",
@@ -1885,7 +1912,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-predictivescalingmode",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingInstructionPredictiveScalingMode"
+          }
         },
         "ResourceId": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-resourceid",
@@ -1897,7 +1927,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-scalabledimension",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingInstructionScalableDimension"
+          }
         },
         "ScalingPolicyUpdateBehavior": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-scalingpolicyupdatebehavior",
@@ -1915,7 +1948,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-servicenamespace",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingInstructionServiceNamespace"
+          }
         },
         "TargetTrackingConfigurations": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-targettrackingconfigurations",
@@ -16814,7 +16850,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-applicationautoscaling-scalingpolicy.html#cfn-applicationautoscaling-scalingpolicy-policytype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ApplicationAutoScalingPolicyType"
+          }
         },
         "ResourceId": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-applicationautoscaling-scalingpolicy.html#cfn-applicationautoscaling-scalingpolicy-resourceid",
@@ -16897,7 +16936,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-group.html#cfn-as-group-healthchecktype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingGroupHealthCheckType"
+          }
         },
         "InstanceId": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-group.html#cfn-as-group-instanceid",
@@ -17126,7 +17168,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-launchconfig.html#cfn-as-launchconfig-placementtenancy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "PlacementTenancy"
+          }
         },
         "RamDiskId": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-launchconfig.html#cfn-as-launchconfig-ramdiskid",
@@ -17173,7 +17218,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-defaultresult",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingLifecycleHookResult"
+          }
         },
         "HeartbeatTimeout": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-heartbeattimeout",
@@ -17191,7 +17239,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-lifecycletransition",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingLifecycleTransition"
+          }
         },
         "NotificationMetadata": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-notificationmetadata",
@@ -17220,7 +17271,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-adjustmenttype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingPolicyAdjustmentType"
+          }
         },
         "AutoScalingGroupName": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-autoscalinggroupname",
@@ -17244,7 +17298,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-metricaggregationtype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingPolicyMetricAggregationType"
+          }
         },
         "MinAdjustmentMagnitude": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-minadjustmentmagnitude",
@@ -17256,7 +17313,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-policytype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingPolicyType"
+          }
         },
         "ScalingAdjustment": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-scalingadjustment",
@@ -20936,7 +20996,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "VpcTenancy"
+            "ValueType": "PlacementTenancy"
           }
         },
         "Tags": {
@@ -28817,6 +28877,66 @@
         "UNIT"
       ]
     },
+    "ApplicationAutoScalingPolicyType": {
+      "AllowedValues": [
+        "StepScaling",
+        "TargetTrackingScaling"
+      ]
+    },
+    "ApplicationAutoScalingPredefinedMetricSpecificationType": {
+      "AllowedValues": [
+        "ALBRequestCountPerTarget",
+        "DynamoDBReadCapacityUtilization",
+        "DynamoDBWriteCapacityUtilization",
+        "EC2SpotFleetRequestAverageCPUUtilization",
+        "EC2SpotFleetRequestAverageNetworkIn",
+        "EC2SpotFleetRequestAverageNetworkOut",
+        "ECSServiceAverageCPUUtilization",
+        "ECSServiceAverageMemoryUtilization",
+        "RDSReaderAverageCPUUtilization",
+        "RDSReaderAverageDatabaseConnections",
+        "SageMakerVariantInvocationsPerInstance"
+      ]
+    },
+    "AutoScalingGroupHealthCheckType": {
+      "AllowedValues": [
+        "EC2",
+        "ELB"
+      ]
+    },
+    "AutoScalingLifecycleHookResult": {
+      "AllowedValues": [
+        "ABANDON",
+        "CONTINUE"
+      ]
+    },
+    "AutoScalingLifecycleTransition": {
+      "AllowedValues": [
+        "autoscaling:EC2_INSTANCE_LAUNCHING",
+        "autoscaling:EC2_INSTANCE_TERMINATING"
+      ]
+    },
+    "AutoScalingPolicyAdjustmentType": {
+      "AllowedValues": [
+        "ChangeInCapacity",
+        "ExactCapacity",
+        "PercentChangeInCapacity"
+      ]
+    },
+    "AutoScalingPolicyMetricAggregationType": {
+      "AllowedValues": [
+        "Average",
+        "Maximum",
+        "Minimum"
+      ]
+    },
+    "AutoScalingPolicyType": {
+      "AllowedValues": [
+        "SimpleScaling",
+        "StepScaling",
+        "TargetTrackingScaling"
+      ]
+    },
     "AvailabilityZone": {
       "GetAtt": {
         "AWS::EC2::Instance": "AvailabilityZone",
@@ -28869,6 +28989,14 @@
       "AllowedValues": [
         "source",
         "target"
+      ]
+    },
+    "EC2ScalingPolicyPredifinedMetricSpecificationType": {
+      "AllowedValues": [
+        "ALBRequestCountPerTarget",
+        "ASGAverageCPUUtilization",
+        "ASGAverageNetworkIn",
+        "ASGAverageNetworkOut"
       ]
     },
     "EbsVolumeType": {
@@ -29061,6 +29189,17 @@
         ]
       }
     },
+    "PlacementTenancy": {
+      "AllowedValues": [
+        "dedicated",
+        "default"
+      ],
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
+    },
     "PredicateType": {
       "AllowedValues": [
         "ByteMatch",
@@ -29102,6 +29241,49 @@
       "AllowedValues": [
         "Enabled",
         "Suspended"
+      ]
+    },
+    "ScalingInstructionPredictiveScalingMaxCapacityBehavior": {
+      "AllowedValues": [
+        "SetForecastCapacityToMaxCapacity",
+        "SetMaxCapacityToForecastCapacity",
+        "SetMaxCapacityAboveForecastCapacity"
+      ]
+    },
+    "ScalingInstructionPredictiveScalingMode": {
+      "AllowedValues": [
+        "ForecastAndScale",
+        "ForecastOnly"
+      ]
+    },
+    "ScalingInstructionScalableDimension": {
+      "AllowedValues": [
+        "autoscaling:autoScalingGroup:DesiredCapacity",
+        "ecs:service:DesiredCount",
+        "ec2:spot-fleet-request:TargetCapacity",
+        "dynamodb:table:ReadCapacityUnits",
+        "dynamodb:table:WriteCapacityUnits",
+        "dynamodb:index:ReadCapacityUnits",
+        "dynamodb:index:WriteCapacityUnits",
+        "rds:cluster:ReadReplicaCount"
+      ]
+    },
+    "ScalingInstructionServiceNamespace": {
+      "AllowedValues": [
+        "autoscaling",
+        "dynamodb",
+        "ecs",
+        "ec2",
+        "rds"
+      ]
+    },
+    "ScalingPolicyCustomizedMetricSpecificationStatistic": {
+      "AllowedValues": [
+        "Average",
+        "Minimum",
+        "Maximum",
+        "SampleCount",
+        "Sum"
       ]
     },
     "SecurityGroup": {
@@ -29224,17 +29406,6 @@
         ],
         "Resources": [
           "AWS::EC2::VPC"
-        ]
-      }
-    },
-    "VpcTenancy": {
-      "AllowedValues": [
-        "dedicated",
-        "default"
-      ],
-      "Ref": {
-        "Parameters": [
-          "String"
         ]
       }
     }

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
@@ -831,7 +831,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-customizedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-customizedmetricspecification-statistic",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingPolicyCustomizedMetricSpecificationStatistic"
+          }
         },
         "Unit": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-customizedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-customizedmetricspecification-unit",
@@ -865,7 +868,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-predefinedmetricspecification-predefinedmetrictype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ApplicationAutoScalingPredefinedMetricSpecificationType"
+          }
         },
         "ResourceLabel": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-predefinedmetricspecification-resourcelabel",
@@ -1077,7 +1083,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-lifecyclehookspecification.html#cfn-autoscaling-autoscalinggroup-lifecyclehookspecification-defaultresult",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingLifecycleHookResult"
+          }
         },
         "HeartbeatTimeout": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-lifecyclehookspecification.html#cfn-autoscaling-autoscalinggroup-lifecyclehookspecification-heartbeattimeout",
@@ -1095,7 +1104,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-lifecyclehookspecification.html#cfn-autoscaling-autoscalinggroup-lifecyclehookspecification-lifecycletransition",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingLifecycleTransition"
+          }
         },
         "NotificationMetadata": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-lifecyclehookspecification.html#cfn-autoscaling-autoscalinggroup-lifecyclehookspecification-notificationmetadata",
@@ -1295,7 +1307,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-customizedmetricspecification.html#cfn-autoscaling-scalingpolicy-customizedmetricspecification-statistic",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingPolicyCustomizedMetricSpecificationStatistic"
+          }
         },
         "Unit": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-customizedmetricspecification.html#cfn-autoscaling-scalingpolicy-customizedmetricspecification-unit",
@@ -1329,7 +1344,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-autoscaling-scalingpolicy-predefinedmetricspecification-predefinedmetrictype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "EC2ScalingPolicyPredifinedMetricSpecificationType"
+          }
         },
         "ResourceLabel": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-autoscaling-scalingpolicy-predefinedmetricspecification-resourcelabel",
@@ -11837,7 +11855,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-applicationautoscaling-scalingpolicy.html#cfn-applicationautoscaling-scalingpolicy-policytype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ApplicationAutoScalingPolicyType"
+          }
         },
         "ResourceId": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-applicationautoscaling-scalingpolicy.html#cfn-applicationautoscaling-scalingpolicy-resourceid",
@@ -11920,7 +11941,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-group.html#cfn-as-group-healthchecktype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingGroupHealthCheckType"
+          }
         },
         "InstanceId": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-group.html#cfn-as-group-instanceid",
@@ -12149,7 +12173,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-launchconfig.html#cfn-as-launchconfig-placementtenancy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "PlacementTenancy"
+          }
         },
         "RamDiskId": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-launchconfig.html#cfn-as-launchconfig-ramdiskid",
@@ -12196,7 +12223,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-defaultresult",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingLifecycleHookResult"
+          }
         },
         "HeartbeatTimeout": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-heartbeattimeout",
@@ -12214,7 +12244,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-lifecycletransition",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingLifecycleTransition"
+          }
         },
         "NotificationMetadata": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-notificationmetadata",
@@ -12243,7 +12276,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-adjustmenttype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingPolicyAdjustmentType"
+          }
         },
         "AutoScalingGroupName": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-autoscalinggroupname",
@@ -12267,7 +12303,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-metricaggregationtype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingPolicyMetricAggregationType"
+          }
         },
         "MinAdjustmentMagnitude": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-minadjustmentmagnitude",
@@ -12279,7 +12318,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-policytype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingPolicyType"
+          }
         },
         "ScalingAdjustment": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-scalingadjustment",
@@ -14699,7 +14741,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "VpcTenancy"
+            "ValueType": "PlacementTenancy"
           }
         },
         "Tags": {
@@ -20756,6 +20798,66 @@
         "UNIT"
       ]
     },
+    "ApplicationAutoScalingPolicyType": {
+      "AllowedValues": [
+        "StepScaling",
+        "TargetTrackingScaling"
+      ]
+    },
+    "ApplicationAutoScalingPredefinedMetricSpecificationType": {
+      "AllowedValues": [
+        "ALBRequestCountPerTarget",
+        "DynamoDBReadCapacityUtilization",
+        "DynamoDBWriteCapacityUtilization",
+        "EC2SpotFleetRequestAverageCPUUtilization",
+        "EC2SpotFleetRequestAverageNetworkIn",
+        "EC2SpotFleetRequestAverageNetworkOut",
+        "ECSServiceAverageCPUUtilization",
+        "ECSServiceAverageMemoryUtilization",
+        "RDSReaderAverageCPUUtilization",
+        "RDSReaderAverageDatabaseConnections",
+        "SageMakerVariantInvocationsPerInstance"
+      ]
+    },
+    "AutoScalingGroupHealthCheckType": {
+      "AllowedValues": [
+        "EC2",
+        "ELB"
+      ]
+    },
+    "AutoScalingLifecycleHookResult": {
+      "AllowedValues": [
+        "ABANDON",
+        "CONTINUE"
+      ]
+    },
+    "AutoScalingLifecycleTransition": {
+      "AllowedValues": [
+        "autoscaling:EC2_INSTANCE_LAUNCHING",
+        "autoscaling:EC2_INSTANCE_TERMINATING"
+      ]
+    },
+    "AutoScalingPolicyAdjustmentType": {
+      "AllowedValues": [
+        "ChangeInCapacity",
+        "ExactCapacity",
+        "PercentChangeInCapacity"
+      ]
+    },
+    "AutoScalingPolicyMetricAggregationType": {
+      "AllowedValues": [
+        "Average",
+        "Maximum",
+        "Minimum"
+      ]
+    },
+    "AutoScalingPolicyType": {
+      "AllowedValues": [
+        "SimpleScaling",
+        "StepScaling",
+        "TargetTrackingScaling"
+      ]
+    },
     "AvailabilityZone": {
       "GetAtt": {
         "AWS::EC2::Instance": "AvailabilityZone",
@@ -20808,6 +20910,14 @@
       "AllowedValues": [
         "source",
         "target"
+      ]
+    },
+    "EC2ScalingPolicyPredifinedMetricSpecificationType": {
+      "AllowedValues": [
+        "ALBRequestCountPerTarget",
+        "ASGAverageCPUUtilization",
+        "ASGAverageNetworkIn",
+        "ASGAverageNetworkOut"
       ]
     },
     "EbsVolumeType": {
@@ -21000,6 +21110,17 @@
         ]
       }
     },
+    "PlacementTenancy": {
+      "AllowedValues": [
+        "dedicated",
+        "default"
+      ],
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
+    },
     "PredicateType": {
       "AllowedValues": [
         "ByteMatch",
@@ -21041,6 +21162,49 @@
       "AllowedValues": [
         "Enabled",
         "Suspended"
+      ]
+    },
+    "ScalingInstructionPredictiveScalingMaxCapacityBehavior": {
+      "AllowedValues": [
+        "SetForecastCapacityToMaxCapacity",
+        "SetMaxCapacityToForecastCapacity",
+        "SetMaxCapacityAboveForecastCapacity"
+      ]
+    },
+    "ScalingInstructionPredictiveScalingMode": {
+      "AllowedValues": [
+        "ForecastAndScale",
+        "ForecastOnly"
+      ]
+    },
+    "ScalingInstructionScalableDimension": {
+      "AllowedValues": [
+        "autoscaling:autoScalingGroup:DesiredCapacity",
+        "ecs:service:DesiredCount",
+        "ec2:spot-fleet-request:TargetCapacity",
+        "dynamodb:table:ReadCapacityUnits",
+        "dynamodb:table:WriteCapacityUnits",
+        "dynamodb:index:ReadCapacityUnits",
+        "dynamodb:index:WriteCapacityUnits",
+        "rds:cluster:ReadReplicaCount"
+      ]
+    },
+    "ScalingInstructionServiceNamespace": {
+      "AllowedValues": [
+        "autoscaling",
+        "dynamodb",
+        "ecs",
+        "ec2",
+        "rds"
+      ]
+    },
+    "ScalingPolicyCustomizedMetricSpecificationStatistic": {
+      "AllowedValues": [
+        "Average",
+        "Minimum",
+        "Maximum",
+        "SampleCount",
+        "Sum"
       ]
     },
     "SecurityGroup": {
@@ -21163,17 +21327,6 @@
         ],
         "Resources": [
           "AWS::EC2::VPC"
-        ]
-      }
-    },
-    "VpcTenancy": {
-      "AllowedValues": [
-        "dedicated",
-        "default"
-      ],
-      "Ref": {
-        "Parameters": [
-          "String"
         ]
       }
     }

--- a/src/cfnlint/data/CloudSpecs/ap-south-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-south-1.json
@@ -997,7 +997,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-customizedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-customizedmetricspecification-statistic",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingPolicyCustomizedMetricSpecificationStatistic"
+          }
         },
         "Unit": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-customizedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-customizedmetricspecification-unit",
@@ -1031,7 +1034,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-predefinedmetricspecification-predefinedmetrictype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ApplicationAutoScalingPredefinedMetricSpecificationType"
+          }
         },
         "ResourceLabel": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-predefinedmetricspecification-resourcelabel",
@@ -1243,7 +1249,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-lifecyclehookspecification.html#cfn-autoscaling-autoscalinggroup-lifecyclehookspecification-defaultresult",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingLifecycleHookResult"
+          }
         },
         "HeartbeatTimeout": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-lifecyclehookspecification.html#cfn-autoscaling-autoscalinggroup-lifecyclehookspecification-heartbeattimeout",
@@ -1261,7 +1270,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-lifecyclehookspecification.html#cfn-autoscaling-autoscalinggroup-lifecyclehookspecification-lifecycletransition",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingLifecycleTransition"
+          }
         },
         "NotificationMetadata": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-lifecyclehookspecification.html#cfn-autoscaling-autoscalinggroup-lifecyclehookspecification-notificationmetadata",
@@ -1461,7 +1473,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-customizedmetricspecification.html#cfn-autoscaling-scalingpolicy-customizedmetricspecification-statistic",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingPolicyCustomizedMetricSpecificationStatistic"
+          }
         },
         "Unit": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-customizedmetricspecification.html#cfn-autoscaling-scalingpolicy-customizedmetricspecification-unit",
@@ -1495,7 +1510,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-autoscaling-scalingpolicy-predefinedmetricspecification-predefinedmetrictype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "EC2ScalingPolicyPredifinedMetricSpecificationType"
+          }
         },
         "ResourceLabel": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-autoscaling-scalingpolicy-predefinedmetricspecification-resourcelabel",
@@ -1637,7 +1655,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-customizedscalingmetricspecification.html#cfn-autoscalingplans-scalingplan-customizedscalingmetricspecification-statistic",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingPolicyCustomizedMetricSpecificationStatistic"
+          }
         },
         "Unit": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-customizedscalingmetricspecification.html#cfn-autoscalingplans-scalingplan-customizedscalingmetricspecification-unit",
@@ -1688,7 +1709,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-predefinedscalingmetricspecification.html#cfn-autoscalingplans-scalingplan-predefinedscalingmetricspecification-predefinedscalingmetrictype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "EC2ScalingPolicyPredifinedMetricSpecificationType"
+          }
         },
         "ResourceLabel": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-predefinedscalingmetricspecification.html#cfn-autoscalingplans-scalingplan-predefinedscalingmetricspecification-resourcelabel",
@@ -1735,7 +1759,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-predictivescalingmaxcapacitybehavior",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingInstructionPredictiveScalingMaxCapacityBehavior"
+          }
         },
         "PredictiveScalingMaxCapacityBuffer": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-predictivescalingmaxcapacitybuffer",
@@ -1747,7 +1774,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-predictivescalingmode",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingInstructionPredictiveScalingMode"
+          }
         },
         "ResourceId": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-resourceid",
@@ -1759,7 +1789,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-scalabledimension",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingInstructionScalableDimension"
+          }
         },
         "ScalingPolicyUpdateBehavior": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-scalingpolicyupdatebehavior",
@@ -1777,7 +1810,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-servicenamespace",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingInstructionServiceNamespace"
+          }
         },
         "TargetTrackingConfigurations": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-targettrackingconfigurations",
@@ -16038,7 +16074,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-applicationautoscaling-scalingpolicy.html#cfn-applicationautoscaling-scalingpolicy-policytype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ApplicationAutoScalingPolicyType"
+          }
         },
         "ResourceId": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-applicationautoscaling-scalingpolicy.html#cfn-applicationautoscaling-scalingpolicy-resourceid",
@@ -16121,7 +16160,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-group.html#cfn-as-group-healthchecktype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingGroupHealthCheckType"
+          }
         },
         "InstanceId": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-group.html#cfn-as-group-instanceid",
@@ -16350,7 +16392,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-launchconfig.html#cfn-as-launchconfig-placementtenancy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "PlacementTenancy"
+          }
         },
         "RamDiskId": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-launchconfig.html#cfn-as-launchconfig-ramdiskid",
@@ -16397,7 +16442,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-defaultresult",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingLifecycleHookResult"
+          }
         },
         "HeartbeatTimeout": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-heartbeattimeout",
@@ -16415,7 +16463,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-lifecycletransition",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingLifecycleTransition"
+          }
         },
         "NotificationMetadata": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-notificationmetadata",
@@ -16444,7 +16495,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-adjustmenttype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingPolicyAdjustmentType"
+          }
         },
         "AutoScalingGroupName": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-autoscalinggroupname",
@@ -16468,7 +16522,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-metricaggregationtype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingPolicyMetricAggregationType"
+          }
         },
         "MinAdjustmentMagnitude": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-minadjustmentmagnitude",
@@ -16480,7 +16537,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-policytype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingPolicyType"
+          }
         },
         "ScalingAdjustment": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-scalingadjustment",
@@ -19776,7 +19836,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "VpcTenancy"
+            "ValueType": "PlacementTenancy"
           }
         },
         "Tags": {
@@ -27657,6 +27717,66 @@
         "UNIT"
       ]
     },
+    "ApplicationAutoScalingPolicyType": {
+      "AllowedValues": [
+        "StepScaling",
+        "TargetTrackingScaling"
+      ]
+    },
+    "ApplicationAutoScalingPredefinedMetricSpecificationType": {
+      "AllowedValues": [
+        "ALBRequestCountPerTarget",
+        "DynamoDBReadCapacityUtilization",
+        "DynamoDBWriteCapacityUtilization",
+        "EC2SpotFleetRequestAverageCPUUtilization",
+        "EC2SpotFleetRequestAverageNetworkIn",
+        "EC2SpotFleetRequestAverageNetworkOut",
+        "ECSServiceAverageCPUUtilization",
+        "ECSServiceAverageMemoryUtilization",
+        "RDSReaderAverageCPUUtilization",
+        "RDSReaderAverageDatabaseConnections",
+        "SageMakerVariantInvocationsPerInstance"
+      ]
+    },
+    "AutoScalingGroupHealthCheckType": {
+      "AllowedValues": [
+        "EC2",
+        "ELB"
+      ]
+    },
+    "AutoScalingLifecycleHookResult": {
+      "AllowedValues": [
+        "ABANDON",
+        "CONTINUE"
+      ]
+    },
+    "AutoScalingLifecycleTransition": {
+      "AllowedValues": [
+        "autoscaling:EC2_INSTANCE_LAUNCHING",
+        "autoscaling:EC2_INSTANCE_TERMINATING"
+      ]
+    },
+    "AutoScalingPolicyAdjustmentType": {
+      "AllowedValues": [
+        "ChangeInCapacity",
+        "ExactCapacity",
+        "PercentChangeInCapacity"
+      ]
+    },
+    "AutoScalingPolicyMetricAggregationType": {
+      "AllowedValues": [
+        "Average",
+        "Maximum",
+        "Minimum"
+      ]
+    },
+    "AutoScalingPolicyType": {
+      "AllowedValues": [
+        "SimpleScaling",
+        "StepScaling",
+        "TargetTrackingScaling"
+      ]
+    },
     "AvailabilityZone": {
       "GetAtt": {
         "AWS::EC2::Instance": "AvailabilityZone",
@@ -27709,6 +27829,14 @@
       "AllowedValues": [
         "source",
         "target"
+      ]
+    },
+    "EC2ScalingPolicyPredifinedMetricSpecificationType": {
+      "AllowedValues": [
+        "ALBRequestCountPerTarget",
+        "ASGAverageCPUUtilization",
+        "ASGAverageNetworkIn",
+        "ASGAverageNetworkOut"
       ]
     },
     "EbsVolumeType": {
@@ -27901,6 +28029,17 @@
         ]
       }
     },
+    "PlacementTenancy": {
+      "AllowedValues": [
+        "dedicated",
+        "default"
+      ],
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
+    },
     "PredicateType": {
       "AllowedValues": [
         "ByteMatch",
@@ -27942,6 +28081,49 @@
       "AllowedValues": [
         "Enabled",
         "Suspended"
+      ]
+    },
+    "ScalingInstructionPredictiveScalingMaxCapacityBehavior": {
+      "AllowedValues": [
+        "SetForecastCapacityToMaxCapacity",
+        "SetMaxCapacityToForecastCapacity",
+        "SetMaxCapacityAboveForecastCapacity"
+      ]
+    },
+    "ScalingInstructionPredictiveScalingMode": {
+      "AllowedValues": [
+        "ForecastAndScale",
+        "ForecastOnly"
+      ]
+    },
+    "ScalingInstructionScalableDimension": {
+      "AllowedValues": [
+        "autoscaling:autoScalingGroup:DesiredCapacity",
+        "ecs:service:DesiredCount",
+        "ec2:spot-fleet-request:TargetCapacity",
+        "dynamodb:table:ReadCapacityUnits",
+        "dynamodb:table:WriteCapacityUnits",
+        "dynamodb:index:ReadCapacityUnits",
+        "dynamodb:index:WriteCapacityUnits",
+        "rds:cluster:ReadReplicaCount"
+      ]
+    },
+    "ScalingInstructionServiceNamespace": {
+      "AllowedValues": [
+        "autoscaling",
+        "dynamodb",
+        "ecs",
+        "ec2",
+        "rds"
+      ]
+    },
+    "ScalingPolicyCustomizedMetricSpecificationStatistic": {
+      "AllowedValues": [
+        "Average",
+        "Minimum",
+        "Maximum",
+        "SampleCount",
+        "Sum"
       ]
     },
     "SecurityGroup": {
@@ -28064,17 +28246,6 @@
         ],
         "Resources": [
           "AWS::EC2::VPC"
-        ]
-      }
-    },
-    "VpcTenancy": {
-      "AllowedValues": [
-        "dedicated",
-        "default"
-      ],
-      "Ref": {
-        "Parameters": [
-          "String"
         ]
       }
     }

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
@@ -1293,7 +1293,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-customizedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-customizedmetricspecification-statistic",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingPolicyCustomizedMetricSpecificationStatistic"
+          }
         },
         "Unit": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-customizedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-customizedmetricspecification-unit",
@@ -1327,7 +1330,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-predefinedmetricspecification-predefinedmetrictype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ApplicationAutoScalingPredefinedMetricSpecificationType"
+          }
         },
         "ResourceLabel": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-predefinedmetricspecification-resourcelabel",
@@ -1539,7 +1545,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-lifecyclehookspecification.html#cfn-autoscaling-autoscalinggroup-lifecyclehookspecification-defaultresult",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingLifecycleHookResult"
+          }
         },
         "HeartbeatTimeout": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-lifecyclehookspecification.html#cfn-autoscaling-autoscalinggroup-lifecyclehookspecification-heartbeattimeout",
@@ -1557,7 +1566,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-lifecyclehookspecification.html#cfn-autoscaling-autoscalinggroup-lifecyclehookspecification-lifecycletransition",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingLifecycleTransition"
+          }
         },
         "NotificationMetadata": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-lifecyclehookspecification.html#cfn-autoscaling-autoscalinggroup-lifecyclehookspecification-notificationmetadata",
@@ -1757,7 +1769,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-customizedmetricspecification.html#cfn-autoscaling-scalingpolicy-customizedmetricspecification-statistic",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingPolicyCustomizedMetricSpecificationStatistic"
+          }
         },
         "Unit": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-customizedmetricspecification.html#cfn-autoscaling-scalingpolicy-customizedmetricspecification-unit",
@@ -1791,7 +1806,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-autoscaling-scalingpolicy-predefinedmetricspecification-predefinedmetrictype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "EC2ScalingPolicyPredifinedMetricSpecificationType"
+          }
         },
         "ResourceLabel": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-autoscaling-scalingpolicy-predefinedmetricspecification-resourcelabel",
@@ -1933,7 +1951,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-customizedscalingmetricspecification.html#cfn-autoscalingplans-scalingplan-customizedscalingmetricspecification-statistic",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingPolicyCustomizedMetricSpecificationStatistic"
+          }
         },
         "Unit": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-customizedscalingmetricspecification.html#cfn-autoscalingplans-scalingplan-customizedscalingmetricspecification-unit",
@@ -1984,7 +2005,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-predefinedscalingmetricspecification.html#cfn-autoscalingplans-scalingplan-predefinedscalingmetricspecification-predefinedscalingmetrictype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "EC2ScalingPolicyPredifinedMetricSpecificationType"
+          }
         },
         "ResourceLabel": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-predefinedscalingmetricspecification.html#cfn-autoscalingplans-scalingplan-predefinedscalingmetricspecification-resourcelabel",
@@ -2031,7 +2055,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-predictivescalingmaxcapacitybehavior",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingInstructionPredictiveScalingMaxCapacityBehavior"
+          }
         },
         "PredictiveScalingMaxCapacityBuffer": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-predictivescalingmaxcapacitybuffer",
@@ -2043,7 +2070,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-predictivescalingmode",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingInstructionPredictiveScalingMode"
+          }
         },
         "ResourceId": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-resourceid",
@@ -2055,7 +2085,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-scalabledimension",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingInstructionScalableDimension"
+          }
         },
         "ScalingPolicyUpdateBehavior": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-scalingpolicyupdatebehavior",
@@ -2073,7 +2106,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-servicenamespace",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingInstructionServiceNamespace"
+          }
         },
         "TargetTrackingConfigurations": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-targettrackingconfigurations",
@@ -16976,7 +17012,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-applicationautoscaling-scalingpolicy.html#cfn-applicationautoscaling-scalingpolicy-policytype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ApplicationAutoScalingPolicyType"
+          }
         },
         "ResourceId": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-applicationautoscaling-scalingpolicy.html#cfn-applicationautoscaling-scalingpolicy-resourceid",
@@ -17088,7 +17127,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-group.html#cfn-as-group-healthchecktype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingGroupHealthCheckType"
+          }
         },
         "InstanceId": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-group.html#cfn-as-group-instanceid",
@@ -17317,7 +17359,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-launchconfig.html#cfn-as-launchconfig-placementtenancy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "PlacementTenancy"
+          }
         },
         "RamDiskId": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-launchconfig.html#cfn-as-launchconfig-ramdiskid",
@@ -17364,7 +17409,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-defaultresult",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingLifecycleHookResult"
+          }
         },
         "HeartbeatTimeout": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-heartbeattimeout",
@@ -17382,7 +17430,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-lifecycletransition",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingLifecycleTransition"
+          }
         },
         "NotificationMetadata": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-notificationmetadata",
@@ -17411,7 +17462,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-adjustmenttype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingPolicyAdjustmentType"
+          }
         },
         "AutoScalingGroupName": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-autoscalinggroupname",
@@ -17435,7 +17489,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-metricaggregationtype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingPolicyMetricAggregationType"
+          }
         },
         "MinAdjustmentMagnitude": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-minadjustmentmagnitude",
@@ -17447,7 +17504,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-policytype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingPolicyType"
+          }
         },
         "ScalingAdjustment": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-scalingadjustment",
@@ -20840,7 +20900,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "VpcTenancy"
+            "ValueType": "PlacementTenancy"
           }
         },
         "Tags": {
@@ -28809,6 +28869,66 @@
         "UNIT"
       ]
     },
+    "ApplicationAutoScalingPolicyType": {
+      "AllowedValues": [
+        "StepScaling",
+        "TargetTrackingScaling"
+      ]
+    },
+    "ApplicationAutoScalingPredefinedMetricSpecificationType": {
+      "AllowedValues": [
+        "ALBRequestCountPerTarget",
+        "DynamoDBReadCapacityUtilization",
+        "DynamoDBWriteCapacityUtilization",
+        "EC2SpotFleetRequestAverageCPUUtilization",
+        "EC2SpotFleetRequestAverageNetworkIn",
+        "EC2SpotFleetRequestAverageNetworkOut",
+        "ECSServiceAverageCPUUtilization",
+        "ECSServiceAverageMemoryUtilization",
+        "RDSReaderAverageCPUUtilization",
+        "RDSReaderAverageDatabaseConnections",
+        "SageMakerVariantInvocationsPerInstance"
+      ]
+    },
+    "AutoScalingGroupHealthCheckType": {
+      "AllowedValues": [
+        "EC2",
+        "ELB"
+      ]
+    },
+    "AutoScalingLifecycleHookResult": {
+      "AllowedValues": [
+        "ABANDON",
+        "CONTINUE"
+      ]
+    },
+    "AutoScalingLifecycleTransition": {
+      "AllowedValues": [
+        "autoscaling:EC2_INSTANCE_LAUNCHING",
+        "autoscaling:EC2_INSTANCE_TERMINATING"
+      ]
+    },
+    "AutoScalingPolicyAdjustmentType": {
+      "AllowedValues": [
+        "ChangeInCapacity",
+        "ExactCapacity",
+        "PercentChangeInCapacity"
+      ]
+    },
+    "AutoScalingPolicyMetricAggregationType": {
+      "AllowedValues": [
+        "Average",
+        "Maximum",
+        "Minimum"
+      ]
+    },
+    "AutoScalingPolicyType": {
+      "AllowedValues": [
+        "SimpleScaling",
+        "StepScaling",
+        "TargetTrackingScaling"
+      ]
+    },
     "AvailabilityZone": {
       "GetAtt": {
         "AWS::EC2::Instance": "AvailabilityZone",
@@ -28861,6 +28981,14 @@
       "AllowedValues": [
         "source",
         "target"
+      ]
+    },
+    "EC2ScalingPolicyPredifinedMetricSpecificationType": {
+      "AllowedValues": [
+        "ALBRequestCountPerTarget",
+        "ASGAverageCPUUtilization",
+        "ASGAverageNetworkIn",
+        "ASGAverageNetworkOut"
       ]
     },
     "EbsVolumeType": {
@@ -29053,6 +29181,17 @@
         ]
       }
     },
+    "PlacementTenancy": {
+      "AllowedValues": [
+        "dedicated",
+        "default"
+      ],
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
+    },
     "PredicateType": {
       "AllowedValues": [
         "ByteMatch",
@@ -29094,6 +29233,49 @@
       "AllowedValues": [
         "Enabled",
         "Suspended"
+      ]
+    },
+    "ScalingInstructionPredictiveScalingMaxCapacityBehavior": {
+      "AllowedValues": [
+        "SetForecastCapacityToMaxCapacity",
+        "SetMaxCapacityToForecastCapacity",
+        "SetMaxCapacityAboveForecastCapacity"
+      ]
+    },
+    "ScalingInstructionPredictiveScalingMode": {
+      "AllowedValues": [
+        "ForecastAndScale",
+        "ForecastOnly"
+      ]
+    },
+    "ScalingInstructionScalableDimension": {
+      "AllowedValues": [
+        "autoscaling:autoScalingGroup:DesiredCapacity",
+        "ecs:service:DesiredCount",
+        "ec2:spot-fleet-request:TargetCapacity",
+        "dynamodb:table:ReadCapacityUnits",
+        "dynamodb:table:WriteCapacityUnits",
+        "dynamodb:index:ReadCapacityUnits",
+        "dynamodb:index:WriteCapacityUnits",
+        "rds:cluster:ReadReplicaCount"
+      ]
+    },
+    "ScalingInstructionServiceNamespace": {
+      "AllowedValues": [
+        "autoscaling",
+        "dynamodb",
+        "ecs",
+        "ec2",
+        "rds"
+      ]
+    },
+    "ScalingPolicyCustomizedMetricSpecificationStatistic": {
+      "AllowedValues": [
+        "Average",
+        "Minimum",
+        "Maximum",
+        "SampleCount",
+        "Sum"
       ]
     },
     "SecurityGroup": {
@@ -29216,17 +29398,6 @@
         ],
         "Resources": [
           "AWS::EC2::VPC"
-        ]
-      }
-    },
-    "VpcTenancy": {
-      "AllowedValues": [
-        "dedicated",
-        "default"
-      ],
-      "Ref": {
-        "Parameters": [
-          "String"
         ]
       }
     }

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
@@ -1368,7 +1368,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-customizedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-customizedmetricspecification-statistic",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingPolicyCustomizedMetricSpecificationStatistic"
+          }
         },
         "Unit": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-customizedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-customizedmetricspecification-unit",
@@ -1402,7 +1405,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-predefinedmetricspecification-predefinedmetrictype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ApplicationAutoScalingPredefinedMetricSpecificationType"
+          }
         },
         "ResourceLabel": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-predefinedmetricspecification-resourcelabel",
@@ -1614,7 +1620,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-lifecyclehookspecification.html#cfn-autoscaling-autoscalinggroup-lifecyclehookspecification-defaultresult",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingLifecycleHookResult"
+          }
         },
         "HeartbeatTimeout": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-lifecyclehookspecification.html#cfn-autoscaling-autoscalinggroup-lifecyclehookspecification-heartbeattimeout",
@@ -1632,7 +1641,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-lifecyclehookspecification.html#cfn-autoscaling-autoscalinggroup-lifecyclehookspecification-lifecycletransition",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingLifecycleTransition"
+          }
         },
         "NotificationMetadata": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-lifecyclehookspecification.html#cfn-autoscaling-autoscalinggroup-lifecyclehookspecification-notificationmetadata",
@@ -1832,7 +1844,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-customizedmetricspecification.html#cfn-autoscaling-scalingpolicy-customizedmetricspecification-statistic",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingPolicyCustomizedMetricSpecificationStatistic"
+          }
         },
         "Unit": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-customizedmetricspecification.html#cfn-autoscaling-scalingpolicy-customizedmetricspecification-unit",
@@ -1866,7 +1881,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-autoscaling-scalingpolicy-predefinedmetricspecification-predefinedmetrictype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "EC2ScalingPolicyPredifinedMetricSpecificationType"
+          }
         },
         "ResourceLabel": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-autoscaling-scalingpolicy-predefinedmetricspecification-resourcelabel",
@@ -2008,7 +2026,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-customizedscalingmetricspecification.html#cfn-autoscalingplans-scalingplan-customizedscalingmetricspecification-statistic",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingPolicyCustomizedMetricSpecificationStatistic"
+          }
         },
         "Unit": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-customizedscalingmetricspecification.html#cfn-autoscalingplans-scalingplan-customizedscalingmetricspecification-unit",
@@ -2059,7 +2080,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-predefinedscalingmetricspecification.html#cfn-autoscalingplans-scalingplan-predefinedscalingmetricspecification-predefinedscalingmetrictype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "EC2ScalingPolicyPredifinedMetricSpecificationType"
+          }
         },
         "ResourceLabel": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-predefinedscalingmetricspecification.html#cfn-autoscalingplans-scalingplan-predefinedscalingmetricspecification-resourcelabel",
@@ -2106,7 +2130,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-predictivescalingmaxcapacitybehavior",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingInstructionPredictiveScalingMaxCapacityBehavior"
+          }
         },
         "PredictiveScalingMaxCapacityBuffer": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-predictivescalingmaxcapacitybuffer",
@@ -2118,7 +2145,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-predictivescalingmode",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingInstructionPredictiveScalingMode"
+          }
         },
         "ResourceId": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-resourceid",
@@ -2130,7 +2160,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-scalabledimension",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingInstructionScalableDimension"
+          }
         },
         "ScalingPolicyUpdateBehavior": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-scalingpolicyupdatebehavior",
@@ -2148,7 +2181,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-servicenamespace",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingInstructionServiceNamespace"
+          }
         },
         "TargetTrackingConfigurations": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-targettrackingconfigurations",
@@ -17594,7 +17630,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-applicationautoscaling-scalingpolicy.html#cfn-applicationautoscaling-scalingpolicy-policytype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ApplicationAutoScalingPolicyType"
+          }
         },
         "ResourceId": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-applicationautoscaling-scalingpolicy.html#cfn-applicationautoscaling-scalingpolicy-resourceid",
@@ -17706,7 +17745,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-group.html#cfn-as-group-healthchecktype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingGroupHealthCheckType"
+          }
         },
         "InstanceId": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-group.html#cfn-as-group-instanceid",
@@ -17935,7 +17977,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-launchconfig.html#cfn-as-launchconfig-placementtenancy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "PlacementTenancy"
+          }
         },
         "RamDiskId": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-launchconfig.html#cfn-as-launchconfig-ramdiskid",
@@ -17982,7 +18027,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-defaultresult",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingLifecycleHookResult"
+          }
         },
         "HeartbeatTimeout": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-heartbeattimeout",
@@ -18000,7 +18048,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-lifecycletransition",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingLifecycleTransition"
+          }
         },
         "NotificationMetadata": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-notificationmetadata",
@@ -18029,7 +18080,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-adjustmenttype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingPolicyAdjustmentType"
+          }
         },
         "AutoScalingGroupName": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-autoscalinggroupname",
@@ -18053,7 +18107,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-metricaggregationtype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingPolicyMetricAggregationType"
+          }
         },
         "MinAdjustmentMagnitude": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-minadjustmentmagnitude",
@@ -18065,7 +18122,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-policytype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingPolicyType"
+          }
         },
         "ScalingAdjustment": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-scalingadjustment",
@@ -21828,7 +21888,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "VpcTenancy"
+            "ValueType": "PlacementTenancy"
           }
         },
         "Tags": {
@@ -29757,6 +29817,66 @@
         "UNIT"
       ]
     },
+    "ApplicationAutoScalingPolicyType": {
+      "AllowedValues": [
+        "StepScaling",
+        "TargetTrackingScaling"
+      ]
+    },
+    "ApplicationAutoScalingPredefinedMetricSpecificationType": {
+      "AllowedValues": [
+        "ALBRequestCountPerTarget",
+        "DynamoDBReadCapacityUtilization",
+        "DynamoDBWriteCapacityUtilization",
+        "EC2SpotFleetRequestAverageCPUUtilization",
+        "EC2SpotFleetRequestAverageNetworkIn",
+        "EC2SpotFleetRequestAverageNetworkOut",
+        "ECSServiceAverageCPUUtilization",
+        "ECSServiceAverageMemoryUtilization",
+        "RDSReaderAverageCPUUtilization",
+        "RDSReaderAverageDatabaseConnections",
+        "SageMakerVariantInvocationsPerInstance"
+      ]
+    },
+    "AutoScalingGroupHealthCheckType": {
+      "AllowedValues": [
+        "EC2",
+        "ELB"
+      ]
+    },
+    "AutoScalingLifecycleHookResult": {
+      "AllowedValues": [
+        "ABANDON",
+        "CONTINUE"
+      ]
+    },
+    "AutoScalingLifecycleTransition": {
+      "AllowedValues": [
+        "autoscaling:EC2_INSTANCE_LAUNCHING",
+        "autoscaling:EC2_INSTANCE_TERMINATING"
+      ]
+    },
+    "AutoScalingPolicyAdjustmentType": {
+      "AllowedValues": [
+        "ChangeInCapacity",
+        "ExactCapacity",
+        "PercentChangeInCapacity"
+      ]
+    },
+    "AutoScalingPolicyMetricAggregationType": {
+      "AllowedValues": [
+        "Average",
+        "Maximum",
+        "Minimum"
+      ]
+    },
+    "AutoScalingPolicyType": {
+      "AllowedValues": [
+        "SimpleScaling",
+        "StepScaling",
+        "TargetTrackingScaling"
+      ]
+    },
     "AvailabilityZone": {
       "GetAtt": {
         "AWS::EC2::Instance": "AvailabilityZone",
@@ -29809,6 +29929,14 @@
       "AllowedValues": [
         "source",
         "target"
+      ]
+    },
+    "EC2ScalingPolicyPredifinedMetricSpecificationType": {
+      "AllowedValues": [
+        "ALBRequestCountPerTarget",
+        "ASGAverageCPUUtilization",
+        "ASGAverageNetworkIn",
+        "ASGAverageNetworkOut"
       ]
     },
     "EbsVolumeType": {
@@ -30001,6 +30129,17 @@
         ]
       }
     },
+    "PlacementTenancy": {
+      "AllowedValues": [
+        "dedicated",
+        "default"
+      ],
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
+    },
     "PredicateType": {
       "AllowedValues": [
         "ByteMatch",
@@ -30042,6 +30181,49 @@
       "AllowedValues": [
         "Enabled",
         "Suspended"
+      ]
+    },
+    "ScalingInstructionPredictiveScalingMaxCapacityBehavior": {
+      "AllowedValues": [
+        "SetForecastCapacityToMaxCapacity",
+        "SetMaxCapacityToForecastCapacity",
+        "SetMaxCapacityAboveForecastCapacity"
+      ]
+    },
+    "ScalingInstructionPredictiveScalingMode": {
+      "AllowedValues": [
+        "ForecastAndScale",
+        "ForecastOnly"
+      ]
+    },
+    "ScalingInstructionScalableDimension": {
+      "AllowedValues": [
+        "autoscaling:autoScalingGroup:DesiredCapacity",
+        "ecs:service:DesiredCount",
+        "ec2:spot-fleet-request:TargetCapacity",
+        "dynamodb:table:ReadCapacityUnits",
+        "dynamodb:table:WriteCapacityUnits",
+        "dynamodb:index:ReadCapacityUnits",
+        "dynamodb:index:WriteCapacityUnits",
+        "rds:cluster:ReadReplicaCount"
+      ]
+    },
+    "ScalingInstructionServiceNamespace": {
+      "AllowedValues": [
+        "autoscaling",
+        "dynamodb",
+        "ecs",
+        "ec2",
+        "rds"
+      ]
+    },
+    "ScalingPolicyCustomizedMetricSpecificationStatistic": {
+      "AllowedValues": [
+        "Average",
+        "Minimum",
+        "Maximum",
+        "SampleCount",
+        "Sum"
       ]
     },
     "SecurityGroup": {
@@ -30164,17 +30346,6 @@
         ],
         "Resources": [
           "AWS::EC2::VPC"
-        ]
-      }
-    },
-    "VpcTenancy": {
-      "AllowedValues": [
-        "dedicated",
-        "default"
-      ],
-      "Ref": {
-        "Parameters": [
-          "String"
         ]
       }
     }

--- a/src/cfnlint/data/CloudSpecs/ca-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/ca-central-1.json
@@ -831,7 +831,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-customizedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-customizedmetricspecification-statistic",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingPolicyCustomizedMetricSpecificationStatistic"
+          }
         },
         "Unit": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-customizedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-customizedmetricspecification-unit",
@@ -865,7 +868,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-predefinedmetricspecification-predefinedmetrictype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ApplicationAutoScalingPredefinedMetricSpecificationType"
+          }
         },
         "ResourceLabel": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-predefinedmetricspecification-resourcelabel",
@@ -1077,7 +1083,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-lifecyclehookspecification.html#cfn-autoscaling-autoscalinggroup-lifecyclehookspecification-defaultresult",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingLifecycleHookResult"
+          }
         },
         "HeartbeatTimeout": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-lifecyclehookspecification.html#cfn-autoscaling-autoscalinggroup-lifecyclehookspecification-heartbeattimeout",
@@ -1095,7 +1104,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-lifecyclehookspecification.html#cfn-autoscaling-autoscalinggroup-lifecyclehookspecification-lifecycletransition",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingLifecycleTransition"
+          }
         },
         "NotificationMetadata": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-lifecyclehookspecification.html#cfn-autoscaling-autoscalinggroup-lifecyclehookspecification-notificationmetadata",
@@ -1295,7 +1307,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-customizedmetricspecification.html#cfn-autoscaling-scalingpolicy-customizedmetricspecification-statistic",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingPolicyCustomizedMetricSpecificationStatistic"
+          }
         },
         "Unit": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-customizedmetricspecification.html#cfn-autoscaling-scalingpolicy-customizedmetricspecification-unit",
@@ -1329,7 +1344,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-autoscaling-scalingpolicy-predefinedmetricspecification-predefinedmetrictype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "EC2ScalingPolicyPredifinedMetricSpecificationType"
+          }
         },
         "ResourceLabel": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-autoscaling-scalingpolicy-predefinedmetricspecification-resourcelabel",
@@ -1471,7 +1489,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-customizedscalingmetricspecification.html#cfn-autoscalingplans-scalingplan-customizedscalingmetricspecification-statistic",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingPolicyCustomizedMetricSpecificationStatistic"
+          }
         },
         "Unit": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-customizedscalingmetricspecification.html#cfn-autoscalingplans-scalingplan-customizedscalingmetricspecification-unit",
@@ -1522,7 +1543,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-predefinedscalingmetricspecification.html#cfn-autoscalingplans-scalingplan-predefinedscalingmetricspecification-predefinedscalingmetrictype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "EC2ScalingPolicyPredifinedMetricSpecificationType"
+          }
         },
         "ResourceLabel": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-predefinedscalingmetricspecification.html#cfn-autoscalingplans-scalingplan-predefinedscalingmetricspecification-resourcelabel",
@@ -1569,7 +1593,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-predictivescalingmaxcapacitybehavior",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingInstructionPredictiveScalingMaxCapacityBehavior"
+          }
         },
         "PredictiveScalingMaxCapacityBuffer": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-predictivescalingmaxcapacitybuffer",
@@ -1581,7 +1608,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-predictivescalingmode",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingInstructionPredictiveScalingMode"
+          }
         },
         "ResourceId": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-resourceid",
@@ -1593,7 +1623,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-scalabledimension",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingInstructionScalableDimension"
+          }
         },
         "ScalingPolicyUpdateBehavior": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-scalingpolicyupdatebehavior",
@@ -1611,7 +1644,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-servicenamespace",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingInstructionServiceNamespace"
+          }
         },
         "TargetTrackingConfigurations": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-targettrackingconfigurations",
@@ -14864,7 +14900,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-applicationautoscaling-scalingpolicy.html#cfn-applicationautoscaling-scalingpolicy-policytype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ApplicationAutoScalingPolicyType"
+          }
         },
         "ResourceId": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-applicationautoscaling-scalingpolicy.html#cfn-applicationautoscaling-scalingpolicy-resourceid",
@@ -14947,7 +14986,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-group.html#cfn-as-group-healthchecktype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingGroupHealthCheckType"
+          }
         },
         "InstanceId": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-group.html#cfn-as-group-instanceid",
@@ -15176,7 +15218,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-launchconfig.html#cfn-as-launchconfig-placementtenancy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "PlacementTenancy"
+          }
         },
         "RamDiskId": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-launchconfig.html#cfn-as-launchconfig-ramdiskid",
@@ -15223,7 +15268,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-defaultresult",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingLifecycleHookResult"
+          }
         },
         "HeartbeatTimeout": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-heartbeattimeout",
@@ -15241,7 +15289,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-lifecycletransition",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingLifecycleTransition"
+          }
         },
         "NotificationMetadata": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-notificationmetadata",
@@ -15270,7 +15321,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-adjustmenttype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingPolicyAdjustmentType"
+          }
         },
         "AutoScalingGroupName": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-autoscalinggroupname",
@@ -15294,7 +15348,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-metricaggregationtype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingPolicyMetricAggregationType"
+          }
         },
         "MinAdjustmentMagnitude": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-minadjustmentmagnitude",
@@ -15306,7 +15363,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-policytype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingPolicyType"
+          }
         },
         "ScalingAdjustment": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-scalingadjustment",
@@ -18602,7 +18662,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "VpcTenancy"
+            "ValueType": "PlacementTenancy"
           }
         },
         "Tags": {
@@ -26017,6 +26077,66 @@
         "UNIT"
       ]
     },
+    "ApplicationAutoScalingPolicyType": {
+      "AllowedValues": [
+        "StepScaling",
+        "TargetTrackingScaling"
+      ]
+    },
+    "ApplicationAutoScalingPredefinedMetricSpecificationType": {
+      "AllowedValues": [
+        "ALBRequestCountPerTarget",
+        "DynamoDBReadCapacityUtilization",
+        "DynamoDBWriteCapacityUtilization",
+        "EC2SpotFleetRequestAverageCPUUtilization",
+        "EC2SpotFleetRequestAverageNetworkIn",
+        "EC2SpotFleetRequestAverageNetworkOut",
+        "ECSServiceAverageCPUUtilization",
+        "ECSServiceAverageMemoryUtilization",
+        "RDSReaderAverageCPUUtilization",
+        "RDSReaderAverageDatabaseConnections",
+        "SageMakerVariantInvocationsPerInstance"
+      ]
+    },
+    "AutoScalingGroupHealthCheckType": {
+      "AllowedValues": [
+        "EC2",
+        "ELB"
+      ]
+    },
+    "AutoScalingLifecycleHookResult": {
+      "AllowedValues": [
+        "ABANDON",
+        "CONTINUE"
+      ]
+    },
+    "AutoScalingLifecycleTransition": {
+      "AllowedValues": [
+        "autoscaling:EC2_INSTANCE_LAUNCHING",
+        "autoscaling:EC2_INSTANCE_TERMINATING"
+      ]
+    },
+    "AutoScalingPolicyAdjustmentType": {
+      "AllowedValues": [
+        "ChangeInCapacity",
+        "ExactCapacity",
+        "PercentChangeInCapacity"
+      ]
+    },
+    "AutoScalingPolicyMetricAggregationType": {
+      "AllowedValues": [
+        "Average",
+        "Maximum",
+        "Minimum"
+      ]
+    },
+    "AutoScalingPolicyType": {
+      "AllowedValues": [
+        "SimpleScaling",
+        "StepScaling",
+        "TargetTrackingScaling"
+      ]
+    },
     "AvailabilityZone": {
       "GetAtt": {
         "AWS::EC2::Instance": "AvailabilityZone",
@@ -26069,6 +26189,14 @@
       "AllowedValues": [
         "source",
         "target"
+      ]
+    },
+    "EC2ScalingPolicyPredifinedMetricSpecificationType": {
+      "AllowedValues": [
+        "ALBRequestCountPerTarget",
+        "ASGAverageCPUUtilization",
+        "ASGAverageNetworkIn",
+        "ASGAverageNetworkOut"
       ]
     },
     "EbsVolumeType": {
@@ -26261,6 +26389,17 @@
         ]
       }
     },
+    "PlacementTenancy": {
+      "AllowedValues": [
+        "dedicated",
+        "default"
+      ],
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
+    },
     "PredicateType": {
       "AllowedValues": [
         "ByteMatch",
@@ -26302,6 +26441,49 @@
       "AllowedValues": [
         "Enabled",
         "Suspended"
+      ]
+    },
+    "ScalingInstructionPredictiveScalingMaxCapacityBehavior": {
+      "AllowedValues": [
+        "SetForecastCapacityToMaxCapacity",
+        "SetMaxCapacityToForecastCapacity",
+        "SetMaxCapacityAboveForecastCapacity"
+      ]
+    },
+    "ScalingInstructionPredictiveScalingMode": {
+      "AllowedValues": [
+        "ForecastAndScale",
+        "ForecastOnly"
+      ]
+    },
+    "ScalingInstructionScalableDimension": {
+      "AllowedValues": [
+        "autoscaling:autoScalingGroup:DesiredCapacity",
+        "ecs:service:DesiredCount",
+        "ec2:spot-fleet-request:TargetCapacity",
+        "dynamodb:table:ReadCapacityUnits",
+        "dynamodb:table:WriteCapacityUnits",
+        "dynamodb:index:ReadCapacityUnits",
+        "dynamodb:index:WriteCapacityUnits",
+        "rds:cluster:ReadReplicaCount"
+      ]
+    },
+    "ScalingInstructionServiceNamespace": {
+      "AllowedValues": [
+        "autoscaling",
+        "dynamodb",
+        "ecs",
+        "ec2",
+        "rds"
+      ]
+    },
+    "ScalingPolicyCustomizedMetricSpecificationStatistic": {
+      "AllowedValues": [
+        "Average",
+        "Minimum",
+        "Maximum",
+        "SampleCount",
+        "Sum"
       ]
     },
     "SecurityGroup": {
@@ -26424,17 +26606,6 @@
         ],
         "Resources": [
           "AWS::EC2::VPC"
-        ]
-      }
-    },
-    "VpcTenancy": {
-      "AllowedValues": [
-        "dedicated",
-        "default"
-      ],
-      "Ref": {
-        "Parameters": [
-          "String"
         ]
       }
     }

--- a/src/cfnlint/data/CloudSpecs/eu-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-central-1.json
@@ -1293,7 +1293,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-customizedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-customizedmetricspecification-statistic",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingPolicyCustomizedMetricSpecificationStatistic"
+          }
         },
         "Unit": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-customizedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-customizedmetricspecification-unit",
@@ -1327,7 +1330,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-predefinedmetricspecification-predefinedmetrictype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ApplicationAutoScalingPredefinedMetricSpecificationType"
+          }
         },
         "ResourceLabel": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-predefinedmetricspecification-resourcelabel",
@@ -1539,7 +1545,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-lifecyclehookspecification.html#cfn-autoscaling-autoscalinggroup-lifecyclehookspecification-defaultresult",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingLifecycleHookResult"
+          }
         },
         "HeartbeatTimeout": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-lifecyclehookspecification.html#cfn-autoscaling-autoscalinggroup-lifecyclehookspecification-heartbeattimeout",
@@ -1557,7 +1566,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-lifecyclehookspecification.html#cfn-autoscaling-autoscalinggroup-lifecyclehookspecification-lifecycletransition",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingLifecycleTransition"
+          }
         },
         "NotificationMetadata": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-lifecyclehookspecification.html#cfn-autoscaling-autoscalinggroup-lifecyclehookspecification-notificationmetadata",
@@ -1757,7 +1769,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-customizedmetricspecification.html#cfn-autoscaling-scalingpolicy-customizedmetricspecification-statistic",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingPolicyCustomizedMetricSpecificationStatistic"
+          }
         },
         "Unit": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-customizedmetricspecification.html#cfn-autoscaling-scalingpolicy-customizedmetricspecification-unit",
@@ -1791,7 +1806,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-autoscaling-scalingpolicy-predefinedmetricspecification-predefinedmetrictype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "EC2ScalingPolicyPredifinedMetricSpecificationType"
+          }
         },
         "ResourceLabel": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-autoscaling-scalingpolicy-predefinedmetricspecification-resourcelabel",
@@ -1933,7 +1951,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-customizedscalingmetricspecification.html#cfn-autoscalingplans-scalingplan-customizedscalingmetricspecification-statistic",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingPolicyCustomizedMetricSpecificationStatistic"
+          }
         },
         "Unit": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-customizedscalingmetricspecification.html#cfn-autoscalingplans-scalingplan-customizedscalingmetricspecification-unit",
@@ -1984,7 +2005,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-predefinedscalingmetricspecification.html#cfn-autoscalingplans-scalingplan-predefinedscalingmetricspecification-predefinedscalingmetrictype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "EC2ScalingPolicyPredifinedMetricSpecificationType"
+          }
         },
         "ResourceLabel": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-predefinedscalingmetricspecification.html#cfn-autoscalingplans-scalingplan-predefinedscalingmetricspecification-resourcelabel",
@@ -2031,7 +2055,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-predictivescalingmaxcapacitybehavior",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingInstructionPredictiveScalingMaxCapacityBehavior"
+          }
         },
         "PredictiveScalingMaxCapacityBuffer": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-predictivescalingmaxcapacitybuffer",
@@ -2043,7 +2070,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-predictivescalingmode",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingInstructionPredictiveScalingMode"
+          }
         },
         "ResourceId": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-resourceid",
@@ -2055,7 +2085,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-scalabledimension",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingInstructionScalableDimension"
+          }
         },
         "ScalingPolicyUpdateBehavior": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-scalingpolicyupdatebehavior",
@@ -2073,7 +2106,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-servicenamespace",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingInstructionServiceNamespace"
+          }
         },
         "TargetTrackingConfigurations": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-targettrackingconfigurations",
@@ -17964,7 +18000,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-applicationautoscaling-scalingpolicy.html#cfn-applicationautoscaling-scalingpolicy-policytype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ApplicationAutoScalingPolicyType"
+          }
         },
         "ResourceId": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-applicationautoscaling-scalingpolicy.html#cfn-applicationautoscaling-scalingpolicy-resourceid",
@@ -18076,7 +18115,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-group.html#cfn-as-group-healthchecktype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingGroupHealthCheckType"
+          }
         },
         "InstanceId": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-group.html#cfn-as-group-instanceid",
@@ -18305,7 +18347,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-launchconfig.html#cfn-as-launchconfig-placementtenancy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "PlacementTenancy"
+          }
         },
         "RamDiskId": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-launchconfig.html#cfn-as-launchconfig-ramdiskid",
@@ -18352,7 +18397,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-defaultresult",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingLifecycleHookResult"
+          }
         },
         "HeartbeatTimeout": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-heartbeattimeout",
@@ -18370,7 +18418,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-lifecycletransition",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingLifecycleTransition"
+          }
         },
         "NotificationMetadata": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-notificationmetadata",
@@ -18399,7 +18450,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-adjustmenttype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingPolicyAdjustmentType"
+          }
         },
         "AutoScalingGroupName": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-autoscalinggroupname",
@@ -18423,7 +18477,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-metricaggregationtype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingPolicyMetricAggregationType"
+          }
         },
         "MinAdjustmentMagnitude": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-minadjustmentmagnitude",
@@ -18435,7 +18492,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-policytype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingPolicyType"
+          }
         },
         "ScalingAdjustment": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-scalingadjustment",
@@ -22186,7 +22246,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "VpcTenancy"
+            "ValueType": "PlacementTenancy"
           }
         },
         "Tags": {
@@ -30498,6 +30558,66 @@
         "UNIT"
       ]
     },
+    "ApplicationAutoScalingPolicyType": {
+      "AllowedValues": [
+        "StepScaling",
+        "TargetTrackingScaling"
+      ]
+    },
+    "ApplicationAutoScalingPredefinedMetricSpecificationType": {
+      "AllowedValues": [
+        "ALBRequestCountPerTarget",
+        "DynamoDBReadCapacityUtilization",
+        "DynamoDBWriteCapacityUtilization",
+        "EC2SpotFleetRequestAverageCPUUtilization",
+        "EC2SpotFleetRequestAverageNetworkIn",
+        "EC2SpotFleetRequestAverageNetworkOut",
+        "ECSServiceAverageCPUUtilization",
+        "ECSServiceAverageMemoryUtilization",
+        "RDSReaderAverageCPUUtilization",
+        "RDSReaderAverageDatabaseConnections",
+        "SageMakerVariantInvocationsPerInstance"
+      ]
+    },
+    "AutoScalingGroupHealthCheckType": {
+      "AllowedValues": [
+        "EC2",
+        "ELB"
+      ]
+    },
+    "AutoScalingLifecycleHookResult": {
+      "AllowedValues": [
+        "ABANDON",
+        "CONTINUE"
+      ]
+    },
+    "AutoScalingLifecycleTransition": {
+      "AllowedValues": [
+        "autoscaling:EC2_INSTANCE_LAUNCHING",
+        "autoscaling:EC2_INSTANCE_TERMINATING"
+      ]
+    },
+    "AutoScalingPolicyAdjustmentType": {
+      "AllowedValues": [
+        "ChangeInCapacity",
+        "ExactCapacity",
+        "PercentChangeInCapacity"
+      ]
+    },
+    "AutoScalingPolicyMetricAggregationType": {
+      "AllowedValues": [
+        "Average",
+        "Maximum",
+        "Minimum"
+      ]
+    },
+    "AutoScalingPolicyType": {
+      "AllowedValues": [
+        "SimpleScaling",
+        "StepScaling",
+        "TargetTrackingScaling"
+      ]
+    },
     "AvailabilityZone": {
       "GetAtt": {
         "AWS::EC2::Instance": "AvailabilityZone",
@@ -30550,6 +30670,14 @@
       "AllowedValues": [
         "source",
         "target"
+      ]
+    },
+    "EC2ScalingPolicyPredifinedMetricSpecificationType": {
+      "AllowedValues": [
+        "ALBRequestCountPerTarget",
+        "ASGAverageCPUUtilization",
+        "ASGAverageNetworkIn",
+        "ASGAverageNetworkOut"
       ]
     },
     "EbsVolumeType": {
@@ -30742,6 +30870,17 @@
         ]
       }
     },
+    "PlacementTenancy": {
+      "AllowedValues": [
+        "dedicated",
+        "default"
+      ],
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
+    },
     "PredicateType": {
       "AllowedValues": [
         "ByteMatch",
@@ -30783,6 +30922,49 @@
       "AllowedValues": [
         "Enabled",
         "Suspended"
+      ]
+    },
+    "ScalingInstructionPredictiveScalingMaxCapacityBehavior": {
+      "AllowedValues": [
+        "SetForecastCapacityToMaxCapacity",
+        "SetMaxCapacityToForecastCapacity",
+        "SetMaxCapacityAboveForecastCapacity"
+      ]
+    },
+    "ScalingInstructionPredictiveScalingMode": {
+      "AllowedValues": [
+        "ForecastAndScale",
+        "ForecastOnly"
+      ]
+    },
+    "ScalingInstructionScalableDimension": {
+      "AllowedValues": [
+        "autoscaling:autoScalingGroup:DesiredCapacity",
+        "ecs:service:DesiredCount",
+        "ec2:spot-fleet-request:TargetCapacity",
+        "dynamodb:table:ReadCapacityUnits",
+        "dynamodb:table:WriteCapacityUnits",
+        "dynamodb:index:ReadCapacityUnits",
+        "dynamodb:index:WriteCapacityUnits",
+        "rds:cluster:ReadReplicaCount"
+      ]
+    },
+    "ScalingInstructionServiceNamespace": {
+      "AllowedValues": [
+        "autoscaling",
+        "dynamodb",
+        "ecs",
+        "ec2",
+        "rds"
+      ]
+    },
+    "ScalingPolicyCustomizedMetricSpecificationStatistic": {
+      "AllowedValues": [
+        "Average",
+        "Minimum",
+        "Maximum",
+        "SampleCount",
+        "Sum"
       ]
     },
     "SecurityGroup": {
@@ -30905,17 +31087,6 @@
         ],
         "Resources": [
           "AWS::EC2::VPC"
-        ]
-      }
-    },
-    "VpcTenancy": {
-      "AllowedValues": [
-        "dedicated",
-        "default"
-      ],
-      "Ref": {
-        "Parameters": [
-          "String"
         ]
       }
     }

--- a/src/cfnlint/data/CloudSpecs/eu-north-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-north-1.json
@@ -831,7 +831,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-customizedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-customizedmetricspecification-statistic",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingPolicyCustomizedMetricSpecificationStatistic"
+          }
         },
         "Unit": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-customizedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-customizedmetricspecification-unit",
@@ -865,7 +868,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-predefinedmetricspecification-predefinedmetrictype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ApplicationAutoScalingPredefinedMetricSpecificationType"
+          }
         },
         "ResourceLabel": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-predefinedmetricspecification-resourcelabel",
@@ -1077,7 +1083,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-lifecyclehookspecification.html#cfn-autoscaling-autoscalinggroup-lifecyclehookspecification-defaultresult",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingLifecycleHookResult"
+          }
         },
         "HeartbeatTimeout": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-lifecyclehookspecification.html#cfn-autoscaling-autoscalinggroup-lifecyclehookspecification-heartbeattimeout",
@@ -1095,7 +1104,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-lifecyclehookspecification.html#cfn-autoscaling-autoscalinggroup-lifecyclehookspecification-lifecycletransition",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingLifecycleTransition"
+          }
         },
         "NotificationMetadata": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-lifecyclehookspecification.html#cfn-autoscaling-autoscalinggroup-lifecyclehookspecification-notificationmetadata",
@@ -1295,7 +1307,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-customizedmetricspecification.html#cfn-autoscaling-scalingpolicy-customizedmetricspecification-statistic",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingPolicyCustomizedMetricSpecificationStatistic"
+          }
         },
         "Unit": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-customizedmetricspecification.html#cfn-autoscaling-scalingpolicy-customizedmetricspecification-unit",
@@ -1329,7 +1344,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-autoscaling-scalingpolicy-predefinedmetricspecification-predefinedmetrictype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "EC2ScalingPolicyPredifinedMetricSpecificationType"
+          }
         },
         "ResourceLabel": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-autoscaling-scalingpolicy-predefinedmetricspecification-resourcelabel",
@@ -11786,7 +11804,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-applicationautoscaling-scalingpolicy.html#cfn-applicationautoscaling-scalingpolicy-policytype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ApplicationAutoScalingPolicyType"
+          }
         },
         "ResourceId": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-applicationautoscaling-scalingpolicy.html#cfn-applicationautoscaling-scalingpolicy-resourceid",
@@ -11869,7 +11890,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-group.html#cfn-as-group-healthchecktype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingGroupHealthCheckType"
+          }
         },
         "InstanceId": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-group.html#cfn-as-group-instanceid",
@@ -12098,7 +12122,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-launchconfig.html#cfn-as-launchconfig-placementtenancy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "PlacementTenancy"
+          }
         },
         "RamDiskId": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-launchconfig.html#cfn-as-launchconfig-ramdiskid",
@@ -12145,7 +12172,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-defaultresult",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingLifecycleHookResult"
+          }
         },
         "HeartbeatTimeout": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-heartbeattimeout",
@@ -12163,7 +12193,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-lifecycletransition",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingLifecycleTransition"
+          }
         },
         "NotificationMetadata": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-notificationmetadata",
@@ -12192,7 +12225,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-adjustmenttype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingPolicyAdjustmentType"
+          }
         },
         "AutoScalingGroupName": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-autoscalinggroupname",
@@ -12216,7 +12252,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-metricaggregationtype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingPolicyMetricAggregationType"
+          }
         },
         "MinAdjustmentMagnitude": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-minadjustmentmagnitude",
@@ -12228,7 +12267,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-policytype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingPolicyType"
+          }
         },
         "ScalingAdjustment": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-scalingadjustment",
@@ -14973,7 +15015,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "VpcTenancy"
+            "ValueType": "PlacementTenancy"
           }
         },
         "Tags": {
@@ -21108,6 +21150,66 @@
         "UNIT"
       ]
     },
+    "ApplicationAutoScalingPolicyType": {
+      "AllowedValues": [
+        "StepScaling",
+        "TargetTrackingScaling"
+      ]
+    },
+    "ApplicationAutoScalingPredefinedMetricSpecificationType": {
+      "AllowedValues": [
+        "ALBRequestCountPerTarget",
+        "DynamoDBReadCapacityUtilization",
+        "DynamoDBWriteCapacityUtilization",
+        "EC2SpotFleetRequestAverageCPUUtilization",
+        "EC2SpotFleetRequestAverageNetworkIn",
+        "EC2SpotFleetRequestAverageNetworkOut",
+        "ECSServiceAverageCPUUtilization",
+        "ECSServiceAverageMemoryUtilization",
+        "RDSReaderAverageCPUUtilization",
+        "RDSReaderAverageDatabaseConnections",
+        "SageMakerVariantInvocationsPerInstance"
+      ]
+    },
+    "AutoScalingGroupHealthCheckType": {
+      "AllowedValues": [
+        "EC2",
+        "ELB"
+      ]
+    },
+    "AutoScalingLifecycleHookResult": {
+      "AllowedValues": [
+        "ABANDON",
+        "CONTINUE"
+      ]
+    },
+    "AutoScalingLifecycleTransition": {
+      "AllowedValues": [
+        "autoscaling:EC2_INSTANCE_LAUNCHING",
+        "autoscaling:EC2_INSTANCE_TERMINATING"
+      ]
+    },
+    "AutoScalingPolicyAdjustmentType": {
+      "AllowedValues": [
+        "ChangeInCapacity",
+        "ExactCapacity",
+        "PercentChangeInCapacity"
+      ]
+    },
+    "AutoScalingPolicyMetricAggregationType": {
+      "AllowedValues": [
+        "Average",
+        "Maximum",
+        "Minimum"
+      ]
+    },
+    "AutoScalingPolicyType": {
+      "AllowedValues": [
+        "SimpleScaling",
+        "StepScaling",
+        "TargetTrackingScaling"
+      ]
+    },
     "AvailabilityZone": {
       "GetAtt": {
         "AWS::EC2::Instance": "AvailabilityZone",
@@ -21160,6 +21262,14 @@
       "AllowedValues": [
         "source",
         "target"
+      ]
+    },
+    "EC2ScalingPolicyPredifinedMetricSpecificationType": {
+      "AllowedValues": [
+        "ALBRequestCountPerTarget",
+        "ASGAverageCPUUtilization",
+        "ASGAverageNetworkIn",
+        "ASGAverageNetworkOut"
       ]
     },
     "EbsVolumeType": {
@@ -21352,6 +21462,17 @@
         ]
       }
     },
+    "PlacementTenancy": {
+      "AllowedValues": [
+        "dedicated",
+        "default"
+      ],
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
+    },
     "PredicateType": {
       "AllowedValues": [
         "ByteMatch",
@@ -21393,6 +21514,49 @@
       "AllowedValues": [
         "Enabled",
         "Suspended"
+      ]
+    },
+    "ScalingInstructionPredictiveScalingMaxCapacityBehavior": {
+      "AllowedValues": [
+        "SetForecastCapacityToMaxCapacity",
+        "SetMaxCapacityToForecastCapacity",
+        "SetMaxCapacityAboveForecastCapacity"
+      ]
+    },
+    "ScalingInstructionPredictiveScalingMode": {
+      "AllowedValues": [
+        "ForecastAndScale",
+        "ForecastOnly"
+      ]
+    },
+    "ScalingInstructionScalableDimension": {
+      "AllowedValues": [
+        "autoscaling:autoScalingGroup:DesiredCapacity",
+        "ecs:service:DesiredCount",
+        "ec2:spot-fleet-request:TargetCapacity",
+        "dynamodb:table:ReadCapacityUnits",
+        "dynamodb:table:WriteCapacityUnits",
+        "dynamodb:index:ReadCapacityUnits",
+        "dynamodb:index:WriteCapacityUnits",
+        "rds:cluster:ReadReplicaCount"
+      ]
+    },
+    "ScalingInstructionServiceNamespace": {
+      "AllowedValues": [
+        "autoscaling",
+        "dynamodb",
+        "ecs",
+        "ec2",
+        "rds"
+      ]
+    },
+    "ScalingPolicyCustomizedMetricSpecificationStatistic": {
+      "AllowedValues": [
+        "Average",
+        "Minimum",
+        "Maximum",
+        "SampleCount",
+        "Sum"
       ]
     },
     "SecurityGroup": {
@@ -21515,17 +21679,6 @@
         ],
         "Resources": [
           "AWS::EC2::VPC"
-        ]
-      }
-    },
-    "VpcTenancy": {
-      "AllowedValues": [
-        "dedicated",
-        "default"
-      ],
-      "Ref": {
-        "Parameters": [
-          "String"
         ]
       }
     }

--- a/src/cfnlint/data/CloudSpecs/eu-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-1.json
@@ -1368,7 +1368,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-customizedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-customizedmetricspecification-statistic",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingPolicyCustomizedMetricSpecificationStatistic"
+          }
         },
         "Unit": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-customizedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-customizedmetricspecification-unit",
@@ -1402,7 +1405,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-predefinedmetricspecification-predefinedmetrictype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ApplicationAutoScalingPredefinedMetricSpecificationType"
+          }
         },
         "ResourceLabel": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-predefinedmetricspecification-resourcelabel",
@@ -1614,7 +1620,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-lifecyclehookspecification.html#cfn-autoscaling-autoscalinggroup-lifecyclehookspecification-defaultresult",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingLifecycleHookResult"
+          }
         },
         "HeartbeatTimeout": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-lifecyclehookspecification.html#cfn-autoscaling-autoscalinggroup-lifecyclehookspecification-heartbeattimeout",
@@ -1632,7 +1641,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-lifecyclehookspecification.html#cfn-autoscaling-autoscalinggroup-lifecyclehookspecification-lifecycletransition",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingLifecycleTransition"
+          }
         },
         "NotificationMetadata": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-lifecyclehookspecification.html#cfn-autoscaling-autoscalinggroup-lifecyclehookspecification-notificationmetadata",
@@ -1832,7 +1844,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-customizedmetricspecification.html#cfn-autoscaling-scalingpolicy-customizedmetricspecification-statistic",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingPolicyCustomizedMetricSpecificationStatistic"
+          }
         },
         "Unit": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-customizedmetricspecification.html#cfn-autoscaling-scalingpolicy-customizedmetricspecification-unit",
@@ -1866,7 +1881,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-autoscaling-scalingpolicy-predefinedmetricspecification-predefinedmetrictype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "EC2ScalingPolicyPredifinedMetricSpecificationType"
+          }
         },
         "ResourceLabel": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-autoscaling-scalingpolicy-predefinedmetricspecification-resourcelabel",
@@ -2008,7 +2026,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-customizedscalingmetricspecification.html#cfn-autoscalingplans-scalingplan-customizedscalingmetricspecification-statistic",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingPolicyCustomizedMetricSpecificationStatistic"
+          }
         },
         "Unit": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-customizedscalingmetricspecification.html#cfn-autoscalingplans-scalingplan-customizedscalingmetricspecification-unit",
@@ -2059,7 +2080,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-predefinedscalingmetricspecification.html#cfn-autoscalingplans-scalingplan-predefinedscalingmetricspecification-predefinedscalingmetrictype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "EC2ScalingPolicyPredifinedMetricSpecificationType"
+          }
         },
         "ResourceLabel": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-predefinedscalingmetricspecification.html#cfn-autoscalingplans-scalingplan-predefinedscalingmetricspecification-resourcelabel",
@@ -2106,7 +2130,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-predictivescalingmaxcapacitybehavior",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingInstructionPredictiveScalingMaxCapacityBehavior"
+          }
         },
         "PredictiveScalingMaxCapacityBuffer": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-predictivescalingmaxcapacitybuffer",
@@ -2118,7 +2145,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-predictivescalingmode",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingInstructionPredictiveScalingMode"
+          }
         },
         "ResourceId": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-resourceid",
@@ -2130,7 +2160,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-scalabledimension",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingInstructionScalableDimension"
+          }
         },
         "ScalingPolicyUpdateBehavior": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-scalingpolicyupdatebehavior",
@@ -2148,7 +2181,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-servicenamespace",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingInstructionServiceNamespace"
+          }
         },
         "TargetTrackingConfigurations": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-targettrackingconfigurations",
@@ -19738,7 +19774,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-applicationautoscaling-scalingpolicy.html#cfn-applicationautoscaling-scalingpolicy-policytype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ApplicationAutoScalingPolicyType"
+          }
         },
         "ResourceId": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-applicationautoscaling-scalingpolicy.html#cfn-applicationautoscaling-scalingpolicy-resourceid",
@@ -19850,7 +19889,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-group.html#cfn-as-group-healthchecktype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingGroupHealthCheckType"
+          }
         },
         "InstanceId": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-group.html#cfn-as-group-instanceid",
@@ -20079,7 +20121,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-launchconfig.html#cfn-as-launchconfig-placementtenancy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "PlacementTenancy"
+          }
         },
         "RamDiskId": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-launchconfig.html#cfn-as-launchconfig-ramdiskid",
@@ -20126,7 +20171,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-defaultresult",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingLifecycleHookResult"
+          }
         },
         "HeartbeatTimeout": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-heartbeattimeout",
@@ -20144,7 +20192,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-lifecycletransition",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingLifecycleTransition"
+          }
         },
         "NotificationMetadata": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-notificationmetadata",
@@ -20173,7 +20224,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-adjustmenttype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingPolicyAdjustmentType"
+          }
         },
         "AutoScalingGroupName": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-autoscalinggroupname",
@@ -20197,7 +20251,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-metricaggregationtype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingPolicyMetricAggregationType"
+          }
         },
         "MinAdjustmentMagnitude": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-minadjustmentmagnitude",
@@ -20209,7 +20266,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-policytype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingPolicyType"
+          }
         },
         "ScalingAdjustment": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-scalingadjustment",
@@ -24312,7 +24372,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "VpcTenancy"
+            "ValueType": "PlacementTenancy"
           }
         },
         "Tags": {
@@ -33350,6 +33410,66 @@
         "UNIT"
       ]
     },
+    "ApplicationAutoScalingPolicyType": {
+      "AllowedValues": [
+        "StepScaling",
+        "TargetTrackingScaling"
+      ]
+    },
+    "ApplicationAutoScalingPredefinedMetricSpecificationType": {
+      "AllowedValues": [
+        "ALBRequestCountPerTarget",
+        "DynamoDBReadCapacityUtilization",
+        "DynamoDBWriteCapacityUtilization",
+        "EC2SpotFleetRequestAverageCPUUtilization",
+        "EC2SpotFleetRequestAverageNetworkIn",
+        "EC2SpotFleetRequestAverageNetworkOut",
+        "ECSServiceAverageCPUUtilization",
+        "ECSServiceAverageMemoryUtilization",
+        "RDSReaderAverageCPUUtilization",
+        "RDSReaderAverageDatabaseConnections",
+        "SageMakerVariantInvocationsPerInstance"
+      ]
+    },
+    "AutoScalingGroupHealthCheckType": {
+      "AllowedValues": [
+        "EC2",
+        "ELB"
+      ]
+    },
+    "AutoScalingLifecycleHookResult": {
+      "AllowedValues": [
+        "ABANDON",
+        "CONTINUE"
+      ]
+    },
+    "AutoScalingLifecycleTransition": {
+      "AllowedValues": [
+        "autoscaling:EC2_INSTANCE_LAUNCHING",
+        "autoscaling:EC2_INSTANCE_TERMINATING"
+      ]
+    },
+    "AutoScalingPolicyAdjustmentType": {
+      "AllowedValues": [
+        "ChangeInCapacity",
+        "ExactCapacity",
+        "PercentChangeInCapacity"
+      ]
+    },
+    "AutoScalingPolicyMetricAggregationType": {
+      "AllowedValues": [
+        "Average",
+        "Maximum",
+        "Minimum"
+      ]
+    },
+    "AutoScalingPolicyType": {
+      "AllowedValues": [
+        "SimpleScaling",
+        "StepScaling",
+        "TargetTrackingScaling"
+      ]
+    },
     "AvailabilityZone": {
       "GetAtt": {
         "AWS::EC2::Instance": "AvailabilityZone",
@@ -33402,6 +33522,14 @@
       "AllowedValues": [
         "source",
         "target"
+      ]
+    },
+    "EC2ScalingPolicyPredifinedMetricSpecificationType": {
+      "AllowedValues": [
+        "ALBRequestCountPerTarget",
+        "ASGAverageCPUUtilization",
+        "ASGAverageNetworkIn",
+        "ASGAverageNetworkOut"
       ]
     },
     "EbsVolumeType": {
@@ -33594,6 +33722,17 @@
         ]
       }
     },
+    "PlacementTenancy": {
+      "AllowedValues": [
+        "dedicated",
+        "default"
+      ],
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
+    },
     "PredicateType": {
       "AllowedValues": [
         "ByteMatch",
@@ -33635,6 +33774,49 @@
       "AllowedValues": [
         "Enabled",
         "Suspended"
+      ]
+    },
+    "ScalingInstructionPredictiveScalingMaxCapacityBehavior": {
+      "AllowedValues": [
+        "SetForecastCapacityToMaxCapacity",
+        "SetMaxCapacityToForecastCapacity",
+        "SetMaxCapacityAboveForecastCapacity"
+      ]
+    },
+    "ScalingInstructionPredictiveScalingMode": {
+      "AllowedValues": [
+        "ForecastAndScale",
+        "ForecastOnly"
+      ]
+    },
+    "ScalingInstructionScalableDimension": {
+      "AllowedValues": [
+        "autoscaling:autoScalingGroup:DesiredCapacity",
+        "ecs:service:DesiredCount",
+        "ec2:spot-fleet-request:TargetCapacity",
+        "dynamodb:table:ReadCapacityUnits",
+        "dynamodb:table:WriteCapacityUnits",
+        "dynamodb:index:ReadCapacityUnits",
+        "dynamodb:index:WriteCapacityUnits",
+        "rds:cluster:ReadReplicaCount"
+      ]
+    },
+    "ScalingInstructionServiceNamespace": {
+      "AllowedValues": [
+        "autoscaling",
+        "dynamodb",
+        "ecs",
+        "ec2",
+        "rds"
+      ]
+    },
+    "ScalingPolicyCustomizedMetricSpecificationStatistic": {
+      "AllowedValues": [
+        "Average",
+        "Minimum",
+        "Maximum",
+        "SampleCount",
+        "Sum"
       ]
     },
     "SecurityGroup": {
@@ -33757,17 +33939,6 @@
         ],
         "Resources": [
           "AWS::EC2::VPC"
-        ]
-      }
-    },
-    "VpcTenancy": {
-      "AllowedValues": [
-        "dedicated",
-        "default"
-      ],
-      "Ref": {
-        "Parameters": [
-          "String"
         ]
       }
     }

--- a/src/cfnlint/data/CloudSpecs/eu-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-2.json
@@ -831,7 +831,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-customizedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-customizedmetricspecification-statistic",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingPolicyCustomizedMetricSpecificationStatistic"
+          }
         },
         "Unit": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-customizedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-customizedmetricspecification-unit",
@@ -865,7 +868,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-predefinedmetricspecification-predefinedmetrictype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ApplicationAutoScalingPredefinedMetricSpecificationType"
+          }
         },
         "ResourceLabel": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-predefinedmetricspecification-resourcelabel",
@@ -1077,7 +1083,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-lifecyclehookspecification.html#cfn-autoscaling-autoscalinggroup-lifecyclehookspecification-defaultresult",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingLifecycleHookResult"
+          }
         },
         "HeartbeatTimeout": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-lifecyclehookspecification.html#cfn-autoscaling-autoscalinggroup-lifecyclehookspecification-heartbeattimeout",
@@ -1095,7 +1104,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-lifecyclehookspecification.html#cfn-autoscaling-autoscalinggroup-lifecyclehookspecification-lifecycletransition",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingLifecycleTransition"
+          }
         },
         "NotificationMetadata": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-lifecyclehookspecification.html#cfn-autoscaling-autoscalinggroup-lifecyclehookspecification-notificationmetadata",
@@ -1295,7 +1307,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-customizedmetricspecification.html#cfn-autoscaling-scalingpolicy-customizedmetricspecification-statistic",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingPolicyCustomizedMetricSpecificationStatistic"
+          }
         },
         "Unit": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-customizedmetricspecification.html#cfn-autoscaling-scalingpolicy-customizedmetricspecification-unit",
@@ -1329,7 +1344,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-autoscaling-scalingpolicy-predefinedmetricspecification-predefinedmetrictype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "EC2ScalingPolicyPredifinedMetricSpecificationType"
+          }
         },
         "ResourceLabel": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-autoscaling-scalingpolicy-predefinedmetricspecification-resourcelabel",
@@ -1471,7 +1489,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-customizedscalingmetricspecification.html#cfn-autoscalingplans-scalingplan-customizedscalingmetricspecification-statistic",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingPolicyCustomizedMetricSpecificationStatistic"
+          }
         },
         "Unit": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-customizedscalingmetricspecification.html#cfn-autoscalingplans-scalingplan-customizedscalingmetricspecification-unit",
@@ -1522,7 +1543,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-predefinedscalingmetricspecification.html#cfn-autoscalingplans-scalingplan-predefinedscalingmetricspecification-predefinedscalingmetrictype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "EC2ScalingPolicyPredifinedMetricSpecificationType"
+          }
         },
         "ResourceLabel": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-predefinedscalingmetricspecification.html#cfn-autoscalingplans-scalingplan-predefinedscalingmetricspecification-resourcelabel",
@@ -1569,7 +1593,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-predictivescalingmaxcapacitybehavior",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingInstructionPredictiveScalingMaxCapacityBehavior"
+          }
         },
         "PredictiveScalingMaxCapacityBuffer": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-predictivescalingmaxcapacitybuffer",
@@ -1581,7 +1608,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-predictivescalingmode",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingInstructionPredictiveScalingMode"
+          }
         },
         "ResourceId": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-resourceid",
@@ -1593,7 +1623,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-scalabledimension",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingInstructionScalableDimension"
+          }
         },
         "ScalingPolicyUpdateBehavior": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-scalingpolicyupdatebehavior",
@@ -1611,7 +1644,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-servicenamespace",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingInstructionServiceNamespace"
+          }
         },
         "TargetTrackingConfigurations": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-targettrackingconfigurations",
@@ -15337,7 +15373,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-applicationautoscaling-scalingpolicy.html#cfn-applicationautoscaling-scalingpolicy-policytype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ApplicationAutoScalingPolicyType"
+          }
         },
         "ResourceId": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-applicationautoscaling-scalingpolicy.html#cfn-applicationautoscaling-scalingpolicy-resourceid",
@@ -15449,7 +15488,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-group.html#cfn-as-group-healthchecktype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingGroupHealthCheckType"
+          }
         },
         "InstanceId": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-group.html#cfn-as-group-instanceid",
@@ -15678,7 +15720,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-launchconfig.html#cfn-as-launchconfig-placementtenancy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "PlacementTenancy"
+          }
         },
         "RamDiskId": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-launchconfig.html#cfn-as-launchconfig-ramdiskid",
@@ -15725,7 +15770,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-defaultresult",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingLifecycleHookResult"
+          }
         },
         "HeartbeatTimeout": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-heartbeattimeout",
@@ -15743,7 +15791,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-lifecycletransition",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingLifecycleTransition"
+          }
         },
         "NotificationMetadata": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-notificationmetadata",
@@ -15772,7 +15823,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-adjustmenttype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingPolicyAdjustmentType"
+          }
         },
         "AutoScalingGroupName": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-autoscalinggroupname",
@@ -15796,7 +15850,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-metricaggregationtype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingPolicyMetricAggregationType"
+          }
         },
         "MinAdjustmentMagnitude": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-minadjustmentmagnitude",
@@ -15808,7 +15865,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-policytype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingPolicyType"
+          }
         },
         "ScalingAdjustment": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-scalingadjustment",
@@ -19518,7 +19578,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "VpcTenancy"
+            "ValueType": "PlacementTenancy"
           }
         },
         "Tags": {
@@ -27318,6 +27378,66 @@
         "UNIT"
       ]
     },
+    "ApplicationAutoScalingPolicyType": {
+      "AllowedValues": [
+        "StepScaling",
+        "TargetTrackingScaling"
+      ]
+    },
+    "ApplicationAutoScalingPredefinedMetricSpecificationType": {
+      "AllowedValues": [
+        "ALBRequestCountPerTarget",
+        "DynamoDBReadCapacityUtilization",
+        "DynamoDBWriteCapacityUtilization",
+        "EC2SpotFleetRequestAverageCPUUtilization",
+        "EC2SpotFleetRequestAverageNetworkIn",
+        "EC2SpotFleetRequestAverageNetworkOut",
+        "ECSServiceAverageCPUUtilization",
+        "ECSServiceAverageMemoryUtilization",
+        "RDSReaderAverageCPUUtilization",
+        "RDSReaderAverageDatabaseConnections",
+        "SageMakerVariantInvocationsPerInstance"
+      ]
+    },
+    "AutoScalingGroupHealthCheckType": {
+      "AllowedValues": [
+        "EC2",
+        "ELB"
+      ]
+    },
+    "AutoScalingLifecycleHookResult": {
+      "AllowedValues": [
+        "ABANDON",
+        "CONTINUE"
+      ]
+    },
+    "AutoScalingLifecycleTransition": {
+      "AllowedValues": [
+        "autoscaling:EC2_INSTANCE_LAUNCHING",
+        "autoscaling:EC2_INSTANCE_TERMINATING"
+      ]
+    },
+    "AutoScalingPolicyAdjustmentType": {
+      "AllowedValues": [
+        "ChangeInCapacity",
+        "ExactCapacity",
+        "PercentChangeInCapacity"
+      ]
+    },
+    "AutoScalingPolicyMetricAggregationType": {
+      "AllowedValues": [
+        "Average",
+        "Maximum",
+        "Minimum"
+      ]
+    },
+    "AutoScalingPolicyType": {
+      "AllowedValues": [
+        "SimpleScaling",
+        "StepScaling",
+        "TargetTrackingScaling"
+      ]
+    },
     "AvailabilityZone": {
       "GetAtt": {
         "AWS::EC2::Instance": "AvailabilityZone",
@@ -27370,6 +27490,14 @@
       "AllowedValues": [
         "source",
         "target"
+      ]
+    },
+    "EC2ScalingPolicyPredifinedMetricSpecificationType": {
+      "AllowedValues": [
+        "ALBRequestCountPerTarget",
+        "ASGAverageCPUUtilization",
+        "ASGAverageNetworkIn",
+        "ASGAverageNetworkOut"
       ]
     },
     "EbsVolumeType": {
@@ -27562,6 +27690,17 @@
         ]
       }
     },
+    "PlacementTenancy": {
+      "AllowedValues": [
+        "dedicated",
+        "default"
+      ],
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
+    },
     "PredicateType": {
       "AllowedValues": [
         "ByteMatch",
@@ -27603,6 +27742,49 @@
       "AllowedValues": [
         "Enabled",
         "Suspended"
+      ]
+    },
+    "ScalingInstructionPredictiveScalingMaxCapacityBehavior": {
+      "AllowedValues": [
+        "SetForecastCapacityToMaxCapacity",
+        "SetMaxCapacityToForecastCapacity",
+        "SetMaxCapacityAboveForecastCapacity"
+      ]
+    },
+    "ScalingInstructionPredictiveScalingMode": {
+      "AllowedValues": [
+        "ForecastAndScale",
+        "ForecastOnly"
+      ]
+    },
+    "ScalingInstructionScalableDimension": {
+      "AllowedValues": [
+        "autoscaling:autoScalingGroup:DesiredCapacity",
+        "ecs:service:DesiredCount",
+        "ec2:spot-fleet-request:TargetCapacity",
+        "dynamodb:table:ReadCapacityUnits",
+        "dynamodb:table:WriteCapacityUnits",
+        "dynamodb:index:ReadCapacityUnits",
+        "dynamodb:index:WriteCapacityUnits",
+        "rds:cluster:ReadReplicaCount"
+      ]
+    },
+    "ScalingInstructionServiceNamespace": {
+      "AllowedValues": [
+        "autoscaling",
+        "dynamodb",
+        "ecs",
+        "ec2",
+        "rds"
+      ]
+    },
+    "ScalingPolicyCustomizedMetricSpecificationStatistic": {
+      "AllowedValues": [
+        "Average",
+        "Minimum",
+        "Maximum",
+        "SampleCount",
+        "Sum"
       ]
     },
     "SecurityGroup": {
@@ -27725,17 +27907,6 @@
         ],
         "Resources": [
           "AWS::EC2::VPC"
-        ]
-      }
-    },
-    "VpcTenancy": {
-      "AllowedValues": [
-        "dedicated",
-        "default"
-      ],
-      "Ref": {
-        "Parameters": [
-          "String"
         ]
       }
     }

--- a/src/cfnlint/data/CloudSpecs/eu-west-3.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-3.json
@@ -831,7 +831,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-customizedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-customizedmetricspecification-statistic",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingPolicyCustomizedMetricSpecificationStatistic"
+          }
         },
         "Unit": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-customizedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-customizedmetricspecification-unit",
@@ -865,7 +868,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-predefinedmetricspecification-predefinedmetrictype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ApplicationAutoScalingPredefinedMetricSpecificationType"
+          }
         },
         "ResourceLabel": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-predefinedmetricspecification-resourcelabel",
@@ -1077,7 +1083,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-lifecyclehookspecification.html#cfn-autoscaling-autoscalinggroup-lifecyclehookspecification-defaultresult",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingLifecycleHookResult"
+          }
         },
         "HeartbeatTimeout": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-lifecyclehookspecification.html#cfn-autoscaling-autoscalinggroup-lifecyclehookspecification-heartbeattimeout",
@@ -1095,7 +1104,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-lifecyclehookspecification.html#cfn-autoscaling-autoscalinggroup-lifecyclehookspecification-lifecycletransition",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingLifecycleTransition"
+          }
         },
         "NotificationMetadata": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-lifecyclehookspecification.html#cfn-autoscaling-autoscalinggroup-lifecyclehookspecification-notificationmetadata",
@@ -1295,7 +1307,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-customizedmetricspecification.html#cfn-autoscaling-scalingpolicy-customizedmetricspecification-statistic",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingPolicyCustomizedMetricSpecificationStatistic"
+          }
         },
         "Unit": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-customizedmetricspecification.html#cfn-autoscaling-scalingpolicy-customizedmetricspecification-unit",
@@ -1329,7 +1344,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-autoscaling-scalingpolicy-predefinedmetricspecification-predefinedmetrictype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "EC2ScalingPolicyPredifinedMetricSpecificationType"
+          }
         },
         "ResourceLabel": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-autoscaling-scalingpolicy-predefinedmetricspecification-resourcelabel",
@@ -13922,7 +13940,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-applicationautoscaling-scalingpolicy.html#cfn-applicationautoscaling-scalingpolicy-policytype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ApplicationAutoScalingPolicyType"
+          }
         },
         "ResourceId": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-applicationautoscaling-scalingpolicy.html#cfn-applicationautoscaling-scalingpolicy-resourceid",
@@ -14005,7 +14026,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-group.html#cfn-as-group-healthchecktype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingGroupHealthCheckType"
+          }
         },
         "InstanceId": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-group.html#cfn-as-group-instanceid",
@@ -14234,7 +14258,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-launchconfig.html#cfn-as-launchconfig-placementtenancy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "PlacementTenancy"
+          }
         },
         "RamDiskId": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-launchconfig.html#cfn-as-launchconfig-ramdiskid",
@@ -14281,7 +14308,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-defaultresult",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingLifecycleHookResult"
+          }
         },
         "HeartbeatTimeout": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-heartbeattimeout",
@@ -14299,7 +14329,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-lifecycletransition",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingLifecycleTransition"
+          }
         },
         "NotificationMetadata": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-notificationmetadata",
@@ -14328,7 +14361,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-adjustmenttype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingPolicyAdjustmentType"
+          }
         },
         "AutoScalingGroupName": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-autoscalinggroupname",
@@ -14352,7 +14388,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-metricaggregationtype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingPolicyMetricAggregationType"
+          }
         },
         "MinAdjustmentMagnitude": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-minadjustmentmagnitude",
@@ -14364,7 +14403,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-policytype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingPolicyType"
+          }
         },
         "ScalingAdjustment": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-scalingadjustment",
@@ -17214,7 +17256,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "VpcTenancy"
+            "ValueType": "PlacementTenancy"
           }
         },
         "Tags": {
@@ -24300,6 +24342,66 @@
         "UNIT"
       ]
     },
+    "ApplicationAutoScalingPolicyType": {
+      "AllowedValues": [
+        "StepScaling",
+        "TargetTrackingScaling"
+      ]
+    },
+    "ApplicationAutoScalingPredefinedMetricSpecificationType": {
+      "AllowedValues": [
+        "ALBRequestCountPerTarget",
+        "DynamoDBReadCapacityUtilization",
+        "DynamoDBWriteCapacityUtilization",
+        "EC2SpotFleetRequestAverageCPUUtilization",
+        "EC2SpotFleetRequestAverageNetworkIn",
+        "EC2SpotFleetRequestAverageNetworkOut",
+        "ECSServiceAverageCPUUtilization",
+        "ECSServiceAverageMemoryUtilization",
+        "RDSReaderAverageCPUUtilization",
+        "RDSReaderAverageDatabaseConnections",
+        "SageMakerVariantInvocationsPerInstance"
+      ]
+    },
+    "AutoScalingGroupHealthCheckType": {
+      "AllowedValues": [
+        "EC2",
+        "ELB"
+      ]
+    },
+    "AutoScalingLifecycleHookResult": {
+      "AllowedValues": [
+        "ABANDON",
+        "CONTINUE"
+      ]
+    },
+    "AutoScalingLifecycleTransition": {
+      "AllowedValues": [
+        "autoscaling:EC2_INSTANCE_LAUNCHING",
+        "autoscaling:EC2_INSTANCE_TERMINATING"
+      ]
+    },
+    "AutoScalingPolicyAdjustmentType": {
+      "AllowedValues": [
+        "ChangeInCapacity",
+        "ExactCapacity",
+        "PercentChangeInCapacity"
+      ]
+    },
+    "AutoScalingPolicyMetricAggregationType": {
+      "AllowedValues": [
+        "Average",
+        "Maximum",
+        "Minimum"
+      ]
+    },
+    "AutoScalingPolicyType": {
+      "AllowedValues": [
+        "SimpleScaling",
+        "StepScaling",
+        "TargetTrackingScaling"
+      ]
+    },
     "AvailabilityZone": {
       "GetAtt": {
         "AWS::EC2::Instance": "AvailabilityZone",
@@ -24352,6 +24454,14 @@
       "AllowedValues": [
         "source",
         "target"
+      ]
+    },
+    "EC2ScalingPolicyPredifinedMetricSpecificationType": {
+      "AllowedValues": [
+        "ALBRequestCountPerTarget",
+        "ASGAverageCPUUtilization",
+        "ASGAverageNetworkIn",
+        "ASGAverageNetworkOut"
       ]
     },
     "EbsVolumeType": {
@@ -24544,6 +24654,17 @@
         ]
       }
     },
+    "PlacementTenancy": {
+      "AllowedValues": [
+        "dedicated",
+        "default"
+      ],
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
+    },
     "PredicateType": {
       "AllowedValues": [
         "ByteMatch",
@@ -24585,6 +24706,49 @@
       "AllowedValues": [
         "Enabled",
         "Suspended"
+      ]
+    },
+    "ScalingInstructionPredictiveScalingMaxCapacityBehavior": {
+      "AllowedValues": [
+        "SetForecastCapacityToMaxCapacity",
+        "SetMaxCapacityToForecastCapacity",
+        "SetMaxCapacityAboveForecastCapacity"
+      ]
+    },
+    "ScalingInstructionPredictiveScalingMode": {
+      "AllowedValues": [
+        "ForecastAndScale",
+        "ForecastOnly"
+      ]
+    },
+    "ScalingInstructionScalableDimension": {
+      "AllowedValues": [
+        "autoscaling:autoScalingGroup:DesiredCapacity",
+        "ecs:service:DesiredCount",
+        "ec2:spot-fleet-request:TargetCapacity",
+        "dynamodb:table:ReadCapacityUnits",
+        "dynamodb:table:WriteCapacityUnits",
+        "dynamodb:index:ReadCapacityUnits",
+        "dynamodb:index:WriteCapacityUnits",
+        "rds:cluster:ReadReplicaCount"
+      ]
+    },
+    "ScalingInstructionServiceNamespace": {
+      "AllowedValues": [
+        "autoscaling",
+        "dynamodb",
+        "ecs",
+        "ec2",
+        "rds"
+      ]
+    },
+    "ScalingPolicyCustomizedMetricSpecificationStatistic": {
+      "AllowedValues": [
+        "Average",
+        "Minimum",
+        "Maximum",
+        "SampleCount",
+        "Sum"
       ]
     },
     "SecurityGroup": {
@@ -24707,17 +24871,6 @@
         ],
         "Resources": [
           "AWS::EC2::VPC"
-        ]
-      }
-    },
-    "VpcTenancy": {
-      "AllowedValues": [
-        "dedicated",
-        "default"
-      ],
-      "Ref": {
-        "Parameters": [
-          "String"
         ]
       }
     }

--- a/src/cfnlint/data/CloudSpecs/sa-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/sa-east-1.json
@@ -831,7 +831,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-customizedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-customizedmetricspecification-statistic",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingPolicyCustomizedMetricSpecificationStatistic"
+          }
         },
         "Unit": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-customizedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-customizedmetricspecification-unit",
@@ -865,7 +868,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-predefinedmetricspecification-predefinedmetrictype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ApplicationAutoScalingPredefinedMetricSpecificationType"
+          }
         },
         "ResourceLabel": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-predefinedmetricspecification-resourcelabel",
@@ -1077,7 +1083,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-lifecyclehookspecification.html#cfn-autoscaling-autoscalinggroup-lifecyclehookspecification-defaultresult",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingLifecycleHookResult"
+          }
         },
         "HeartbeatTimeout": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-lifecyclehookspecification.html#cfn-autoscaling-autoscalinggroup-lifecyclehookspecification-heartbeattimeout",
@@ -1095,7 +1104,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-lifecyclehookspecification.html#cfn-autoscaling-autoscalinggroup-lifecyclehookspecification-lifecycletransition",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingLifecycleTransition"
+          }
         },
         "NotificationMetadata": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-lifecyclehookspecification.html#cfn-autoscaling-autoscalinggroup-lifecyclehookspecification-notificationmetadata",
@@ -1295,7 +1307,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-customizedmetricspecification.html#cfn-autoscaling-scalingpolicy-customizedmetricspecification-statistic",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingPolicyCustomizedMetricSpecificationStatistic"
+          }
         },
         "Unit": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-customizedmetricspecification.html#cfn-autoscaling-scalingpolicy-customizedmetricspecification-unit",
@@ -1329,7 +1344,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-autoscaling-scalingpolicy-predefinedmetricspecification-predefinedmetrictype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "EC2ScalingPolicyPredifinedMetricSpecificationType"
+          }
         },
         "ResourceLabel": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-autoscaling-scalingpolicy-predefinedmetricspecification-resourcelabel",
@@ -14445,7 +14463,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-applicationautoscaling-scalingpolicy.html#cfn-applicationautoscaling-scalingpolicy-policytype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ApplicationAutoScalingPolicyType"
+          }
         },
         "ResourceId": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-applicationautoscaling-scalingpolicy.html#cfn-applicationautoscaling-scalingpolicy-resourceid",
@@ -14528,7 +14549,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-group.html#cfn-as-group-healthchecktype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingGroupHealthCheckType"
+          }
         },
         "InstanceId": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-group.html#cfn-as-group-instanceid",
@@ -14757,7 +14781,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-launchconfig.html#cfn-as-launchconfig-placementtenancy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "PlacementTenancy"
+          }
         },
         "RamDiskId": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-launchconfig.html#cfn-as-launchconfig-ramdiskid",
@@ -14804,7 +14831,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-defaultresult",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingLifecycleHookResult"
+          }
         },
         "HeartbeatTimeout": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-heartbeattimeout",
@@ -14822,7 +14852,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-lifecycletransition",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingLifecycleTransition"
+          }
         },
         "NotificationMetadata": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-notificationmetadata",
@@ -14851,7 +14884,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-adjustmenttype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingPolicyAdjustmentType"
+          }
         },
         "AutoScalingGroupName": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-autoscalinggroupname",
@@ -14875,7 +14911,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-metricaggregationtype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingPolicyMetricAggregationType"
+          }
         },
         "MinAdjustmentMagnitude": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-minadjustmentmagnitude",
@@ -14887,7 +14926,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-policytype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingPolicyType"
+          }
         },
         "ScalingAdjustment": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-scalingadjustment",
@@ -17988,7 +18030,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "VpcTenancy"
+            "ValueType": "PlacementTenancy"
           }
         },
         "Tags": {
@@ -25209,6 +25251,66 @@
         "UNIT"
       ]
     },
+    "ApplicationAutoScalingPolicyType": {
+      "AllowedValues": [
+        "StepScaling",
+        "TargetTrackingScaling"
+      ]
+    },
+    "ApplicationAutoScalingPredefinedMetricSpecificationType": {
+      "AllowedValues": [
+        "ALBRequestCountPerTarget",
+        "DynamoDBReadCapacityUtilization",
+        "DynamoDBWriteCapacityUtilization",
+        "EC2SpotFleetRequestAverageCPUUtilization",
+        "EC2SpotFleetRequestAverageNetworkIn",
+        "EC2SpotFleetRequestAverageNetworkOut",
+        "ECSServiceAverageCPUUtilization",
+        "ECSServiceAverageMemoryUtilization",
+        "RDSReaderAverageCPUUtilization",
+        "RDSReaderAverageDatabaseConnections",
+        "SageMakerVariantInvocationsPerInstance"
+      ]
+    },
+    "AutoScalingGroupHealthCheckType": {
+      "AllowedValues": [
+        "EC2",
+        "ELB"
+      ]
+    },
+    "AutoScalingLifecycleHookResult": {
+      "AllowedValues": [
+        "ABANDON",
+        "CONTINUE"
+      ]
+    },
+    "AutoScalingLifecycleTransition": {
+      "AllowedValues": [
+        "autoscaling:EC2_INSTANCE_LAUNCHING",
+        "autoscaling:EC2_INSTANCE_TERMINATING"
+      ]
+    },
+    "AutoScalingPolicyAdjustmentType": {
+      "AllowedValues": [
+        "ChangeInCapacity",
+        "ExactCapacity",
+        "PercentChangeInCapacity"
+      ]
+    },
+    "AutoScalingPolicyMetricAggregationType": {
+      "AllowedValues": [
+        "Average",
+        "Maximum",
+        "Minimum"
+      ]
+    },
+    "AutoScalingPolicyType": {
+      "AllowedValues": [
+        "SimpleScaling",
+        "StepScaling",
+        "TargetTrackingScaling"
+      ]
+    },
     "AvailabilityZone": {
       "GetAtt": {
         "AWS::EC2::Instance": "AvailabilityZone",
@@ -25261,6 +25363,14 @@
       "AllowedValues": [
         "source",
         "target"
+      ]
+    },
+    "EC2ScalingPolicyPredifinedMetricSpecificationType": {
+      "AllowedValues": [
+        "ALBRequestCountPerTarget",
+        "ASGAverageCPUUtilization",
+        "ASGAverageNetworkIn",
+        "ASGAverageNetworkOut"
       ]
     },
     "EbsVolumeType": {
@@ -25453,6 +25563,17 @@
         ]
       }
     },
+    "PlacementTenancy": {
+      "AllowedValues": [
+        "dedicated",
+        "default"
+      ],
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
+    },
     "PredicateType": {
       "AllowedValues": [
         "ByteMatch",
@@ -25494,6 +25615,49 @@
       "AllowedValues": [
         "Enabled",
         "Suspended"
+      ]
+    },
+    "ScalingInstructionPredictiveScalingMaxCapacityBehavior": {
+      "AllowedValues": [
+        "SetForecastCapacityToMaxCapacity",
+        "SetMaxCapacityToForecastCapacity",
+        "SetMaxCapacityAboveForecastCapacity"
+      ]
+    },
+    "ScalingInstructionPredictiveScalingMode": {
+      "AllowedValues": [
+        "ForecastAndScale",
+        "ForecastOnly"
+      ]
+    },
+    "ScalingInstructionScalableDimension": {
+      "AllowedValues": [
+        "autoscaling:autoScalingGroup:DesiredCapacity",
+        "ecs:service:DesiredCount",
+        "ec2:spot-fleet-request:TargetCapacity",
+        "dynamodb:table:ReadCapacityUnits",
+        "dynamodb:table:WriteCapacityUnits",
+        "dynamodb:index:ReadCapacityUnits",
+        "dynamodb:index:WriteCapacityUnits",
+        "rds:cluster:ReadReplicaCount"
+      ]
+    },
+    "ScalingInstructionServiceNamespace": {
+      "AllowedValues": [
+        "autoscaling",
+        "dynamodb",
+        "ecs",
+        "ec2",
+        "rds"
+      ]
+    },
+    "ScalingPolicyCustomizedMetricSpecificationStatistic": {
+      "AllowedValues": [
+        "Average",
+        "Minimum",
+        "Maximum",
+        "SampleCount",
+        "Sum"
       ]
     },
     "SecurityGroup": {
@@ -25616,17 +25780,6 @@
         ],
         "Resources": [
           "AWS::EC2::VPC"
-        ]
-      }
-    },
-    "VpcTenancy": {
-      "AllowedValues": [
-        "dedicated",
-        "default"
-      ],
-      "Ref": {
-        "Parameters": [
-          "String"
         ]
       }
     }

--- a/src/cfnlint/data/CloudSpecs/us-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-1.json
@@ -1368,7 +1368,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-customizedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-customizedmetricspecification-statistic",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingPolicyCustomizedMetricSpecificationStatistic"
+          }
         },
         "Unit": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-customizedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-customizedmetricspecification-unit",
@@ -1402,7 +1405,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-predefinedmetricspecification-predefinedmetrictype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ApplicationAutoScalingPredefinedMetricSpecificationType"
+          }
         },
         "ResourceLabel": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-predefinedmetricspecification-resourcelabel",
@@ -1614,7 +1620,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-lifecyclehookspecification.html#cfn-autoscaling-autoscalinggroup-lifecyclehookspecification-defaultresult",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingLifecycleHookResult"
+          }
         },
         "HeartbeatTimeout": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-lifecyclehookspecification.html#cfn-autoscaling-autoscalinggroup-lifecyclehookspecification-heartbeattimeout",
@@ -1632,7 +1641,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-lifecyclehookspecification.html#cfn-autoscaling-autoscalinggroup-lifecyclehookspecification-lifecycletransition",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingLifecycleTransition"
+          }
         },
         "NotificationMetadata": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-lifecyclehookspecification.html#cfn-autoscaling-autoscalinggroup-lifecyclehookspecification-notificationmetadata",
@@ -1832,7 +1844,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-customizedmetricspecification.html#cfn-autoscaling-scalingpolicy-customizedmetricspecification-statistic",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingPolicyCustomizedMetricSpecificationStatistic"
+          }
         },
         "Unit": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-customizedmetricspecification.html#cfn-autoscaling-scalingpolicy-customizedmetricspecification-unit",
@@ -1866,7 +1881,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-autoscaling-scalingpolicy-predefinedmetricspecification-predefinedmetrictype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "EC2ScalingPolicyPredifinedMetricSpecificationType"
+          }
         },
         "ResourceLabel": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-autoscaling-scalingpolicy-predefinedmetricspecification-resourcelabel",
@@ -2008,7 +2026,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-customizedscalingmetricspecification.html#cfn-autoscalingplans-scalingplan-customizedscalingmetricspecification-statistic",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingPolicyCustomizedMetricSpecificationStatistic"
+          }
         },
         "Unit": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-customizedscalingmetricspecification.html#cfn-autoscalingplans-scalingplan-customizedscalingmetricspecification-unit",
@@ -2059,7 +2080,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-predefinedscalingmetricspecification.html#cfn-autoscalingplans-scalingplan-predefinedscalingmetricspecification-predefinedscalingmetrictype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "EC2ScalingPolicyPredifinedMetricSpecificationType"
+          }
         },
         "ResourceLabel": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-predefinedscalingmetricspecification.html#cfn-autoscalingplans-scalingplan-predefinedscalingmetricspecification-resourcelabel",
@@ -2106,7 +2130,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-predictivescalingmaxcapacitybehavior",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingInstructionPredictiveScalingMaxCapacityBehavior"
+          }
         },
         "PredictiveScalingMaxCapacityBuffer": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-predictivescalingmaxcapacitybuffer",
@@ -2118,7 +2145,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-predictivescalingmode",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingInstructionPredictiveScalingMode"
+          }
         },
         "ResourceId": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-resourceid",
@@ -2130,7 +2160,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-scalabledimension",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingInstructionScalableDimension"
+          }
         },
         "ScalingPolicyUpdateBehavior": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-scalingpolicyupdatebehavior",
@@ -2148,7 +2181,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-servicenamespace",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingInstructionServiceNamespace"
+          }
         },
         "TargetTrackingConfigurations": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-targettrackingconfigurations",
@@ -19739,7 +19775,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-applicationautoscaling-scalingpolicy.html#cfn-applicationautoscaling-scalingpolicy-policytype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ApplicationAutoScalingPolicyType"
+          }
         },
         "ResourceId": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-applicationautoscaling-scalingpolicy.html#cfn-applicationautoscaling-scalingpolicy-resourceid",
@@ -19851,7 +19890,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-group.html#cfn-as-group-healthchecktype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingGroupHealthCheckType"
+          }
         },
         "InstanceId": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-group.html#cfn-as-group-instanceid",
@@ -20080,7 +20122,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-launchconfig.html#cfn-as-launchconfig-placementtenancy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "PlacementTenancy"
+          }
         },
         "RamDiskId": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-launchconfig.html#cfn-as-launchconfig-ramdiskid",
@@ -20127,7 +20172,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-defaultresult",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingLifecycleHookResult"
+          }
         },
         "HeartbeatTimeout": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-heartbeattimeout",
@@ -20145,7 +20193,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-lifecycletransition",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingLifecycleTransition"
+          }
         },
         "NotificationMetadata": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-notificationmetadata",
@@ -20174,7 +20225,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-adjustmenttype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingPolicyAdjustmentType"
+          }
         },
         "AutoScalingGroupName": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-autoscalinggroupname",
@@ -20198,7 +20252,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-metricaggregationtype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingPolicyMetricAggregationType"
+          }
         },
         "MinAdjustmentMagnitude": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-minadjustmentmagnitude",
@@ -20210,7 +20267,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-policytype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingPolicyType"
+          }
         },
         "ScalingAdjustment": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-scalingadjustment",
@@ -24313,7 +24373,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "VpcTenancy"
+            "ValueType": "PlacementTenancy"
           }
         },
         "Tags": {
@@ -33379,6 +33439,66 @@
         "UNIT"
       ]
     },
+    "ApplicationAutoScalingPolicyType": {
+      "AllowedValues": [
+        "StepScaling",
+        "TargetTrackingScaling"
+      ]
+    },
+    "ApplicationAutoScalingPredefinedMetricSpecificationType": {
+      "AllowedValues": [
+        "ALBRequestCountPerTarget",
+        "DynamoDBReadCapacityUtilization",
+        "DynamoDBWriteCapacityUtilization",
+        "EC2SpotFleetRequestAverageCPUUtilization",
+        "EC2SpotFleetRequestAverageNetworkIn",
+        "EC2SpotFleetRequestAverageNetworkOut",
+        "ECSServiceAverageCPUUtilization",
+        "ECSServiceAverageMemoryUtilization",
+        "RDSReaderAverageCPUUtilization",
+        "RDSReaderAverageDatabaseConnections",
+        "SageMakerVariantInvocationsPerInstance"
+      ]
+    },
+    "AutoScalingGroupHealthCheckType": {
+      "AllowedValues": [
+        "EC2",
+        "ELB"
+      ]
+    },
+    "AutoScalingLifecycleHookResult": {
+      "AllowedValues": [
+        "ABANDON",
+        "CONTINUE"
+      ]
+    },
+    "AutoScalingLifecycleTransition": {
+      "AllowedValues": [
+        "autoscaling:EC2_INSTANCE_LAUNCHING",
+        "autoscaling:EC2_INSTANCE_TERMINATING"
+      ]
+    },
+    "AutoScalingPolicyAdjustmentType": {
+      "AllowedValues": [
+        "ChangeInCapacity",
+        "ExactCapacity",
+        "PercentChangeInCapacity"
+      ]
+    },
+    "AutoScalingPolicyMetricAggregationType": {
+      "AllowedValues": [
+        "Average",
+        "Maximum",
+        "Minimum"
+      ]
+    },
+    "AutoScalingPolicyType": {
+      "AllowedValues": [
+        "SimpleScaling",
+        "StepScaling",
+        "TargetTrackingScaling"
+      ]
+    },
     "AvailabilityZone": {
       "GetAtt": {
         "AWS::EC2::Instance": "AvailabilityZone",
@@ -33431,6 +33551,14 @@
       "AllowedValues": [
         "source",
         "target"
+      ]
+    },
+    "EC2ScalingPolicyPredifinedMetricSpecificationType": {
+      "AllowedValues": [
+        "ALBRequestCountPerTarget",
+        "ASGAverageCPUUtilization",
+        "ASGAverageNetworkIn",
+        "ASGAverageNetworkOut"
       ]
     },
     "EbsVolumeType": {
@@ -33623,6 +33751,17 @@
         ]
       }
     },
+    "PlacementTenancy": {
+      "AllowedValues": [
+        "dedicated",
+        "default"
+      ],
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
+    },
     "PredicateType": {
       "AllowedValues": [
         "ByteMatch",
@@ -33664,6 +33803,49 @@
       "AllowedValues": [
         "Enabled",
         "Suspended"
+      ]
+    },
+    "ScalingInstructionPredictiveScalingMaxCapacityBehavior": {
+      "AllowedValues": [
+        "SetForecastCapacityToMaxCapacity",
+        "SetMaxCapacityToForecastCapacity",
+        "SetMaxCapacityAboveForecastCapacity"
+      ]
+    },
+    "ScalingInstructionPredictiveScalingMode": {
+      "AllowedValues": [
+        "ForecastAndScale",
+        "ForecastOnly"
+      ]
+    },
+    "ScalingInstructionScalableDimension": {
+      "AllowedValues": [
+        "autoscaling:autoScalingGroup:DesiredCapacity",
+        "ecs:service:DesiredCount",
+        "ec2:spot-fleet-request:TargetCapacity",
+        "dynamodb:table:ReadCapacityUnits",
+        "dynamodb:table:WriteCapacityUnits",
+        "dynamodb:index:ReadCapacityUnits",
+        "dynamodb:index:WriteCapacityUnits",
+        "rds:cluster:ReadReplicaCount"
+      ]
+    },
+    "ScalingInstructionServiceNamespace": {
+      "AllowedValues": [
+        "autoscaling",
+        "dynamodb",
+        "ecs",
+        "ec2",
+        "rds"
+      ]
+    },
+    "ScalingPolicyCustomizedMetricSpecificationStatistic": {
+      "AllowedValues": [
+        "Average",
+        "Minimum",
+        "Maximum",
+        "SampleCount",
+        "Sum"
       ]
     },
     "SecurityGroup": {
@@ -33786,17 +33968,6 @@
         ],
         "Resources": [
           "AWS::EC2::VPC"
-        ]
-      }
-    },
-    "VpcTenancy": {
-      "AllowedValues": [
-        "dedicated",
-        "default"
-      ],
-      "Ref": {
-        "Parameters": [
-          "String"
         ]
       }
     }

--- a/src/cfnlint/data/CloudSpecs/us-east-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-2.json
@@ -1210,7 +1210,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-customizedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-customizedmetricspecification-statistic",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingPolicyCustomizedMetricSpecificationStatistic"
+          }
         },
         "Unit": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-customizedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-customizedmetricspecification-unit",
@@ -1244,7 +1247,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-predefinedmetricspecification-predefinedmetrictype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ApplicationAutoScalingPredefinedMetricSpecificationType"
+          }
         },
         "ResourceLabel": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-predefinedmetricspecification-resourcelabel",
@@ -1456,7 +1462,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-lifecyclehookspecification.html#cfn-autoscaling-autoscalinggroup-lifecyclehookspecification-defaultresult",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingLifecycleHookResult"
+          }
         },
         "HeartbeatTimeout": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-lifecyclehookspecification.html#cfn-autoscaling-autoscalinggroup-lifecyclehookspecification-heartbeattimeout",
@@ -1474,7 +1483,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-lifecyclehookspecification.html#cfn-autoscaling-autoscalinggroup-lifecyclehookspecification-lifecycletransition",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingLifecycleTransition"
+          }
         },
         "NotificationMetadata": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-lifecyclehookspecification.html#cfn-autoscaling-autoscalinggroup-lifecyclehookspecification-notificationmetadata",
@@ -1674,7 +1686,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-customizedmetricspecification.html#cfn-autoscaling-scalingpolicy-customizedmetricspecification-statistic",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingPolicyCustomizedMetricSpecificationStatistic"
+          }
         },
         "Unit": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-customizedmetricspecification.html#cfn-autoscaling-scalingpolicy-customizedmetricspecification-unit",
@@ -1708,7 +1723,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-autoscaling-scalingpolicy-predefinedmetricspecification-predefinedmetrictype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "EC2ScalingPolicyPredifinedMetricSpecificationType"
+          }
         },
         "ResourceLabel": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-autoscaling-scalingpolicy-predefinedmetricspecification-resourcelabel",
@@ -1850,7 +1868,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-customizedscalingmetricspecification.html#cfn-autoscalingplans-scalingplan-customizedscalingmetricspecification-statistic",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingPolicyCustomizedMetricSpecificationStatistic"
+          }
         },
         "Unit": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-customizedscalingmetricspecification.html#cfn-autoscalingplans-scalingplan-customizedscalingmetricspecification-unit",
@@ -1901,7 +1922,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-predefinedscalingmetricspecification.html#cfn-autoscalingplans-scalingplan-predefinedscalingmetricspecification-predefinedscalingmetrictype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "EC2ScalingPolicyPredifinedMetricSpecificationType"
+          }
         },
         "ResourceLabel": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-predefinedscalingmetricspecification.html#cfn-autoscalingplans-scalingplan-predefinedscalingmetricspecification-resourcelabel",
@@ -1948,7 +1972,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-predictivescalingmaxcapacitybehavior",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingInstructionPredictiveScalingMaxCapacityBehavior"
+          }
         },
         "PredictiveScalingMaxCapacityBuffer": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-predictivescalingmaxcapacitybuffer",
@@ -1960,7 +1987,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-predictivescalingmode",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingInstructionPredictiveScalingMode"
+          }
         },
         "ResourceId": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-resourceid",
@@ -1972,7 +2002,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-scalabledimension",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingInstructionScalableDimension"
+          }
         },
         "ScalingPolicyUpdateBehavior": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-scalingpolicyupdatebehavior",
@@ -1990,7 +2023,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-servicenamespace",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingInstructionServiceNamespace"
+          }
         },
         "TargetTrackingConfigurations": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-targettrackingconfigurations",
@@ -18297,7 +18333,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-applicationautoscaling-scalingpolicy.html#cfn-applicationautoscaling-scalingpolicy-policytype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ApplicationAutoScalingPolicyType"
+          }
         },
         "ResourceId": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-applicationautoscaling-scalingpolicy.html#cfn-applicationautoscaling-scalingpolicy-resourceid",
@@ -18409,7 +18448,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-group.html#cfn-as-group-healthchecktype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingGroupHealthCheckType"
+          }
         },
         "InstanceId": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-group.html#cfn-as-group-instanceid",
@@ -18638,7 +18680,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-launchconfig.html#cfn-as-launchconfig-placementtenancy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "PlacementTenancy"
+          }
         },
         "RamDiskId": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-launchconfig.html#cfn-as-launchconfig-ramdiskid",
@@ -18685,7 +18730,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-defaultresult",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingLifecycleHookResult"
+          }
         },
         "HeartbeatTimeout": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-heartbeattimeout",
@@ -18703,7 +18751,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-lifecycletransition",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingLifecycleTransition"
+          }
         },
         "NotificationMetadata": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-notificationmetadata",
@@ -18732,7 +18783,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-adjustmenttype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingPolicyAdjustmentType"
+          }
         },
         "AutoScalingGroupName": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-autoscalinggroupname",
@@ -18756,7 +18810,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-metricaggregationtype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingPolicyMetricAggregationType"
+          }
         },
         "MinAdjustmentMagnitude": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-minadjustmentmagnitude",
@@ -18768,7 +18825,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-policytype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingPolicyType"
+          }
         },
         "ScalingAdjustment": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-scalingadjustment",
@@ -22613,7 +22673,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "VpcTenancy"
+            "ValueType": "PlacementTenancy"
           }
         },
         "Tags": {
@@ -31395,6 +31455,66 @@
         "UNIT"
       ]
     },
+    "ApplicationAutoScalingPolicyType": {
+      "AllowedValues": [
+        "StepScaling",
+        "TargetTrackingScaling"
+      ]
+    },
+    "ApplicationAutoScalingPredefinedMetricSpecificationType": {
+      "AllowedValues": [
+        "ALBRequestCountPerTarget",
+        "DynamoDBReadCapacityUtilization",
+        "DynamoDBWriteCapacityUtilization",
+        "EC2SpotFleetRequestAverageCPUUtilization",
+        "EC2SpotFleetRequestAverageNetworkIn",
+        "EC2SpotFleetRequestAverageNetworkOut",
+        "ECSServiceAverageCPUUtilization",
+        "ECSServiceAverageMemoryUtilization",
+        "RDSReaderAverageCPUUtilization",
+        "RDSReaderAverageDatabaseConnections",
+        "SageMakerVariantInvocationsPerInstance"
+      ]
+    },
+    "AutoScalingGroupHealthCheckType": {
+      "AllowedValues": [
+        "EC2",
+        "ELB"
+      ]
+    },
+    "AutoScalingLifecycleHookResult": {
+      "AllowedValues": [
+        "ABANDON",
+        "CONTINUE"
+      ]
+    },
+    "AutoScalingLifecycleTransition": {
+      "AllowedValues": [
+        "autoscaling:EC2_INSTANCE_LAUNCHING",
+        "autoscaling:EC2_INSTANCE_TERMINATING"
+      ]
+    },
+    "AutoScalingPolicyAdjustmentType": {
+      "AllowedValues": [
+        "ChangeInCapacity",
+        "ExactCapacity",
+        "PercentChangeInCapacity"
+      ]
+    },
+    "AutoScalingPolicyMetricAggregationType": {
+      "AllowedValues": [
+        "Average",
+        "Maximum",
+        "Minimum"
+      ]
+    },
+    "AutoScalingPolicyType": {
+      "AllowedValues": [
+        "SimpleScaling",
+        "StepScaling",
+        "TargetTrackingScaling"
+      ]
+    },
     "AvailabilityZone": {
       "GetAtt": {
         "AWS::EC2::Instance": "AvailabilityZone",
@@ -31447,6 +31567,14 @@
       "AllowedValues": [
         "source",
         "target"
+      ]
+    },
+    "EC2ScalingPolicyPredifinedMetricSpecificationType": {
+      "AllowedValues": [
+        "ALBRequestCountPerTarget",
+        "ASGAverageCPUUtilization",
+        "ASGAverageNetworkIn",
+        "ASGAverageNetworkOut"
       ]
     },
     "EbsVolumeType": {
@@ -31639,6 +31767,17 @@
         ]
       }
     },
+    "PlacementTenancy": {
+      "AllowedValues": [
+        "dedicated",
+        "default"
+      ],
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
+    },
     "PredicateType": {
       "AllowedValues": [
         "ByteMatch",
@@ -31680,6 +31819,49 @@
       "AllowedValues": [
         "Enabled",
         "Suspended"
+      ]
+    },
+    "ScalingInstructionPredictiveScalingMaxCapacityBehavior": {
+      "AllowedValues": [
+        "SetForecastCapacityToMaxCapacity",
+        "SetMaxCapacityToForecastCapacity",
+        "SetMaxCapacityAboveForecastCapacity"
+      ]
+    },
+    "ScalingInstructionPredictiveScalingMode": {
+      "AllowedValues": [
+        "ForecastAndScale",
+        "ForecastOnly"
+      ]
+    },
+    "ScalingInstructionScalableDimension": {
+      "AllowedValues": [
+        "autoscaling:autoScalingGroup:DesiredCapacity",
+        "ecs:service:DesiredCount",
+        "ec2:spot-fleet-request:TargetCapacity",
+        "dynamodb:table:ReadCapacityUnits",
+        "dynamodb:table:WriteCapacityUnits",
+        "dynamodb:index:ReadCapacityUnits",
+        "dynamodb:index:WriteCapacityUnits",
+        "rds:cluster:ReadReplicaCount"
+      ]
+    },
+    "ScalingInstructionServiceNamespace": {
+      "AllowedValues": [
+        "autoscaling",
+        "dynamodb",
+        "ecs",
+        "ec2",
+        "rds"
+      ]
+    },
+    "ScalingPolicyCustomizedMetricSpecificationStatistic": {
+      "AllowedValues": [
+        "Average",
+        "Minimum",
+        "Maximum",
+        "SampleCount",
+        "Sum"
       ]
     },
     "SecurityGroup": {
@@ -31802,17 +31984,6 @@
         ],
         "Resources": [
           "AWS::EC2::VPC"
-        ]
-      }
-    },
-    "VpcTenancy": {
-      "AllowedValues": [
-        "dedicated",
-        "default"
-      ],
-      "Ref": {
-        "Parameters": [
-          "String"
         ]
       }
     }

--- a/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
@@ -831,7 +831,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-customizedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-customizedmetricspecification-statistic",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingPolicyCustomizedMetricSpecificationStatistic"
+          }
         },
         "Unit": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-customizedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-customizedmetricspecification-unit",
@@ -865,7 +868,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-predefinedmetricspecification-predefinedmetrictype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ApplicationAutoScalingPredefinedMetricSpecificationType"
+          }
         },
         "ResourceLabel": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-predefinedmetricspecification-resourcelabel",
@@ -1077,7 +1083,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-lifecyclehookspecification.html#cfn-autoscaling-autoscalinggroup-lifecyclehookspecification-defaultresult",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingLifecycleHookResult"
+          }
         },
         "HeartbeatTimeout": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-lifecyclehookspecification.html#cfn-autoscaling-autoscalinggroup-lifecyclehookspecification-heartbeattimeout",
@@ -1095,7 +1104,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-lifecyclehookspecification.html#cfn-autoscaling-autoscalinggroup-lifecyclehookspecification-lifecycletransition",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingLifecycleTransition"
+          }
         },
         "NotificationMetadata": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-lifecyclehookspecification.html#cfn-autoscaling-autoscalinggroup-lifecyclehookspecification-notificationmetadata",
@@ -1295,7 +1307,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-customizedmetricspecification.html#cfn-autoscaling-scalingpolicy-customizedmetricspecification-statistic",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingPolicyCustomizedMetricSpecificationStatistic"
+          }
         },
         "Unit": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-customizedmetricspecification.html#cfn-autoscaling-scalingpolicy-customizedmetricspecification-unit",
@@ -1329,7 +1344,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-autoscaling-scalingpolicy-predefinedmetricspecification-predefinedmetrictype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "EC2ScalingPolicyPredifinedMetricSpecificationType"
+          }
         },
         "ResourceLabel": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-autoscaling-scalingpolicy-predefinedmetricspecification-resourcelabel",
@@ -11657,7 +11675,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-applicationautoscaling-scalingpolicy.html#cfn-applicationautoscaling-scalingpolicy-policytype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ApplicationAutoScalingPolicyType"
+          }
         },
         "ResourceId": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-applicationautoscaling-scalingpolicy.html#cfn-applicationautoscaling-scalingpolicy-resourceid",
@@ -11740,7 +11761,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-group.html#cfn-as-group-healthchecktype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingGroupHealthCheckType"
+          }
         },
         "InstanceId": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-group.html#cfn-as-group-instanceid",
@@ -11969,7 +11993,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-launchconfig.html#cfn-as-launchconfig-placementtenancy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "PlacementTenancy"
+          }
         },
         "RamDiskId": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-launchconfig.html#cfn-as-launchconfig-ramdiskid",
@@ -12016,7 +12043,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-defaultresult",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingLifecycleHookResult"
+          }
         },
         "HeartbeatTimeout": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-heartbeattimeout",
@@ -12034,7 +12064,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-lifecycletransition",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingLifecycleTransition"
+          }
         },
         "NotificationMetadata": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-notificationmetadata",
@@ -12063,7 +12096,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-adjustmenttype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingPolicyAdjustmentType"
+          }
         },
         "AutoScalingGroupName": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-autoscalinggroupname",
@@ -12087,7 +12123,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-metricaggregationtype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingPolicyMetricAggregationType"
+          }
         },
         "MinAdjustmentMagnitude": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-minadjustmentmagnitude",
@@ -12099,7 +12138,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-policytype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingPolicyType"
+          }
         },
         "ScalingAdjustment": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-scalingadjustment",
@@ -14446,7 +14488,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "VpcTenancy"
+            "ValueType": "PlacementTenancy"
           }
         },
         "Tags": {
@@ -20531,6 +20573,66 @@
         "UNIT"
       ]
     },
+    "ApplicationAutoScalingPolicyType": {
+      "AllowedValues": [
+        "StepScaling",
+        "TargetTrackingScaling"
+      ]
+    },
+    "ApplicationAutoScalingPredefinedMetricSpecificationType": {
+      "AllowedValues": [
+        "ALBRequestCountPerTarget",
+        "DynamoDBReadCapacityUtilization",
+        "DynamoDBWriteCapacityUtilization",
+        "EC2SpotFleetRequestAverageCPUUtilization",
+        "EC2SpotFleetRequestAverageNetworkIn",
+        "EC2SpotFleetRequestAverageNetworkOut",
+        "ECSServiceAverageCPUUtilization",
+        "ECSServiceAverageMemoryUtilization",
+        "RDSReaderAverageCPUUtilization",
+        "RDSReaderAverageDatabaseConnections",
+        "SageMakerVariantInvocationsPerInstance"
+      ]
+    },
+    "AutoScalingGroupHealthCheckType": {
+      "AllowedValues": [
+        "EC2",
+        "ELB"
+      ]
+    },
+    "AutoScalingLifecycleHookResult": {
+      "AllowedValues": [
+        "ABANDON",
+        "CONTINUE"
+      ]
+    },
+    "AutoScalingLifecycleTransition": {
+      "AllowedValues": [
+        "autoscaling:EC2_INSTANCE_LAUNCHING",
+        "autoscaling:EC2_INSTANCE_TERMINATING"
+      ]
+    },
+    "AutoScalingPolicyAdjustmentType": {
+      "AllowedValues": [
+        "ChangeInCapacity",
+        "ExactCapacity",
+        "PercentChangeInCapacity"
+      ]
+    },
+    "AutoScalingPolicyMetricAggregationType": {
+      "AllowedValues": [
+        "Average",
+        "Maximum",
+        "Minimum"
+      ]
+    },
+    "AutoScalingPolicyType": {
+      "AllowedValues": [
+        "SimpleScaling",
+        "StepScaling",
+        "TargetTrackingScaling"
+      ]
+    },
     "AvailabilityZone": {
       "GetAtt": {
         "AWS::EC2::Instance": "AvailabilityZone",
@@ -20583,6 +20685,14 @@
       "AllowedValues": [
         "source",
         "target"
+      ]
+    },
+    "EC2ScalingPolicyPredifinedMetricSpecificationType": {
+      "AllowedValues": [
+        "ALBRequestCountPerTarget",
+        "ASGAverageCPUUtilization",
+        "ASGAverageNetworkIn",
+        "ASGAverageNetworkOut"
       ]
     },
     "EbsVolumeType": {
@@ -20775,6 +20885,17 @@
         ]
       }
     },
+    "PlacementTenancy": {
+      "AllowedValues": [
+        "dedicated",
+        "default"
+      ],
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
+    },
     "PredicateType": {
       "AllowedValues": [
         "ByteMatch",
@@ -20816,6 +20937,49 @@
       "AllowedValues": [
         "Enabled",
         "Suspended"
+      ]
+    },
+    "ScalingInstructionPredictiveScalingMaxCapacityBehavior": {
+      "AllowedValues": [
+        "SetForecastCapacityToMaxCapacity",
+        "SetMaxCapacityToForecastCapacity",
+        "SetMaxCapacityAboveForecastCapacity"
+      ]
+    },
+    "ScalingInstructionPredictiveScalingMode": {
+      "AllowedValues": [
+        "ForecastAndScale",
+        "ForecastOnly"
+      ]
+    },
+    "ScalingInstructionScalableDimension": {
+      "AllowedValues": [
+        "autoscaling:autoScalingGroup:DesiredCapacity",
+        "ecs:service:DesiredCount",
+        "ec2:spot-fleet-request:TargetCapacity",
+        "dynamodb:table:ReadCapacityUnits",
+        "dynamodb:table:WriteCapacityUnits",
+        "dynamodb:index:ReadCapacityUnits",
+        "dynamodb:index:WriteCapacityUnits",
+        "rds:cluster:ReadReplicaCount"
+      ]
+    },
+    "ScalingInstructionServiceNamespace": {
+      "AllowedValues": [
+        "autoscaling",
+        "dynamodb",
+        "ecs",
+        "ec2",
+        "rds"
+      ]
+    },
+    "ScalingPolicyCustomizedMetricSpecificationStatistic": {
+      "AllowedValues": [
+        "Average",
+        "Minimum",
+        "Maximum",
+        "SampleCount",
+        "Sum"
       ]
     },
     "SecurityGroup": {
@@ -20938,17 +21102,6 @@
         ],
         "Resources": [
           "AWS::EC2::VPC"
-        ]
-      }
-    },
-    "VpcTenancy": {
-      "AllowedValues": [
-        "dedicated",
-        "default"
-      ],
-      "Ref": {
-        "Parameters": [
-          "String"
         ]
       }
     }

--- a/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
@@ -831,7 +831,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-customizedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-customizedmetricspecification-statistic",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingPolicyCustomizedMetricSpecificationStatistic"
+          }
         },
         "Unit": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-customizedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-customizedmetricspecification-unit",
@@ -865,7 +868,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-predefinedmetricspecification-predefinedmetrictype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ApplicationAutoScalingPredefinedMetricSpecificationType"
+          }
         },
         "ResourceLabel": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-predefinedmetricspecification-resourcelabel",
@@ -1077,7 +1083,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-lifecyclehookspecification.html#cfn-autoscaling-autoscalinggroup-lifecyclehookspecification-defaultresult",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingLifecycleHookResult"
+          }
         },
         "HeartbeatTimeout": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-lifecyclehookspecification.html#cfn-autoscaling-autoscalinggroup-lifecyclehookspecification-heartbeattimeout",
@@ -1095,7 +1104,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-lifecyclehookspecification.html#cfn-autoscaling-autoscalinggroup-lifecyclehookspecification-lifecycletransition",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingLifecycleTransition"
+          }
         },
         "NotificationMetadata": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-lifecyclehookspecification.html#cfn-autoscaling-autoscalinggroup-lifecyclehookspecification-notificationmetadata",
@@ -1295,7 +1307,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-customizedmetricspecification.html#cfn-autoscaling-scalingpolicy-customizedmetricspecification-statistic",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingPolicyCustomizedMetricSpecificationStatistic"
+          }
         },
         "Unit": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-customizedmetricspecification.html#cfn-autoscaling-scalingpolicy-customizedmetricspecification-unit",
@@ -1329,7 +1344,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-autoscaling-scalingpolicy-predefinedmetricspecification-predefinedmetrictype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "EC2ScalingPolicyPredifinedMetricSpecificationType"
+          }
         },
         "ResourceLabel": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-autoscaling-scalingpolicy-predefinedmetricspecification-resourcelabel",
@@ -11704,7 +11722,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-applicationautoscaling-scalingpolicy.html#cfn-applicationautoscaling-scalingpolicy-policytype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ApplicationAutoScalingPolicyType"
+          }
         },
         "ResourceId": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-applicationautoscaling-scalingpolicy.html#cfn-applicationautoscaling-scalingpolicy-resourceid",
@@ -11787,7 +11808,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-group.html#cfn-as-group-healthchecktype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingGroupHealthCheckType"
+          }
         },
         "InstanceId": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-group.html#cfn-as-group-instanceid",
@@ -12016,7 +12040,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-launchconfig.html#cfn-as-launchconfig-placementtenancy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "PlacementTenancy"
+          }
         },
         "RamDiskId": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-launchconfig.html#cfn-as-launchconfig-ramdiskid",
@@ -12063,7 +12090,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-defaultresult",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingLifecycleHookResult"
+          }
         },
         "HeartbeatTimeout": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-heartbeattimeout",
@@ -12081,7 +12111,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-lifecycletransition",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingLifecycleTransition"
+          }
         },
         "NotificationMetadata": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-notificationmetadata",
@@ -12110,7 +12143,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-adjustmenttype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingPolicyAdjustmentType"
+          }
         },
         "AutoScalingGroupName": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-autoscalinggroupname",
@@ -12134,7 +12170,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-metricaggregationtype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingPolicyMetricAggregationType"
+          }
         },
         "MinAdjustmentMagnitude": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-minadjustmentmagnitude",
@@ -12146,7 +12185,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-policytype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingPolicyType"
+          }
         },
         "ScalingAdjustment": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-scalingadjustment",
@@ -14493,7 +14535,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "VpcTenancy"
+            "ValueType": "PlacementTenancy"
           }
         },
         "Tags": {
@@ -20689,6 +20731,66 @@
         "UNIT"
       ]
     },
+    "ApplicationAutoScalingPolicyType": {
+      "AllowedValues": [
+        "StepScaling",
+        "TargetTrackingScaling"
+      ]
+    },
+    "ApplicationAutoScalingPredefinedMetricSpecificationType": {
+      "AllowedValues": [
+        "ALBRequestCountPerTarget",
+        "DynamoDBReadCapacityUtilization",
+        "DynamoDBWriteCapacityUtilization",
+        "EC2SpotFleetRequestAverageCPUUtilization",
+        "EC2SpotFleetRequestAverageNetworkIn",
+        "EC2SpotFleetRequestAverageNetworkOut",
+        "ECSServiceAverageCPUUtilization",
+        "ECSServiceAverageMemoryUtilization",
+        "RDSReaderAverageCPUUtilization",
+        "RDSReaderAverageDatabaseConnections",
+        "SageMakerVariantInvocationsPerInstance"
+      ]
+    },
+    "AutoScalingGroupHealthCheckType": {
+      "AllowedValues": [
+        "EC2",
+        "ELB"
+      ]
+    },
+    "AutoScalingLifecycleHookResult": {
+      "AllowedValues": [
+        "ABANDON",
+        "CONTINUE"
+      ]
+    },
+    "AutoScalingLifecycleTransition": {
+      "AllowedValues": [
+        "autoscaling:EC2_INSTANCE_LAUNCHING",
+        "autoscaling:EC2_INSTANCE_TERMINATING"
+      ]
+    },
+    "AutoScalingPolicyAdjustmentType": {
+      "AllowedValues": [
+        "ChangeInCapacity",
+        "ExactCapacity",
+        "PercentChangeInCapacity"
+      ]
+    },
+    "AutoScalingPolicyMetricAggregationType": {
+      "AllowedValues": [
+        "Average",
+        "Maximum",
+        "Minimum"
+      ]
+    },
+    "AutoScalingPolicyType": {
+      "AllowedValues": [
+        "SimpleScaling",
+        "StepScaling",
+        "TargetTrackingScaling"
+      ]
+    },
     "AvailabilityZone": {
       "GetAtt": {
         "AWS::EC2::Instance": "AvailabilityZone",
@@ -20741,6 +20843,14 @@
       "AllowedValues": [
         "source",
         "target"
+      ]
+    },
+    "EC2ScalingPolicyPredifinedMetricSpecificationType": {
+      "AllowedValues": [
+        "ALBRequestCountPerTarget",
+        "ASGAverageCPUUtilization",
+        "ASGAverageNetworkIn",
+        "ASGAverageNetworkOut"
       ]
     },
     "EbsVolumeType": {
@@ -20933,6 +21043,17 @@
         ]
       }
     },
+    "PlacementTenancy": {
+      "AllowedValues": [
+        "dedicated",
+        "default"
+      ],
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
+    },
     "PredicateType": {
       "AllowedValues": [
         "ByteMatch",
@@ -20974,6 +21095,49 @@
       "AllowedValues": [
         "Enabled",
         "Suspended"
+      ]
+    },
+    "ScalingInstructionPredictiveScalingMaxCapacityBehavior": {
+      "AllowedValues": [
+        "SetForecastCapacityToMaxCapacity",
+        "SetMaxCapacityToForecastCapacity",
+        "SetMaxCapacityAboveForecastCapacity"
+      ]
+    },
+    "ScalingInstructionPredictiveScalingMode": {
+      "AllowedValues": [
+        "ForecastAndScale",
+        "ForecastOnly"
+      ]
+    },
+    "ScalingInstructionScalableDimension": {
+      "AllowedValues": [
+        "autoscaling:autoScalingGroup:DesiredCapacity",
+        "ecs:service:DesiredCount",
+        "ec2:spot-fleet-request:TargetCapacity",
+        "dynamodb:table:ReadCapacityUnits",
+        "dynamodb:table:WriteCapacityUnits",
+        "dynamodb:index:ReadCapacityUnits",
+        "dynamodb:index:WriteCapacityUnits",
+        "rds:cluster:ReadReplicaCount"
+      ]
+    },
+    "ScalingInstructionServiceNamespace": {
+      "AllowedValues": [
+        "autoscaling",
+        "dynamodb",
+        "ecs",
+        "ec2",
+        "rds"
+      ]
+    },
+    "ScalingPolicyCustomizedMetricSpecificationStatistic": {
+      "AllowedValues": [
+        "Average",
+        "Minimum",
+        "Maximum",
+        "SampleCount",
+        "Sum"
       ]
     },
     "SecurityGroup": {
@@ -21096,17 +21260,6 @@
         ],
         "Resources": [
           "AWS::EC2::VPC"
-        ]
-      }
-    },
-    "VpcTenancy": {
-      "AllowedValues": [
-        "dedicated",
-        "default"
-      ],
-      "Ref": {
-        "Parameters": [
-          "String"
         ]
       }
     }

--- a/src/cfnlint/data/CloudSpecs/us-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-1.json
@@ -969,7 +969,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-customizedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-customizedmetricspecification-statistic",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingPolicyCustomizedMetricSpecificationStatistic"
+          }
         },
         "Unit": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-customizedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-customizedmetricspecification-unit",
@@ -1003,7 +1006,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-predefinedmetricspecification-predefinedmetrictype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ApplicationAutoScalingPredefinedMetricSpecificationType"
+          }
         },
         "ResourceLabel": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-predefinedmetricspecification-resourcelabel",
@@ -1215,7 +1221,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-lifecyclehookspecification.html#cfn-autoscaling-autoscalinggroup-lifecyclehookspecification-defaultresult",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingLifecycleHookResult"
+          }
         },
         "HeartbeatTimeout": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-lifecyclehookspecification.html#cfn-autoscaling-autoscalinggroup-lifecyclehookspecification-heartbeattimeout",
@@ -1233,7 +1242,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-lifecyclehookspecification.html#cfn-autoscaling-autoscalinggroup-lifecyclehookspecification-lifecycletransition",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingLifecycleTransition"
+          }
         },
         "NotificationMetadata": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-lifecyclehookspecification.html#cfn-autoscaling-autoscalinggroup-lifecyclehookspecification-notificationmetadata",
@@ -1433,7 +1445,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-customizedmetricspecification.html#cfn-autoscaling-scalingpolicy-customizedmetricspecification-statistic",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingPolicyCustomizedMetricSpecificationStatistic"
+          }
         },
         "Unit": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-customizedmetricspecification.html#cfn-autoscaling-scalingpolicy-customizedmetricspecification-unit",
@@ -1467,7 +1482,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-autoscaling-scalingpolicy-predefinedmetricspecification-predefinedmetrictype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "EC2ScalingPolicyPredifinedMetricSpecificationType"
+          }
         },
         "ResourceLabel": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-autoscaling-scalingpolicy-predefinedmetricspecification-resourcelabel",
@@ -1609,7 +1627,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-customizedscalingmetricspecification.html#cfn-autoscalingplans-scalingplan-customizedscalingmetricspecification-statistic",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingPolicyCustomizedMetricSpecificationStatistic"
+          }
         },
         "Unit": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-customizedscalingmetricspecification.html#cfn-autoscalingplans-scalingplan-customizedscalingmetricspecification-unit",
@@ -1660,7 +1681,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-predefinedscalingmetricspecification.html#cfn-autoscalingplans-scalingplan-predefinedscalingmetricspecification-predefinedscalingmetrictype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "EC2ScalingPolicyPredifinedMetricSpecificationType"
+          }
         },
         "ResourceLabel": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-predefinedscalingmetricspecification.html#cfn-autoscalingplans-scalingplan-predefinedscalingmetricspecification-resourcelabel",
@@ -1707,7 +1731,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-predictivescalingmaxcapacitybehavior",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingInstructionPredictiveScalingMaxCapacityBehavior"
+          }
         },
         "PredictiveScalingMaxCapacityBuffer": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-predictivescalingmaxcapacitybuffer",
@@ -1719,7 +1746,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-predictivescalingmode",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingInstructionPredictiveScalingMode"
+          }
         },
         "ResourceId": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-resourceid",
@@ -1731,7 +1761,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-scalabledimension",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingInstructionScalableDimension"
+          }
         },
         "ScalingPolicyUpdateBehavior": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-scalingpolicyupdatebehavior",
@@ -1749,7 +1782,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-servicenamespace",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingInstructionServiceNamespace"
+          }
         },
         "TargetTrackingConfigurations": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-targettrackingconfigurations",
@@ -15230,7 +15266,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-applicationautoscaling-scalingpolicy.html#cfn-applicationautoscaling-scalingpolicy-policytype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ApplicationAutoScalingPolicyType"
+          }
         },
         "ResourceId": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-applicationautoscaling-scalingpolicy.html#cfn-applicationautoscaling-scalingpolicy-resourceid",
@@ -15313,7 +15352,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-group.html#cfn-as-group-healthchecktype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingGroupHealthCheckType"
+          }
         },
         "InstanceId": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-group.html#cfn-as-group-instanceid",
@@ -15542,7 +15584,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-launchconfig.html#cfn-as-launchconfig-placementtenancy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "PlacementTenancy"
+          }
         },
         "RamDiskId": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-launchconfig.html#cfn-as-launchconfig-ramdiskid",
@@ -15589,7 +15634,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-defaultresult",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingLifecycleHookResult"
+          }
         },
         "HeartbeatTimeout": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-heartbeattimeout",
@@ -15607,7 +15655,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-lifecycletransition",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingLifecycleTransition"
+          }
         },
         "NotificationMetadata": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-notificationmetadata",
@@ -15636,7 +15687,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-adjustmenttype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingPolicyAdjustmentType"
+          }
         },
         "AutoScalingGroupName": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-autoscalinggroupname",
@@ -15660,7 +15714,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-metricaggregationtype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingPolicyMetricAggregationType"
+          }
         },
         "MinAdjustmentMagnitude": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-minadjustmentmagnitude",
@@ -15672,7 +15729,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-policytype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingPolicyType"
+          }
         },
         "ScalingAdjustment": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-scalingadjustment",
@@ -19149,7 +19209,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "VpcTenancy"
+            "ValueType": "PlacementTenancy"
           }
         },
         "Tags": {
@@ -26651,6 +26711,66 @@
         "UNIT"
       ]
     },
+    "ApplicationAutoScalingPolicyType": {
+      "AllowedValues": [
+        "StepScaling",
+        "TargetTrackingScaling"
+      ]
+    },
+    "ApplicationAutoScalingPredefinedMetricSpecificationType": {
+      "AllowedValues": [
+        "ALBRequestCountPerTarget",
+        "DynamoDBReadCapacityUtilization",
+        "DynamoDBWriteCapacityUtilization",
+        "EC2SpotFleetRequestAverageCPUUtilization",
+        "EC2SpotFleetRequestAverageNetworkIn",
+        "EC2SpotFleetRequestAverageNetworkOut",
+        "ECSServiceAverageCPUUtilization",
+        "ECSServiceAverageMemoryUtilization",
+        "RDSReaderAverageCPUUtilization",
+        "RDSReaderAverageDatabaseConnections",
+        "SageMakerVariantInvocationsPerInstance"
+      ]
+    },
+    "AutoScalingGroupHealthCheckType": {
+      "AllowedValues": [
+        "EC2",
+        "ELB"
+      ]
+    },
+    "AutoScalingLifecycleHookResult": {
+      "AllowedValues": [
+        "ABANDON",
+        "CONTINUE"
+      ]
+    },
+    "AutoScalingLifecycleTransition": {
+      "AllowedValues": [
+        "autoscaling:EC2_INSTANCE_LAUNCHING",
+        "autoscaling:EC2_INSTANCE_TERMINATING"
+      ]
+    },
+    "AutoScalingPolicyAdjustmentType": {
+      "AllowedValues": [
+        "ChangeInCapacity",
+        "ExactCapacity",
+        "PercentChangeInCapacity"
+      ]
+    },
+    "AutoScalingPolicyMetricAggregationType": {
+      "AllowedValues": [
+        "Average",
+        "Maximum",
+        "Minimum"
+      ]
+    },
+    "AutoScalingPolicyType": {
+      "AllowedValues": [
+        "SimpleScaling",
+        "StepScaling",
+        "TargetTrackingScaling"
+      ]
+    },
     "AvailabilityZone": {
       "GetAtt": {
         "AWS::EC2::Instance": "AvailabilityZone",
@@ -26703,6 +26823,14 @@
       "AllowedValues": [
         "source",
         "target"
+      ]
+    },
+    "EC2ScalingPolicyPredifinedMetricSpecificationType": {
+      "AllowedValues": [
+        "ALBRequestCountPerTarget",
+        "ASGAverageCPUUtilization",
+        "ASGAverageNetworkIn",
+        "ASGAverageNetworkOut"
       ]
     },
     "EbsVolumeType": {
@@ -26895,6 +27023,17 @@
         ]
       }
     },
+    "PlacementTenancy": {
+      "AllowedValues": [
+        "dedicated",
+        "default"
+      ],
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
+    },
     "PredicateType": {
       "AllowedValues": [
         "ByteMatch",
@@ -26936,6 +27075,49 @@
       "AllowedValues": [
         "Enabled",
         "Suspended"
+      ]
+    },
+    "ScalingInstructionPredictiveScalingMaxCapacityBehavior": {
+      "AllowedValues": [
+        "SetForecastCapacityToMaxCapacity",
+        "SetMaxCapacityToForecastCapacity",
+        "SetMaxCapacityAboveForecastCapacity"
+      ]
+    },
+    "ScalingInstructionPredictiveScalingMode": {
+      "AllowedValues": [
+        "ForecastAndScale",
+        "ForecastOnly"
+      ]
+    },
+    "ScalingInstructionScalableDimension": {
+      "AllowedValues": [
+        "autoscaling:autoScalingGroup:DesiredCapacity",
+        "ecs:service:DesiredCount",
+        "ec2:spot-fleet-request:TargetCapacity",
+        "dynamodb:table:ReadCapacityUnits",
+        "dynamodb:table:WriteCapacityUnits",
+        "dynamodb:index:ReadCapacityUnits",
+        "dynamodb:index:WriteCapacityUnits",
+        "rds:cluster:ReadReplicaCount"
+      ]
+    },
+    "ScalingInstructionServiceNamespace": {
+      "AllowedValues": [
+        "autoscaling",
+        "dynamodb",
+        "ecs",
+        "ec2",
+        "rds"
+      ]
+    },
+    "ScalingPolicyCustomizedMetricSpecificationStatistic": {
+      "AllowedValues": [
+        "Average",
+        "Minimum",
+        "Maximum",
+        "SampleCount",
+        "Sum"
       ]
     },
     "SecurityGroup": {
@@ -27058,17 +27240,6 @@
         ],
         "Resources": [
           "AWS::EC2::VPC"
-        ]
-      }
-    },
-    "VpcTenancy": {
-      "AllowedValues": [
-        "dedicated",
-        "default"
-      ],
-      "Ref": {
-        "Parameters": [
-          "String"
         ]
       }
     }

--- a/src/cfnlint/data/CloudSpecs/us-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-2.json
@@ -1368,7 +1368,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-customizedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-customizedmetricspecification-statistic",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingPolicyCustomizedMetricSpecificationStatistic"
+          }
         },
         "Unit": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-customizedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-customizedmetricspecification-unit",
@@ -1402,7 +1405,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-predefinedmetricspecification-predefinedmetrictype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ApplicationAutoScalingPredefinedMetricSpecificationType"
+          }
         },
         "ResourceLabel": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-predefinedmetricspecification-resourcelabel",
@@ -1614,7 +1620,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-lifecyclehookspecification.html#cfn-autoscaling-autoscalinggroup-lifecyclehookspecification-defaultresult",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingLifecycleHookResult"
+          }
         },
         "HeartbeatTimeout": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-lifecyclehookspecification.html#cfn-autoscaling-autoscalinggroup-lifecyclehookspecification-heartbeattimeout",
@@ -1632,7 +1641,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-lifecyclehookspecification.html#cfn-autoscaling-autoscalinggroup-lifecyclehookspecification-lifecycletransition",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingLifecycleTransition"
+          }
         },
         "NotificationMetadata": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-lifecyclehookspecification.html#cfn-autoscaling-autoscalinggroup-lifecyclehookspecification-notificationmetadata",
@@ -1832,7 +1844,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-customizedmetricspecification.html#cfn-autoscaling-scalingpolicy-customizedmetricspecification-statistic",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingPolicyCustomizedMetricSpecificationStatistic"
+          }
         },
         "Unit": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-customizedmetricspecification.html#cfn-autoscaling-scalingpolicy-customizedmetricspecification-unit",
@@ -1866,7 +1881,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-autoscaling-scalingpolicy-predefinedmetricspecification-predefinedmetrictype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "EC2ScalingPolicyPredifinedMetricSpecificationType"
+          }
         },
         "ResourceLabel": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-autoscaling-scalingpolicy-predefinedmetricspecification-resourcelabel",
@@ -2008,7 +2026,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-customizedscalingmetricspecification.html#cfn-autoscalingplans-scalingplan-customizedscalingmetricspecification-statistic",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingPolicyCustomizedMetricSpecificationStatistic"
+          }
         },
         "Unit": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-customizedscalingmetricspecification.html#cfn-autoscalingplans-scalingplan-customizedscalingmetricspecification-unit",
@@ -2059,7 +2080,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-predefinedscalingmetricspecification.html#cfn-autoscalingplans-scalingplan-predefinedscalingmetricspecification-predefinedscalingmetrictype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "EC2ScalingPolicyPredifinedMetricSpecificationType"
+          }
         },
         "ResourceLabel": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-predefinedscalingmetricspecification.html#cfn-autoscalingplans-scalingplan-predefinedscalingmetricspecification-resourcelabel",
@@ -2106,7 +2130,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-predictivescalingmaxcapacitybehavior",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingInstructionPredictiveScalingMaxCapacityBehavior"
+          }
         },
         "PredictiveScalingMaxCapacityBuffer": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-predictivescalingmaxcapacitybuffer",
@@ -2118,7 +2145,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-predictivescalingmode",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingInstructionPredictiveScalingMode"
+          }
         },
         "ResourceId": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-resourceid",
@@ -2130,7 +2160,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-scalabledimension",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingInstructionScalableDimension"
+          }
         },
         "ScalingPolicyUpdateBehavior": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-scalingpolicyupdatebehavior",
@@ -2148,7 +2181,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-servicenamespace",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ScalingInstructionServiceNamespace"
+          }
         },
         "TargetTrackingConfigurations": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-targettrackingconfigurations",
@@ -19757,7 +19793,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-applicationautoscaling-scalingpolicy.html#cfn-applicationautoscaling-scalingpolicy-policytype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ApplicationAutoScalingPolicyType"
+          }
         },
         "ResourceId": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-applicationautoscaling-scalingpolicy.html#cfn-applicationautoscaling-scalingpolicy-resourceid",
@@ -19869,7 +19908,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-group.html#cfn-as-group-healthchecktype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingGroupHealthCheckType"
+          }
         },
         "InstanceId": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-group.html#cfn-as-group-instanceid",
@@ -20098,7 +20140,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-launchconfig.html#cfn-as-launchconfig-placementtenancy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "PlacementTenancy"
+          }
         },
         "RamDiskId": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-launchconfig.html#cfn-as-launchconfig-ramdiskid",
@@ -20145,7 +20190,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-defaultresult",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingLifecycleHookResult"
+          }
         },
         "HeartbeatTimeout": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-heartbeattimeout",
@@ -20163,7 +20211,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-lifecycletransition",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingLifecycleTransition"
+          }
         },
         "NotificationMetadata": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-notificationmetadata",
@@ -20192,7 +20243,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-adjustmenttype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingPolicyAdjustmentType"
+          }
         },
         "AutoScalingGroupName": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-autoscalinggroupname",
@@ -20216,7 +20270,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-metricaggregationtype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingPolicyMetricAggregationType"
+          }
         },
         "MinAdjustmentMagnitude": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-minadjustmentmagnitude",
@@ -20228,7 +20285,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-policytype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "AutoScalingPolicyType"
+          }
         },
         "ScalingAdjustment": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-scalingadjustment",
@@ -24331,7 +24391,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "VpcTenancy"
+            "ValueType": "PlacementTenancy"
           }
         },
         "Tags": {
@@ -33409,6 +33469,66 @@
         "UNIT"
       ]
     },
+    "ApplicationAutoScalingPolicyType": {
+      "AllowedValues": [
+        "StepScaling",
+        "TargetTrackingScaling"
+      ]
+    },
+    "ApplicationAutoScalingPredefinedMetricSpecificationType": {
+      "AllowedValues": [
+        "ALBRequestCountPerTarget",
+        "DynamoDBReadCapacityUtilization",
+        "DynamoDBWriteCapacityUtilization",
+        "EC2SpotFleetRequestAverageCPUUtilization",
+        "EC2SpotFleetRequestAverageNetworkIn",
+        "EC2SpotFleetRequestAverageNetworkOut",
+        "ECSServiceAverageCPUUtilization",
+        "ECSServiceAverageMemoryUtilization",
+        "RDSReaderAverageCPUUtilization",
+        "RDSReaderAverageDatabaseConnections",
+        "SageMakerVariantInvocationsPerInstance"
+      ]
+    },
+    "AutoScalingGroupHealthCheckType": {
+      "AllowedValues": [
+        "EC2",
+        "ELB"
+      ]
+    },
+    "AutoScalingLifecycleHookResult": {
+      "AllowedValues": [
+        "ABANDON",
+        "CONTINUE"
+      ]
+    },
+    "AutoScalingLifecycleTransition": {
+      "AllowedValues": [
+        "autoscaling:EC2_INSTANCE_LAUNCHING",
+        "autoscaling:EC2_INSTANCE_TERMINATING"
+      ]
+    },
+    "AutoScalingPolicyAdjustmentType": {
+      "AllowedValues": [
+        "ChangeInCapacity",
+        "ExactCapacity",
+        "PercentChangeInCapacity"
+      ]
+    },
+    "AutoScalingPolicyMetricAggregationType": {
+      "AllowedValues": [
+        "Average",
+        "Maximum",
+        "Minimum"
+      ]
+    },
+    "AutoScalingPolicyType": {
+      "AllowedValues": [
+        "SimpleScaling",
+        "StepScaling",
+        "TargetTrackingScaling"
+      ]
+    },
     "AvailabilityZone": {
       "GetAtt": {
         "AWS::EC2::Instance": "AvailabilityZone",
@@ -33461,6 +33581,14 @@
       "AllowedValues": [
         "source",
         "target"
+      ]
+    },
+    "EC2ScalingPolicyPredifinedMetricSpecificationType": {
+      "AllowedValues": [
+        "ALBRequestCountPerTarget",
+        "ASGAverageCPUUtilization",
+        "ASGAverageNetworkIn",
+        "ASGAverageNetworkOut"
       ]
     },
     "EbsVolumeType": {
@@ -33653,6 +33781,17 @@
         ]
       }
     },
+    "PlacementTenancy": {
+      "AllowedValues": [
+        "dedicated",
+        "default"
+      ],
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
+    },
     "PredicateType": {
       "AllowedValues": [
         "ByteMatch",
@@ -33694,6 +33833,49 @@
       "AllowedValues": [
         "Enabled",
         "Suspended"
+      ]
+    },
+    "ScalingInstructionPredictiveScalingMaxCapacityBehavior": {
+      "AllowedValues": [
+        "SetForecastCapacityToMaxCapacity",
+        "SetMaxCapacityToForecastCapacity",
+        "SetMaxCapacityAboveForecastCapacity"
+      ]
+    },
+    "ScalingInstructionPredictiveScalingMode": {
+      "AllowedValues": [
+        "ForecastAndScale",
+        "ForecastOnly"
+      ]
+    },
+    "ScalingInstructionScalableDimension": {
+      "AllowedValues": [
+        "autoscaling:autoScalingGroup:DesiredCapacity",
+        "ecs:service:DesiredCount",
+        "ec2:spot-fleet-request:TargetCapacity",
+        "dynamodb:table:ReadCapacityUnits",
+        "dynamodb:table:WriteCapacityUnits",
+        "dynamodb:index:ReadCapacityUnits",
+        "dynamodb:index:WriteCapacityUnits",
+        "rds:cluster:ReadReplicaCount"
+      ]
+    },
+    "ScalingInstructionServiceNamespace": {
+      "AllowedValues": [
+        "autoscaling",
+        "dynamodb",
+        "ecs",
+        "ec2",
+        "rds"
+      ]
+    },
+    "ScalingPolicyCustomizedMetricSpecificationStatistic": {
+      "AllowedValues": [
+        "Average",
+        "Minimum",
+        "Maximum",
+        "SampleCount",
+        "Sum"
       ]
     },
     "SecurityGroup": {
@@ -33816,17 +33998,6 @@
         ],
         "Resources": [
           "AWS::EC2::VPC"
-        ]
-      }
-    },
-    "VpcTenancy": {
-      "AllowedValues": [
-        "dedicated",
-        "default"
-      ],
-      "Ref": {
-        "Parameters": [
-          "String"
         ]
       }
     }

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
@@ -83,6 +83,27 @@
           "API_KEY"
         ]
       },
+      "ApplicationAutoScalingPolicyType": {
+        "AllowedValues": [
+          "StepScaling",
+          "TargetTrackingScaling"
+        ]
+      },
+      "ApplicationAutoScalingPredefinedMetricSpecificationType": {
+        "AllowedValues": [
+          "ALBRequestCountPerTarget",
+          "DynamoDBReadCapacityUtilization",
+          "DynamoDBWriteCapacityUtilization",
+          "EC2SpotFleetRequestAverageCPUUtilization",
+          "EC2SpotFleetRequestAverageNetworkIn",
+          "EC2SpotFleetRequestAverageNetworkOut",
+          "ECSServiceAverageCPUUtilization",
+          "ECSServiceAverageMemoryUtilization",
+          "RDSReaderAverageCPUUtilization",
+          "RDSReaderAverageDatabaseConnections",
+          "SageMakerVariantInvocationsPerInstance"
+        ]
+      },
       "AppSyncDataSourceType": {
         "AllowedValues": [
           "AMAZON_DYNAMODB",
@@ -129,6 +150,45 @@
         },
         "GetAtt": {}
       },
+      "AutoScalingGroupHealthCheckType": {
+        "AllowedValues": [
+          "EC2",
+          "ELB"
+        ]
+      },
+      "AutoScalingLifecycleHookResult": {
+        "AllowedValues": [
+          "ABANDON",
+          "CONTINUE"
+        ]
+      },
+      "AutoScalingLifecycleTransition": {
+        "AllowedValues": [
+          "autoscaling:EC2_INSTANCE_LAUNCHING",
+          "autoscaling:EC2_INSTANCE_TERMINATING"
+        ]
+      },
+      "AutoScalingPolicyAdjustmentType": {
+        "AllowedValues": [
+          "ChangeInCapacity",
+          "ExactCapacity",
+          "PercentChangeInCapacity"
+        ]
+      },
+      "AutoScalingPolicyMetricAggregationType": {
+        "AllowedValues": [
+          "Average",
+          "Maximum",
+          "Minimum"
+        ]
+      },
+      "AutoScalingPolicyType": {
+        "AllowedValues": [
+          "SimpleScaling",
+          "StepScaling",
+          "TargetTrackingScaling"
+        ]
+      },
       "DmsEndpointEngineName": {
         "AllowedValues": [
           "aurora-postgresql",
@@ -168,6 +228,14 @@
           "sc1",
           "st1",
           "standard"
+        ]
+      },
+      "EC2ScalingPolicyPredifinedMetricSpecificationType": {
+        "AllowedValues": [
+          "ALBRequestCountPerTarget",
+          "ASGAverageCPUUtilization",
+          "ASGAverageNetworkIn",
+          "ASGAverageNetworkOut"
         ]
       },
       "GlueConnectionInputType": {
@@ -351,6 +419,17 @@
         },
         "GetAtt": {}
       },
+      "PlacementTenancy": {
+        "Ref": {
+          "Parameters": [
+            "String"
+          ]
+        },
+        "AllowedValues": [
+          "dedicated",
+          "default"
+        ]
+      },
       "PrivateIpAddress": {
         "GetAtt": {
           "AWS::EC2::NetworkInterface": "PrimaryPrivateIpAddress"
@@ -392,6 +471,49 @@
         "AllowedValues": [
           "Enabled",
           "Suspended"
+        ]
+      },
+      "ScalingInstructionPredictiveScalingMaxCapacityBehavior": {
+        "AllowedValues": [
+          "SetForecastCapacityToMaxCapacity",
+          "SetMaxCapacityToForecastCapacity",
+          "SetMaxCapacityAboveForecastCapacity"
+        ]
+      },
+      "ScalingInstructionPredictiveScalingMode": {
+        "AllowedValues": [
+          "ForecastAndScale",
+          "ForecastOnly"
+        ]
+      },
+      "ScalingInstructionScalableDimension": {
+        "AllowedValues": [
+          "autoscaling:autoScalingGroup:DesiredCapacity",
+          "ecs:service:DesiredCount",
+          "ec2:spot-fleet-request:TargetCapacity",
+          "dynamodb:table:ReadCapacityUnits",
+          "dynamodb:table:WriteCapacityUnits",
+          "dynamodb:index:ReadCapacityUnits",
+          "dynamodb:index:WriteCapacityUnits",
+          "rds:cluster:ReadReplicaCount"
+        ]
+      },
+      "ScalingInstructionServiceNamespace": {
+        "AllowedValues": [
+          "autoscaling",
+          "dynamodb",
+          "ecs",
+          "ec2",
+          "rds"
+        ]
+      },
+      "ScalingPolicyCustomizedMetricSpecificationStatistic": {
+        "AllowedValues": [
+          "Average",
+          "Minimum",
+          "Maximum",
+          "SampleCount",
+          "Sum"
         ]
       },
       "SecurityGroup": {
@@ -516,17 +638,6 @@
             "AWS::EC2::VPC"
           ]
         }
-      },
-      "VpcTenancy": {
-        "Ref": {
-          "Parameters": [
-            "String"
-          ]
-        },
-        "AllowedValues": [
-          "dedicated",
-          "default"
-        ]
       }
     }
   }

--- a/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
@@ -1,6 +1,90 @@
 [
   {
     "op": "add",
+    "path": "/PropertyTypes/AWS::ApplicationAutoScaling::ScalingPolicy.CustomizedMetricSpecification/Properties/Statistic/Value",
+    "value": {
+      "ValueType": "ScalingPolicyCustomizedMetricSpecificationStatistic"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/PropertyTypes/AWS::ApplicationAutoScaling::ScalingPolicy.PredefinedMetricSpecification/Properties/PredefinedMetricType/Value",
+    "value": {
+      "ValueType": "ApplicationAutoScalingPredefinedMetricSpecificationType"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/PropertyTypes/AWS::AutoScaling::AutoScalingGroup.LifecycleHookSpecification/Properties/DefaultResult/Value",
+    "value": {
+      "ValueType": "AutoScalingLifecycleHookResult"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/PropertyTypes/AWS::AutoScaling::AutoScalingGroup.LifecycleHookSpecification/Properties/LifecycleTransition/Value",
+    "value": {
+      "ValueType": "AutoScalingLifecycleTransition"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/PropertyTypes/AWS::AutoScaling::ScalingPolicy.CustomizedMetricSpecification/Properties/Statistic/Value",
+    "value": {
+      "ValueType": "ScalingPolicyCustomizedMetricSpecificationStatistic"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/PropertyTypes/AWS::AutoScaling::ScalingPolicy.PredefinedMetricSpecification/Properties/PredefinedMetricType/Value",
+    "value": {
+      "ValueType": "EC2ScalingPolicyPredifinedMetricSpecificationType"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/PropertyTypes/AWS::AutoScalingPlans::ScalingPlan.CustomizedScalingMetricSpecification/Properties/Statistic/Value",
+    "value": {
+      "ValueType": "ScalingPolicyCustomizedMetricSpecificationStatistic"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/PropertyTypes/AWS::AutoScalingPlans::ScalingPlan.PredefinedScalingMetricSpecification/Properties/PredefinedScalingMetricType/Value",
+    "value": {
+      "ValueType": "EC2ScalingPolicyPredifinedMetricSpecificationType"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/PropertyTypes/AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction/Properties/ScalableDimension/Value",
+    "value": {
+      "ValueType": "ScalingInstructionScalableDimension"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/PropertyTypes/AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction/Properties/ServiceNamespace/Value",
+    "value": {
+      "ValueType": "ScalingInstructionServiceNamespace"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/PropertyTypes/AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction/Properties/PredictiveScalingMaxCapacityBehavior/Value",
+    "value": {
+      "ValueType": "ScalingInstructionPredictiveScalingMaxCapacityBehavior"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/PropertyTypes/AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction/Properties/PredictiveScalingMode/Value",
+    "value": {
+      "ValueType": "ScalingInstructionPredictiveScalingMode"
+    }
+  },
+  {
+    "op": "add",
     "path": "/PropertyTypes/AWS::Batch::ComputeEnvironment.ComputeResources/Properties/InstanceRole/Value",
     "value": {
       "ValueType": "IamRole"
@@ -191,6 +275,13 @@
   },
   {
     "op": "add",
+    "path": "/ResourceTypes/AWS::AutoScaling::AutoScalingGroup/Properties/HealthCheckType/Value",
+    "value": {
+      "ValueType": "AutoScalingGroupHealthCheckType"
+    }
+  },
+  {
+    "op": "add",
     "path": "/ResourceTypes/AWS::AutoScaling::AutoScalingGroup/Properties/LaunchConfigurationName/Value",
     "value": {
       "ValueType": "LaunchConfigurationName"
@@ -239,6 +330,13 @@
     "path": "/ResourceTypes/AWS::AutoScaling::LaunchConfiguration/Properties/KeyName/Value",
     "value": {
       "ValueType": "KeyPair"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/ResourceTypes/AWS::AutoScaling::LaunchConfiguration/Properties/PlacementTenancy/Value",
+    "value": {
+      "ValueType": "PlacementTenancy"
     }
   },
   {
@@ -388,7 +486,7 @@
     "op": "add",
     "path": "/ResourceTypes/AWS::EC2::VPC/Properties/InstanceTenancy/Value",
     "value": {
-      "ValueType": "VpcTenancy"
+      "ValueType": "PlacementTenancy"
     }
   },
   {
@@ -592,6 +690,52 @@
       "ValueType": "AmazonMQEngineVersion"
     }
   },
+  {
+    "op": "add",
+    "path": "/ResourceTypes/AWS::ApplicationAutoScaling::ScalingPolicy/Properties/PolicyType/Value",
+    "value": {
+      "ValueType": "ApplicationAutoScalingPolicyType"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/ResourceTypes/AWS::AutoScaling::LifecycleHook/Properties/DefaultResult/Value",
+    "value": {
+      "ValueType": "AutoScalingLifecycleHookResult"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/ResourceTypes/AWS::AutoScaling::LifecycleHook/Properties/LifecycleTransition/Value",
+    "value": {
+      "ValueType": "AutoScalingLifecycleTransition"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/ResourceTypes/AWS::AutoScaling::ScalingPolicy/Properties/AdjustmentType/Value",
+    "value": {
+      "ValueType": "AutoScalingPolicyAdjustmentType"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/ResourceTypes/AWS::AutoScaling::ScalingPolicy/Properties/MetricAggregationType/Value",
+    "value": {
+      "ValueType": "AutoScalingPolicyMetricAggregationType"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/ResourceTypes/AWS::AutoScaling::ScalingPolicy/Properties/PolicyType/Value",
+    "value": {
+      "ValueType": "AutoScalingPolicyType"
+    }
+  },
+
+
+
+
   {
     "op": "add",
     "path": "/ResourceTypes/AWS::EC2::EgressOnlyInternetGateway/Properties/VpcId/Value",

--- a/test/fixtures/templates/bad/resources/properties/allowed_values.yaml
+++ b/test/fixtures/templates/bad/resources/properties/allowed_values.yaml
@@ -23,7 +23,7 @@ Resources:
         - ConsoleAccess: false
           Groups:
             - "group1"
-          Password: !Ref "PassWord"
+          Password: !Ref "Password"
           Username: "user"
   AmazonMQConfiguration:
     Type: "AWS::AmazonMQ::Configuration"
@@ -52,6 +52,16 @@ Resources:
       KeyId: "ApiGatewayUsagePlanKey"
       KeyType: "random value" # Invalid AllowedValue
       UsagePlanId: "UsagePlanId"
+  ApplicationAutoScalingPolicy:
+    Type: "AWS::ApplicationAutoScaling::ScalingPolicy"
+    Properties:
+      PolicyName: "ApplicationAutoScalingPolicy"
+      PolicyType: "SimpleScaling" # Invalid AllowedValue
+      ScalingTargetId: ""
+      TargetTrackingScalingPolicyConfiguration:
+        TargetValue: 50.0
+        PredefinedMetricSpecification:
+          PredefinedMetricType: "DynamoDbReadCapacityUtilization" # Invalid AllowedValue
   AppSyncDataSource:
     Type: "AWS::AppSync::DataSource"
     Properties:
@@ -70,6 +80,68 @@ Resources:
       FieldName: "field"
       Kind: "PIPELINES" # Invlid AllowedValue
       TypeName: "type"
+  AutoScalingGroup:
+    Type: "AWS::AutoScaling::AutoScalingGroup"
+    Properties:
+      HealthCheckType: "elb" # Invalid AlllowedValue
+      LifecycleHookSpecificationList:
+        - DefaultResult: " ABANDON" # Invalid AlllowedValue
+          LifecycleHookName: "hook"
+          LifecycleTransition: "autoscaling: EC2_INSTANCE_TERMINATING" # Invalid AllowedValue
+      MaxSize: "1"
+      MinSize: "1"
+  AutoScalingLaunchConfiguration:
+    Type: "AWS::AutoScaling::LaunchConfiguration"
+    Properties:
+      BlockDeviceMappings:
+        - DeviceName: /dev/sdm
+          Ebs:
+            VolumeType: "ssd" # Invalid AllowedValue
+      ImageId: "ami-1234"
+      InstanceType: "t2.4xlarge"
+      PlacementTenancy: "Standard" # Invalid AllowedValue
+  AutoScalingLifecycleHook:
+    Type: "AWS::AutoScaling::LifecycleHook"
+    Properties:
+      DefaultResult: "ABORT" # Invalid AlllowedValue
+      AutoScalingGroupName: !Ref "AutoScalingGroup"
+      LifecycleTransition: "EC2_INSTANCE_LAUNCHING" # Invalid AllowedValue
+  AutoScalingPolicy:
+    Type: "AWS::AutoScaling::ScalingPolicy"
+    Properties:
+      AdjustmentType: "ChangeCapacity" # Invalid AllowedValue
+      AutoScalingGroupName: !Ref "AutoScalingGroup"
+      MetricAggregationType: "max" # Invalid AllowedValue
+      PolicyType: "Simplescaling" # Invalid AllowedValue
+      TargetTrackingConfiguration:
+        CustomizedMetricSpecification:
+          MetricName: "MetricName"
+          Namespace: "Namespace"
+          Statistic: "Sample Count" # Invalid AllowedValue
+        PredefinedMetricSpecification:
+          PredefinedMetricType: "MaxCount" # Invalid AllowedValue
+        TargetValue: 10.5
+  AutoScalingPlan:
+    Type: "AWS::AutoScalingPlans::ScalingPlan"
+    Properties:
+      ApplicationSource:
+        CloudFormationStackARN: "StackArn"
+      ScalingInstructions:
+        - MaxCapacity: 1
+          MinCapacity: 1
+          ResourceId: "ResourceId"
+          ScalableDimension: "dynamodb:WriteCapacityUnits" # Invalid AllowedValues
+          ServiceNamespace: "dynamoDB" # Invalid AllowedValues
+          PredictiveScalingMaxCapacityBehavior: "SetForecastCapacityToMaxCapacity ok" # Invalid AllowedValue
+          PredictiveScalingMode: "Forecast" # Invalid AllowedValue
+          TargetTrackingConfigurations:
+            - CustomizedScalingMetricSpecification:
+                MetricName: "MetricName"
+                Namespace: "Namespace"
+                Statistic: "sample count" # Invalid AllowedValue
+              PredefinedScalingMetricSpecification:
+                PredefinedScalingMetricType: "RequestCountPerTarget" # Invalid AllowedValue
+              TargetValue: 10.5
   DmsEndpoint:
     Type: "AWS::DMS::Endpoint"
     Properties:
@@ -94,11 +166,10 @@ Resources:
     Type: "AWS::EC2::Instance"
     Properties:
       ImageId: "ami-2f726546"
-      InstanceType: t1.micro
+      InstanceType: "t1.micro"
       KeyName: ""
       BlockDeviceMappings:
-        -
-          DeviceName: /dev/sdm
+        - DeviceName: "/dev/sdm"
           Ebs:
             VolumeType: "magnetic" # Invalid AllowedValue
   S3Bucket:

--- a/test/fixtures/templates/good/resources/properties/allowed_values.yaml
+++ b/test/fixtures/templates/good/resources/properties/allowed_values.yaml
@@ -52,6 +52,16 @@ Resources:
       KeyId: "ApiGatewayUsagePlanKey"
       KeyType: "API_KEY" # Valid AllowedValue
       UsagePlanId: "UsagePlanId"
+  ApplicationAutoScalingPolicy:
+    Type: "AWS::ApplicationAutoScaling::ScalingPolicy"
+    Properties:
+      PolicyName: "ApplicationAutoScalingPolicy"
+      PolicyType: "StepScaling" # Valid AllowedValue
+      ScalingTargetId: ""
+      TargetTrackingScalingPolicyConfiguration:
+        TargetValue: 50.0
+        PredefinedMetricSpecification:
+          PredefinedMetricType: "DynamoDBReadCapacityUtilization" # Valid AllowedValue
   AppSyncDataSource:
     Type: "AWS::AppSync::DataSource"
     Properties:
@@ -70,6 +80,68 @@ Resources:
       FieldName: "field"
       Kind: "PIPELINE" # Valid AllowedValue
       TypeName: "type"
+  AutoScalingGroup:
+    Type: "AWS::AutoScaling::AutoScalingGroup"
+    Properties:
+      HealthCheckType: "ELB" # Valid AlllowedValue
+      LifecycleHookSpecificationList:
+        - DefaultResult: "ABANDON" # Valid AlllowedValue
+          LifecycleHookName: "hook"
+          LifecycleTransition: "autoscaling:EC2_INSTANCE_TERMINATING" # Valid AllowedValue
+      MaxSize: "1"
+      MinSize: "1"
+  AutoScalingLaunchConfiguration:
+    Type: "AWS::AutoScaling::LaunchConfiguration"
+    Properties:
+      BlockDeviceMappings:
+        - DeviceName: /dev/sdm
+          Ebs:
+            VolumeType: "gp2" # Valid AllowedValue
+      ImageId: "ami-1234"
+      InstanceType: "t2.small"
+      PlacementTenancy: "default" # Valid AllowedValue
+  AutoScalingLifecycleHook:
+    Type: "AWS::AutoScaling::LifecycleHook"
+    Properties:
+      DefaultResult: "CONTINUE" # Valid AlllowedValue
+      AutoScalingGroupName: !Ref "AutoScalingGroup"
+      LifecycleTransition: "autoscaling:EC2_INSTANCE_LAUNCHING" # Valid AllowedValue
+  AutoScalingPolicy:
+    Type: "AWS::AutoScaling::ScalingPolicy"
+    Properties:
+      AdjustmentType: "ChangeInCapacity" # Valid AllowedValue
+      AutoScalingGroupName: !Ref "AutoScalingGroup"
+      MetricAggregationType: "Average" # Valid AllowedValue
+      PolicyType: "SimpleScaling" # Valid AllowedValue
+      TargetTrackingConfiguration:
+        CustomizedMetricSpecification:
+          MetricName: "MetricName"
+          Namespace: "Namespace"
+          Statistic: "SampleCount" # Valid AllowedValue
+        PredefinedMetricSpecification:
+          PredefinedMetricType: "ALBRequestCountPerTarget" # Valid AllowedValue
+        TargetValue: 10.5
+  AutoScalingPlan:
+    Type: "AWS::AutoScalingPlans::ScalingPlan"
+    Properties:
+      ApplicationSource:
+        CloudFormationStackARN: "StackArn"
+      ScalingInstructions:
+        - MaxCapacity: 1
+          MinCapacity: 1
+          ResourceId: "ResourceId"
+          ScalableDimension: "dynamodb:index:WriteCapacityUnits" # Valid AllowedValues
+          ServiceNamespace: "dynamodb" # Valid AllowedValues
+          PredictiveScalingMaxCapacityBehavior: "SetForecastCapacityToMaxCapacity" # Valid AllowedValue
+          PredictiveScalingMode: "ForecastOnly" # Valid AllowedValue
+          TargetTrackingConfigurations:
+            - CustomizedScalingMetricSpecification:
+                MetricName: "MetricName"
+                Namespace: "Namespace"
+                Statistic: "SampleCount" # Valid AllowedValue
+              PredefinedScalingMetricSpecification:
+                PredefinedScalingMetricType: "ALBRequestCountPerTarget" # Valid AllowedValue
+              TargetValue: 10.5
   DmsEndpoint:
     Type: "AWS::DMS::Endpoint"
     Properties:
@@ -80,11 +152,10 @@ Resources:
     Type: "AWS::EC2::Instance"
     Properties:
       ImageId: "ami-2f726546"
-      InstanceType: t1.micro
+      InstanceType: "t1.micro"
       KeyName: ""
       BlockDeviceMappings:
-        -
-          DeviceName: /dev/sdm
+        - DeviceName: "/dev/sdm"
           Ebs:
             VolumeType: "gp2" # Valid AllowedValue
   GlueConnection:

--- a/test/rules/resources/properties/test_allowed_value.py
+++ b/test/rules/resources/properties/test_allowed_value.py
@@ -34,4 +34,4 @@ class TestAllowedValue(BaseRuleTestCase):
 
     def test_file_negative(self):
         """Test failure"""
-        self.helper_file_negative('test/fixtures/templates/bad/resources/properties/allowed_values.yaml', 22)
+        self.helper_file_negative('test/fixtures/templates/bad/resources/properties/allowed_values.yaml', 42)


### PR DESCRIPTION
*Issue https://github.com/awslabs/cfn-python-lint/issues/50, if available:*

Added (all the) allowed values of the [AWS::AutoScaling](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-reference-autoscaling.html) resources.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
