### PR TITLE
Add S3 Bucket Allowed Values

### DIFF
--- a/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
@@ -29419,7 +29419,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sns-subscription.html#cfn-sns-protocol",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "SnsSubscriptionProtocol"
+          }
         },
         "RawMessageDelivery": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sns-subscription.html#cfn-sns-subscription-rawmessagedelivery",
@@ -31920,6 +31923,18 @@
           "AWS::EC2::SecurityGroup"
         ]
       }
+    },
+    "SnsSubscriptionProtocol": {
+      "AllowedValues": [
+        "application",
+        "email-json",
+        "email",
+        "http",
+        "https",
+        "lambda",
+        "sms",
+        "sqs"
+      ]
     },
     "SsmDocumentName": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
@@ -14653,7 +14653,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-accelerateconfiguration.html#cfn-s3-bucket-accelerateconfiguration-accelerationstatus",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "S3BucketAccelerationStatus"
+          }
         }
       }
     },
@@ -15097,7 +15100,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-redirectallrequeststo.html#cfn-s3-websiteconfiguration-redirectallrequeststo-protocol",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "HttpProtocol"
+          }
         }
       }
     },
@@ -15371,7 +15377,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-serversideencryptionbydefault.html#cfn-s3-bucket-serversideencryptionbydefault-ssealgorithm",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "S3BucketSSEAlgorithm"
+          }
         }
       }
     },
@@ -15443,7 +15452,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-notificationconfig-topicconfig.html#cfn-s3-bucket-notificationconfig-topicconfig-event",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "S3BucketTopicConfigurationEvent"
+          }
         },
         "Filter": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-notificationconfig-topicconfig.html#cfn-s3-bucket-notificationconfig-topicconfig-filter",
@@ -29255,7 +29267,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket.html#cfn-s3-bucket-accesscontrol",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "S3BucketAccessControl"
+          }
         },
         "AnalyticsConfigurations": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket.html#cfn-s3-bucket-analyticsconfigurations",
@@ -31522,6 +31537,12 @@
         "SFTP"
       ]
     },
+    "HttpProtocol": {
+      "AllowedValues": [
+        "http",
+        "https"
+      ]
+    },
     "IamInstanceProfile": {
       "GetAtt": {},
       "Ref": {
@@ -31761,6 +31782,45 @@
           "AWS::ApiGateway::RestApi"
         ]
       }
+    },
+    "S3BucketAccelerationStatus": {
+      "AllowedValues": [
+        "Enabled",
+        "Suspended"
+      ]
+    },
+    "S3BucketAccessControl": {
+      "AllowedValues": [
+        "AuthenticatedRead",
+        "AwsExecRead",
+        "BucketOwnerFullControl",
+        "BucketOwnerRead",
+        "LogDeliveryWrite",
+        "Private",
+        "PublicRead",
+        "PublicReadWrite"
+      ]
+    },
+    "S3BucketSSEAlgorithm": {
+      "AllowedValues": [
+        "AES256",
+        "aws:kms"
+      ]
+    },
+    "S3BucketTopicConfigurationEvent": {
+      "AllowedValues": [
+        "s3:ObjectCreated:*",
+        "s3:ObjectCreated:CompleteMultipartUpload",
+        "s3:ObjectCreated:Copy",
+        "s3:ObjectCreated:Post",
+        "s3:ObjectCreated:Put",
+        "s3:ObjectRemoved:*",
+        "s3:ObjectRemoved:Delete",
+        "s3:ObjectRemoved:DeleteMarkerCreated",
+        "s3:ObjectRestore:Completed",
+        "s3:ObjectRestore:Post",
+        "s3:ReducedRedundancyLostObject"
+      ]
     },
     "S3BucketVersioningConfigurationStatus": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
@@ -27198,7 +27198,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sns-subscription.html#cfn-sns-protocol",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "SnsSubscriptionProtocol"
+          }
         },
         "RawMessageDelivery": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sns-subscription.html#cfn-sns-subscription-rawmessagedelivery",
@@ -29445,6 +29448,18 @@
           "AWS::EC2::SecurityGroup"
         ]
       }
+    },
+    "SnsSubscriptionProtocol": {
+      "AllowedValues": [
+        "application",
+        "email-json",
+        "email",
+        "http",
+        "https",
+        "lambda",
+        "sms",
+        "sqs"
+      ]
     },
     "SsmDocumentName": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
@@ -13685,7 +13685,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-accelerateconfiguration.html#cfn-s3-bucket-accelerateconfiguration-accelerationstatus",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "S3BucketAccelerationStatus"
+          }
         }
       }
     },
@@ -14129,7 +14132,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-redirectallrequeststo.html#cfn-s3-websiteconfiguration-redirectallrequeststo-protocol",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "HttpProtocol"
+          }
         }
       }
     },
@@ -14403,7 +14409,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-serversideencryptionbydefault.html#cfn-s3-bucket-serversideencryptionbydefault-ssealgorithm",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "S3BucketSSEAlgorithm"
+          }
         }
       }
     },
@@ -14475,7 +14484,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-notificationconfig-topicconfig.html#cfn-s3-bucket-notificationconfig-topicconfig-event",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "S3BucketTopicConfigurationEvent"
+          }
         },
         "Filter": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-notificationconfig-topicconfig.html#cfn-s3-bucket-notificationconfig-topicconfig-filter",
@@ -27045,7 +27057,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket.html#cfn-s3-bucket-accesscontrol",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "S3BucketAccessControl"
+          }
         },
         "AnalyticsConfigurations": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket.html#cfn-s3-bucket-analyticsconfigurations",
@@ -29047,6 +29062,12 @@
         "SFTP"
       ]
     },
+    "HttpProtocol": {
+      "AllowedValues": [
+        "http",
+        "https"
+      ]
+    },
     "IamInstanceProfile": {
       "GetAtt": {},
       "Ref": {
@@ -29286,6 +29307,45 @@
           "AWS::ApiGateway::RestApi"
         ]
       }
+    },
+    "S3BucketAccelerationStatus": {
+      "AllowedValues": [
+        "Enabled",
+        "Suspended"
+      ]
+    },
+    "S3BucketAccessControl": {
+      "AllowedValues": [
+        "AuthenticatedRead",
+        "AwsExecRead",
+        "BucketOwnerFullControl",
+        "BucketOwnerRead",
+        "LogDeliveryWrite",
+        "Private",
+        "PublicRead",
+        "PublicReadWrite"
+      ]
+    },
+    "S3BucketSSEAlgorithm": {
+      "AllowedValues": [
+        "AES256",
+        "aws:kms"
+      ]
+    },
+    "S3BucketTopicConfigurationEvent": {
+      "AllowedValues": [
+        "s3:ObjectCreated:*",
+        "s3:ObjectCreated:CompleteMultipartUpload",
+        "s3:ObjectCreated:Copy",
+        "s3:ObjectCreated:Post",
+        "s3:ObjectCreated:Put",
+        "s3:ObjectRemoved:*",
+        "s3:ObjectRemoved:Delete",
+        "s3:ObjectRemoved:DeleteMarkerCreated",
+        "s3:ObjectRestore:Completed",
+        "s3:ObjectRestore:Post",
+        "s3:ReducedRedundancyLostObject"
+      ]
     },
     "S3BucketVersioningConfigurationStatus": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
@@ -9789,7 +9789,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-accelerateconfiguration.html#cfn-s3-bucket-accelerateconfiguration-accelerationstatus",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "S3BucketAccelerationStatus"
+          }
         }
       }
     },
@@ -10233,7 +10236,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-redirectallrequeststo.html#cfn-s3-websiteconfiguration-redirectallrequeststo-protocol",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "HttpProtocol"
+          }
         }
       }
     },
@@ -10507,7 +10513,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-serversideencryptionbydefault.html#cfn-s3-bucket-serversideencryptionbydefault-ssealgorithm",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "S3BucketSSEAlgorithm"
+          }
         }
       }
     },
@@ -10579,7 +10588,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-notificationconfig-topicconfig.html#cfn-s3-bucket-notificationconfig-topicconfig-event",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "S3BucketTopicConfigurationEvent"
+          }
         },
         "Filter": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-notificationconfig-topicconfig.html#cfn-s3-bucket-notificationconfig-topicconfig-filter",
@@ -20105,7 +20117,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket.html#cfn-s3-bucket-accesscontrol",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "S3BucketAccessControl"
+          }
         },
         "AnalyticsConfigurations": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket.html#cfn-s3-bucket-analyticsconfigurations",
@@ -20968,6 +20983,12 @@
         "SFTP"
       ]
     },
+    "HttpProtocol": {
+      "AllowedValues": [
+        "http",
+        "https"
+      ]
+    },
     "IamInstanceProfile": {
       "GetAtt": {},
       "Ref": {
@@ -21207,6 +21228,45 @@
           "AWS::ApiGateway::RestApi"
         ]
       }
+    },
+    "S3BucketAccelerationStatus": {
+      "AllowedValues": [
+        "Enabled",
+        "Suspended"
+      ]
+    },
+    "S3BucketAccessControl": {
+      "AllowedValues": [
+        "AuthenticatedRead",
+        "AwsExecRead",
+        "BucketOwnerFullControl",
+        "BucketOwnerRead",
+        "LogDeliveryWrite",
+        "Private",
+        "PublicRead",
+        "PublicReadWrite"
+      ]
+    },
+    "S3BucketSSEAlgorithm": {
+      "AllowedValues": [
+        "AES256",
+        "aws:kms"
+      ]
+    },
+    "S3BucketTopicConfigurationEvent": {
+      "AllowedValues": [
+        "s3:ObjectCreated:*",
+        "s3:ObjectCreated:CompleteMultipartUpload",
+        "s3:ObjectCreated:Copy",
+        "s3:ObjectCreated:Post",
+        "s3:ObjectCreated:Put",
+        "s3:ObjectRemoved:*",
+        "s3:ObjectRemoved:Delete",
+        "s3:ObjectRemoved:DeleteMarkerCreated",
+        "s3:ObjectRestore:Completed",
+        "s3:ObjectRestore:Post",
+        "s3:ReducedRedundancyLostObject"
+      ]
     },
     "S3BucketVersioningConfigurationStatus": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
@@ -20269,7 +20269,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sns-subscription.html#cfn-sns-protocol",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "SnsSubscriptionProtocol"
+          }
         },
         "RawMessageDelivery": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sns-subscription.html#cfn-sns-subscription-rawmessagedelivery",
@@ -21366,6 +21369,18 @@
           "AWS::EC2::SecurityGroup"
         ]
       }
+    },
+    "SnsSubscriptionProtocol": {
+      "AllowedValues": [
+        "application",
+        "email-json",
+        "email",
+        "http",
+        "https",
+        "lambda",
+        "sms",
+        "sqs"
+      ]
     },
     "SsmDocumentName": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/ap-south-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-south-1.json
@@ -26038,7 +26038,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sns-subscription.html#cfn-sns-protocol",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "SnsSubscriptionProtocol"
+          }
         },
         "RawMessageDelivery": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sns-subscription.html#cfn-sns-subscription-rawmessagedelivery",
@@ -28285,6 +28288,18 @@
           "AWS::EC2::SecurityGroup"
         ]
       }
+    },
+    "SnsSubscriptionProtocol": {
+      "AllowedValues": [
+        "application",
+        "email-json",
+        "email",
+        "http",
+        "https",
+        "lambda",
+        "sms",
+        "sqs"
+      ]
     },
     "SsmDocumentName": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/ap-south-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-south-1.json
@@ -13125,7 +13125,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-accelerateconfiguration.html#cfn-s3-bucket-accelerateconfiguration-accelerationstatus",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "S3BucketAccelerationStatus"
+          }
         }
       }
     },
@@ -13569,7 +13572,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-redirectallrequeststo.html#cfn-s3-websiteconfiguration-redirectallrequeststo-protocol",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "HttpProtocol"
+          }
         }
       }
     },
@@ -13843,7 +13849,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-serversideencryptionbydefault.html#cfn-s3-bucket-serversideencryptionbydefault-ssealgorithm",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "S3BucketSSEAlgorithm"
+          }
         }
       }
     },
@@ -13915,7 +13924,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-notificationconfig-topicconfig.html#cfn-s3-bucket-notificationconfig-topicconfig-event",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "S3BucketTopicConfigurationEvent"
+          }
         },
         "Filter": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-notificationconfig-topicconfig.html#cfn-s3-bucket-notificationconfig-topicconfig-filter",
@@ -25885,7 +25897,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket.html#cfn-s3-bucket-accesscontrol",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "S3BucketAccessControl"
+          }
         },
         "AnalyticsConfigurations": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket.html#cfn-s3-bucket-analyticsconfigurations",
@@ -27887,6 +27902,12 @@
         "SFTP"
       ]
     },
+    "HttpProtocol": {
+      "AllowedValues": [
+        "http",
+        "https"
+      ]
+    },
     "IamInstanceProfile": {
       "GetAtt": {},
       "Ref": {
@@ -28126,6 +28147,45 @@
           "AWS::ApiGateway::RestApi"
         ]
       }
+    },
+    "S3BucketAccelerationStatus": {
+      "AllowedValues": [
+        "Enabled",
+        "Suspended"
+      ]
+    },
+    "S3BucketAccessControl": {
+      "AllowedValues": [
+        "AuthenticatedRead",
+        "AwsExecRead",
+        "BucketOwnerFullControl",
+        "BucketOwnerRead",
+        "LogDeliveryWrite",
+        "Private",
+        "PublicRead",
+        "PublicReadWrite"
+      ]
+    },
+    "S3BucketSSEAlgorithm": {
+      "AllowedValues": [
+        "AES256",
+        "aws:kms"
+      ]
+    },
+    "S3BucketTopicConfigurationEvent": {
+      "AllowedValues": [
+        "s3:ObjectCreated:*",
+        "s3:ObjectCreated:CompleteMultipartUpload",
+        "s3:ObjectCreated:Copy",
+        "s3:ObjectCreated:Post",
+        "s3:ObjectCreated:Put",
+        "s3:ObjectRemoved:*",
+        "s3:ObjectRemoved:Delete",
+        "s3:ObjectRemoved:DeleteMarkerCreated",
+        "s3:ObjectRestore:Completed",
+        "s3:ObjectRestore:Post",
+        "s3:ReducedRedundancyLostObject"
+      ]
     },
     "S3BucketVersioningConfigurationStatus": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
@@ -13521,7 +13521,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-accelerateconfiguration.html#cfn-s3-bucket-accelerateconfiguration-accelerationstatus",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "S3BucketAccelerationStatus"
+          }
         }
       }
     },
@@ -13965,7 +13968,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-redirectallrequeststo.html#cfn-s3-websiteconfiguration-redirectallrequeststo-protocol",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "HttpProtocol"
+          }
         }
       }
     },
@@ -14239,7 +14245,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-serversideencryptionbydefault.html#cfn-s3-bucket-serversideencryptionbydefault-ssealgorithm",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "S3BucketSSEAlgorithm"
+          }
         }
       }
     },
@@ -14311,7 +14320,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-notificationconfig-topicconfig.html#cfn-s3-bucket-notificationconfig-topicconfig-event",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "S3BucketTopicConfigurationEvent"
+          }
         },
         "Filter": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-notificationconfig-topicconfig.html#cfn-s3-bucket-notificationconfig-topicconfig-filter",
@@ -27026,7 +27038,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket.html#cfn-s3-bucket-accesscontrol",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "S3BucketAccessControl"
+          }
         },
         "AnalyticsConfigurations": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket.html#cfn-s3-bucket-analyticsconfigurations",
@@ -29039,6 +29054,12 @@
         "SFTP"
       ]
     },
+    "HttpProtocol": {
+      "AllowedValues": [
+        "http",
+        "https"
+      ]
+    },
     "IamInstanceProfile": {
       "GetAtt": {},
       "Ref": {
@@ -29278,6 +29299,45 @@
           "AWS::ApiGateway::RestApi"
         ]
       }
+    },
+    "S3BucketAccelerationStatus": {
+      "AllowedValues": [
+        "Enabled",
+        "Suspended"
+      ]
+    },
+    "S3BucketAccessControl": {
+      "AllowedValues": [
+        "AuthenticatedRead",
+        "AwsExecRead",
+        "BucketOwnerFullControl",
+        "BucketOwnerRead",
+        "LogDeliveryWrite",
+        "Private",
+        "PublicRead",
+        "PublicReadWrite"
+      ]
+    },
+    "S3BucketSSEAlgorithm": {
+      "AllowedValues": [
+        "AES256",
+        "aws:kms"
+      ]
+    },
+    "S3BucketTopicConfigurationEvent": {
+      "AllowedValues": [
+        "s3:ObjectCreated:*",
+        "s3:ObjectCreated:CompleteMultipartUpload",
+        "s3:ObjectCreated:Copy",
+        "s3:ObjectCreated:Post",
+        "s3:ObjectCreated:Put",
+        "s3:ObjectRemoved:*",
+        "s3:ObjectRemoved:Delete",
+        "s3:ObjectRemoved:DeleteMarkerCreated",
+        "s3:ObjectRestore:Completed",
+        "s3:ObjectRestore:Post",
+        "s3:ReducedRedundancyLostObject"
+      ]
     },
     "S3BucketVersioningConfigurationStatus": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
@@ -27190,7 +27190,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sns-subscription.html#cfn-sns-protocol",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "SnsSubscriptionProtocol"
+          }
         },
         "RawMessageDelivery": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sns-subscription.html#cfn-sns-subscription-rawmessagedelivery",
@@ -29437,6 +29440,18 @@
           "AWS::EC2::SecurityGroup"
         ]
       }
+    },
+    "SnsSubscriptionProtocol": {
+      "AllowedValues": [
+        "application",
+        "email-json",
+        "email",
+        "http",
+        "https",
+        "lambda",
+        "sms",
+        "sqs"
+      ]
     },
     "SsmDocumentName": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
@@ -28138,7 +28138,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sns-subscription.html#cfn-sns-protocol",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "SnsSubscriptionProtocol"
+          }
         },
         "RawMessageDelivery": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sns-subscription.html#cfn-sns-subscription-rawmessagedelivery",
@@ -30385,6 +30388,18 @@
           "AWS::EC2::SecurityGroup"
         ]
       }
+    },
+    "SnsSubscriptionProtocol": {
+      "AllowedValues": [
+        "application",
+        "email-json",
+        "email",
+        "http",
+        "https",
+        "lambda",
+        "sms",
+        "sqs"
+      ]
     },
     "SsmDocumentName": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
@@ -14036,7 +14036,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-accelerateconfiguration.html#cfn-s3-bucket-accelerateconfiguration-accelerationstatus",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "S3BucketAccelerationStatus"
+          }
         }
       }
     },
@@ -14480,7 +14483,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-redirectallrequeststo.html#cfn-s3-websiteconfiguration-redirectallrequeststo-protocol",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "HttpProtocol"
+          }
         }
       }
     },
@@ -14754,7 +14760,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-serversideencryptionbydefault.html#cfn-s3-bucket-serversideencryptionbydefault-ssealgorithm",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "S3BucketSSEAlgorithm"
+          }
         }
       }
     },
@@ -14826,7 +14835,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-notificationconfig-topicconfig.html#cfn-s3-bucket-notificationconfig-topicconfig-event",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "S3BucketTopicConfigurationEvent"
+          }
         },
         "Filter": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-notificationconfig-topicconfig.html#cfn-s3-bucket-notificationconfig-topicconfig-filter",
@@ -27974,7 +27986,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket.html#cfn-s3-bucket-accesscontrol",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "S3BucketAccessControl"
+          }
         },
         "AnalyticsConfigurations": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket.html#cfn-s3-bucket-analyticsconfigurations",
@@ -29987,6 +30002,12 @@
         "SFTP"
       ]
     },
+    "HttpProtocol": {
+      "AllowedValues": [
+        "http",
+        "https"
+      ]
+    },
     "IamInstanceProfile": {
       "GetAtt": {},
       "Ref": {
@@ -30226,6 +30247,45 @@
           "AWS::ApiGateway::RestApi"
         ]
       }
+    },
+    "S3BucketAccelerationStatus": {
+      "AllowedValues": [
+        "Enabled",
+        "Suspended"
+      ]
+    },
+    "S3BucketAccessControl": {
+      "AllowedValues": [
+        "AuthenticatedRead",
+        "AwsExecRead",
+        "BucketOwnerFullControl",
+        "BucketOwnerRead",
+        "LogDeliveryWrite",
+        "Private",
+        "PublicRead",
+        "PublicReadWrite"
+      ]
+    },
+    "S3BucketSSEAlgorithm": {
+      "AllowedValues": [
+        "AES256",
+        "aws:kms"
+      ]
+    },
+    "S3BucketTopicConfigurationEvent": {
+      "AllowedValues": [
+        "s3:ObjectCreated:*",
+        "s3:ObjectCreated:CompleteMultipartUpload",
+        "s3:ObjectCreated:Copy",
+        "s3:ObjectCreated:Post",
+        "s3:ObjectCreated:Put",
+        "s3:ObjectRemoved:*",
+        "s3:ObjectRemoved:Delete",
+        "s3:ObjectRemoved:DeleteMarkerCreated",
+        "s3:ObjectRestore:Completed",
+        "s3:ObjectRestore:Post",
+        "s3:ReducedRedundancyLostObject"
+      ]
     },
     "S3BucketVersioningConfigurationStatus": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ca-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/ca-central-1.json
@@ -12179,7 +12179,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-accelerateconfiguration.html#cfn-s3-bucket-accelerateconfiguration-accelerationstatus",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "S3BucketAccelerationStatus"
+          }
         }
       }
     },
@@ -12623,7 +12626,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-redirectallrequeststo.html#cfn-s3-websiteconfiguration-redirectallrequeststo-protocol",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "HttpProtocol"
+          }
         }
       }
     },
@@ -12897,7 +12903,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-serversideencryptionbydefault.html#cfn-s3-bucket-serversideencryptionbydefault-ssealgorithm",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "S3BucketSSEAlgorithm"
+          }
         }
       }
     },
@@ -12969,7 +12978,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-notificationconfig-topicconfig.html#cfn-s3-bucket-notificationconfig-topicconfig-event",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "S3BucketTopicConfigurationEvent"
+          }
         },
         "Filter": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-notificationconfig-topicconfig.html#cfn-s3-bucket-notificationconfig-topicconfig-filter",
@@ -24288,7 +24300,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket.html#cfn-s3-bucket-accesscontrol",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "S3BucketAccessControl"
+          }
         },
         "AnalyticsConfigurations": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket.html#cfn-s3-bucket-analyticsconfigurations",
@@ -26247,6 +26262,12 @@
         "SFTP"
       ]
     },
+    "HttpProtocol": {
+      "AllowedValues": [
+        "http",
+        "https"
+      ]
+    },
     "IamInstanceProfile": {
       "GetAtt": {},
       "Ref": {
@@ -26486,6 +26507,45 @@
           "AWS::ApiGateway::RestApi"
         ]
       }
+    },
+    "S3BucketAccelerationStatus": {
+      "AllowedValues": [
+        "Enabled",
+        "Suspended"
+      ]
+    },
+    "S3BucketAccessControl": {
+      "AllowedValues": [
+        "AuthenticatedRead",
+        "AwsExecRead",
+        "BucketOwnerFullControl",
+        "BucketOwnerRead",
+        "LogDeliveryWrite",
+        "Private",
+        "PublicRead",
+        "PublicReadWrite"
+      ]
+    },
+    "S3BucketSSEAlgorithm": {
+      "AllowedValues": [
+        "AES256",
+        "aws:kms"
+      ]
+    },
+    "S3BucketTopicConfigurationEvent": {
+      "AllowedValues": [
+        "s3:ObjectCreated:*",
+        "s3:ObjectCreated:CompleteMultipartUpload",
+        "s3:ObjectCreated:Copy",
+        "s3:ObjectCreated:Post",
+        "s3:ObjectCreated:Put",
+        "s3:ObjectRemoved:*",
+        "s3:ObjectRemoved:Delete",
+        "s3:ObjectRemoved:DeleteMarkerCreated",
+        "s3:ObjectRestore:Completed",
+        "s3:ObjectRestore:Post",
+        "s3:ReducedRedundancyLostObject"
+      ]
     },
     "S3BucketVersioningConfigurationStatus": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ca-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/ca-central-1.json
@@ -24441,7 +24441,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sns-subscription.html#cfn-sns-protocol",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "SnsSubscriptionProtocol"
+          }
         },
         "RawMessageDelivery": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sns-subscription.html#cfn-sns-subscription-rawmessagedelivery",
@@ -26645,6 +26648,18 @@
           "AWS::EC2::SecurityGroup"
         ]
       }
+    },
+    "SnsSubscriptionProtocol": {
+      "AllowedValues": [
+        "application",
+        "email-json",
+        "email",
+        "http",
+        "https",
+        "lambda",
+        "sms",
+        "sqs"
+      ]
     },
     "SsmDocumentName": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/eu-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-central-1.json
@@ -14533,7 +14533,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-accelerateconfiguration.html#cfn-s3-bucket-accelerateconfiguration-accelerationstatus",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "S3BucketAccelerationStatus"
+          }
         }
       }
     },
@@ -14977,7 +14980,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-redirectallrequeststo.html#cfn-s3-websiteconfiguration-redirectallrequeststo-protocol",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "HttpProtocol"
+          }
         }
       }
     },
@@ -15251,7 +15257,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-serversideencryptionbydefault.html#cfn-s3-bucket-serversideencryptionbydefault-ssealgorithm",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "S3BucketSSEAlgorithm"
+          }
         }
       }
     },
@@ -15323,7 +15332,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-notificationconfig-topicconfig.html#cfn-s3-bucket-notificationconfig-topicconfig-event",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "S3BucketTopicConfigurationEvent"
+          }
         },
         "Filter": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-notificationconfig-topicconfig.html#cfn-s3-bucket-notificationconfig-topicconfig-filter",
@@ -28710,7 +28722,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket.html#cfn-s3-bucket-accesscontrol",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "S3BucketAccessControl"
+          }
         },
         "AnalyticsConfigurations": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket.html#cfn-s3-bucket-analyticsconfigurations",
@@ -30728,6 +30743,12 @@
         "SFTP"
       ]
     },
+    "HttpProtocol": {
+      "AllowedValues": [
+        "http",
+        "https"
+      ]
+    },
     "IamInstanceProfile": {
       "GetAtt": {},
       "Ref": {
@@ -30967,6 +30988,45 @@
           "AWS::ApiGateway::RestApi"
         ]
       }
+    },
+    "S3BucketAccelerationStatus": {
+      "AllowedValues": [
+        "Enabled",
+        "Suspended"
+      ]
+    },
+    "S3BucketAccessControl": {
+      "AllowedValues": [
+        "AuthenticatedRead",
+        "AwsExecRead",
+        "BucketOwnerFullControl",
+        "BucketOwnerRead",
+        "LogDeliveryWrite",
+        "Private",
+        "PublicRead",
+        "PublicReadWrite"
+      ]
+    },
+    "S3BucketSSEAlgorithm": {
+      "AllowedValues": [
+        "AES256",
+        "aws:kms"
+      ]
+    },
+    "S3BucketTopicConfigurationEvent": {
+      "AllowedValues": [
+        "s3:ObjectCreated:*",
+        "s3:ObjectCreated:CompleteMultipartUpload",
+        "s3:ObjectCreated:Copy",
+        "s3:ObjectCreated:Post",
+        "s3:ObjectCreated:Put",
+        "s3:ObjectRemoved:*",
+        "s3:ObjectRemoved:Delete",
+        "s3:ObjectRemoved:DeleteMarkerCreated",
+        "s3:ObjectRestore:Completed",
+        "s3:ObjectRestore:Post",
+        "s3:ReducedRedundancyLostObject"
+      ]
     },
     "S3BucketVersioningConfigurationStatus": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/eu-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-central-1.json
@@ -28863,7 +28863,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sns-subscription.html#cfn-sns-protocol",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "SnsSubscriptionProtocol"
+          }
         },
         "RawMessageDelivery": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sns-subscription.html#cfn-sns-subscription-rawmessagedelivery",
@@ -31126,6 +31129,18 @@
           "AWS::EC2::SecurityGroup"
         ]
       }
+    },
+    "SnsSubscriptionProtocol": {
+      "AllowedValues": [
+        "application",
+        "email-json",
+        "email",
+        "http",
+        "https",
+        "lambda",
+        "sms",
+        "sqs"
+      ]
     },
     "SsmDocumentName": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/eu-north-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-north-1.json
@@ -20593,7 +20593,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sns-subscription.html#cfn-sns-protocol",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "SnsSubscriptionProtocol"
+          }
         },
         "RawMessageDelivery": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sns-subscription.html#cfn-sns-subscription-rawmessagedelivery",
@@ -21718,6 +21721,18 @@
           "AWS::EC2::SecurityGroup"
         ]
       }
+    },
+    "SnsSubscriptionProtocol": {
+      "AllowedValues": [
+        "application",
+        "email-json",
+        "email",
+        "http",
+        "https",
+        "lambda",
+        "sms",
+        "sqs"
+      ]
     },
     "SsmDocumentName": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/eu-north-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-north-1.json
@@ -9738,7 +9738,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-accelerateconfiguration.html#cfn-s3-bucket-accelerateconfiguration-accelerationstatus",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "S3BucketAccelerationStatus"
+          }
         }
       }
     },
@@ -10182,7 +10185,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-redirectallrequeststo.html#cfn-s3-websiteconfiguration-redirectallrequeststo-protocol",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "HttpProtocol"
+          }
         }
       }
     },
@@ -10456,7 +10462,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-serversideencryptionbydefault.html#cfn-s3-bucket-serversideencryptionbydefault-ssealgorithm",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "S3BucketSSEAlgorithm"
+          }
         }
       }
     },
@@ -10528,7 +10537,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-notificationconfig-topicconfig.html#cfn-s3-bucket-notificationconfig-topicconfig-event",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "S3BucketTopicConfigurationEvent"
+          }
         },
         "Filter": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-notificationconfig-topicconfig.html#cfn-s3-bucket-notificationconfig-topicconfig-filter",
@@ -20429,7 +20441,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket.html#cfn-s3-bucket-accesscontrol",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "S3BucketAccessControl"
+          }
         },
         "AnalyticsConfigurations": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket.html#cfn-s3-bucket-analyticsconfigurations",
@@ -21320,6 +21335,12 @@
         "SFTP"
       ]
     },
+    "HttpProtocol": {
+      "AllowedValues": [
+        "http",
+        "https"
+      ]
+    },
     "IamInstanceProfile": {
       "GetAtt": {},
       "Ref": {
@@ -21559,6 +21580,45 @@
           "AWS::ApiGateway::RestApi"
         ]
       }
+    },
+    "S3BucketAccelerationStatus": {
+      "AllowedValues": [
+        "Enabled",
+        "Suspended"
+      ]
+    },
+    "S3BucketAccessControl": {
+      "AllowedValues": [
+        "AuthenticatedRead",
+        "AwsExecRead",
+        "BucketOwnerFullControl",
+        "BucketOwnerRead",
+        "LogDeliveryWrite",
+        "Private",
+        "PublicRead",
+        "PublicReadWrite"
+      ]
+    },
+    "S3BucketSSEAlgorithm": {
+      "AllowedValues": [
+        "AES256",
+        "aws:kms"
+      ]
+    },
+    "S3BucketTopicConfigurationEvent": {
+      "AllowedValues": [
+        "s3:ObjectCreated:*",
+        "s3:ObjectCreated:CompleteMultipartUpload",
+        "s3:ObjectCreated:Copy",
+        "s3:ObjectCreated:Post",
+        "s3:ObjectCreated:Put",
+        "s3:ObjectRemoved:*",
+        "s3:ObjectRemoved:Delete",
+        "s3:ObjectRemoved:DeleteMarkerCreated",
+        "s3:ObjectRestore:Completed",
+        "s3:ObjectRestore:Post",
+        "s3:ReducedRedundancyLostObject"
+      ]
     },
     "S3BucketVersioningConfigurationStatus": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/eu-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-1.json
@@ -15489,7 +15489,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-accelerateconfiguration.html#cfn-s3-bucket-accelerateconfiguration-accelerationstatus",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "S3BucketAccelerationStatus"
+          }
         }
       }
     },
@@ -15933,7 +15936,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-redirectallrequeststo.html#cfn-s3-websiteconfiguration-redirectallrequeststo-protocol",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "HttpProtocol"
+          }
         }
       }
     },
@@ -16207,7 +16213,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-serversideencryptionbydefault.html#cfn-s3-bucket-serversideencryptionbydefault-ssealgorithm",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "S3BucketSSEAlgorithm"
+          }
         }
       }
     },
@@ -16279,7 +16288,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-notificationconfig-topicconfig.html#cfn-s3-bucket-notificationconfig-topicconfig-event",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "S3BucketTopicConfigurationEvent"
+          }
         },
         "Filter": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-notificationconfig-topicconfig.html#cfn-s3-bucket-notificationconfig-topicconfig-filter",
@@ -31139,7 +31151,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket.html#cfn-s3-bucket-accesscontrol",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "S3BucketAccessControl"
+          }
         },
         "AnalyticsConfigurations": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket.html#cfn-s3-bucket-analyticsconfigurations",
@@ -33580,6 +33595,12 @@
         "SFTP"
       ]
     },
+    "HttpProtocol": {
+      "AllowedValues": [
+        "http",
+        "https"
+      ]
+    },
     "IamInstanceProfile": {
       "GetAtt": {},
       "Ref": {
@@ -33819,6 +33840,45 @@
           "AWS::ApiGateway::RestApi"
         ]
       }
+    },
+    "S3BucketAccelerationStatus": {
+      "AllowedValues": [
+        "Enabled",
+        "Suspended"
+      ]
+    },
+    "S3BucketAccessControl": {
+      "AllowedValues": [
+        "AuthenticatedRead",
+        "AwsExecRead",
+        "BucketOwnerFullControl",
+        "BucketOwnerRead",
+        "LogDeliveryWrite",
+        "Private",
+        "PublicRead",
+        "PublicReadWrite"
+      ]
+    },
+    "S3BucketSSEAlgorithm": {
+      "AllowedValues": [
+        "AES256",
+        "aws:kms"
+      ]
+    },
+    "S3BucketTopicConfigurationEvent": {
+      "AllowedValues": [
+        "s3:ObjectCreated:*",
+        "s3:ObjectCreated:CompleteMultipartUpload",
+        "s3:ObjectCreated:Copy",
+        "s3:ObjectCreated:Post",
+        "s3:ObjectCreated:Put",
+        "s3:ObjectRemoved:*",
+        "s3:ObjectRemoved:Delete",
+        "s3:ObjectRemoved:DeleteMarkerCreated",
+        "s3:ObjectRestore:Completed",
+        "s3:ObjectRestore:Post",
+        "s3:ReducedRedundancyLostObject"
+      ]
     },
     "S3BucketVersioningConfigurationStatus": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/eu-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-1.json
@@ -31387,7 +31387,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sns-subscription.html#cfn-sns-protocol",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "SnsSubscriptionProtocol"
+          }
         },
         "RawMessageDelivery": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sns-subscription.html#cfn-sns-subscription-rawmessagedelivery",
@@ -33978,6 +33981,18 @@
           "AWS::EC2::SecurityGroup"
         ]
       }
+    },
+    "SnsSubscriptionProtocol": {
+      "AllowedValues": [
+        "application",
+        "email-json",
+        "email",
+        "http",
+        "https",
+        "lambda",
+        "sms",
+        "sqs"
+      ]
     },
     "SsmDocumentName": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/eu-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-2.json
@@ -25742,7 +25742,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sns-subscription.html#cfn-sns-protocol",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "SnsSubscriptionProtocol"
+          }
         },
         "RawMessageDelivery": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sns-subscription.html#cfn-sns-subscription-rawmessagedelivery",
@@ -27946,6 +27949,18 @@
           "AWS::EC2::SecurityGroup"
         ]
       }
+    },
+    "SnsSubscriptionProtocol": {
+      "AllowedValues": [
+        "application",
+        "email-json",
+        "email",
+        "http",
+        "https",
+        "lambda",
+        "sms",
+        "sqs"
+      ]
     },
     "SsmDocumentName": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/eu-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-2.json
@@ -12652,7 +12652,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-accelerateconfiguration.html#cfn-s3-bucket-accelerateconfiguration-accelerationstatus",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "S3BucketAccelerationStatus"
+          }
         }
       }
     },
@@ -13096,7 +13099,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-redirectallrequeststo.html#cfn-s3-websiteconfiguration-redirectallrequeststo-protocol",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "HttpProtocol"
+          }
         }
       }
     },
@@ -13370,7 +13376,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-serversideencryptionbydefault.html#cfn-s3-bucket-serversideencryptionbydefault-ssealgorithm",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "S3BucketSSEAlgorithm"
+          }
         }
       }
     },
@@ -13442,7 +13451,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-notificationconfig-topicconfig.html#cfn-s3-bucket-notificationconfig-topicconfig-event",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "S3BucketTopicConfigurationEvent"
+          }
         },
         "Filter": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-notificationconfig-topicconfig.html#cfn-s3-bucket-notificationconfig-topicconfig-filter",
@@ -25589,7 +25601,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket.html#cfn-s3-bucket-accesscontrol",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "S3BucketAccessControl"
+          }
         },
         "AnalyticsConfigurations": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket.html#cfn-s3-bucket-analyticsconfigurations",
@@ -27548,6 +27563,12 @@
         "SFTP"
       ]
     },
+    "HttpProtocol": {
+      "AllowedValues": [
+        "http",
+        "https"
+      ]
+    },
     "IamInstanceProfile": {
       "GetAtt": {},
       "Ref": {
@@ -27787,6 +27808,45 @@
           "AWS::ApiGateway::RestApi"
         ]
       }
+    },
+    "S3BucketAccelerationStatus": {
+      "AllowedValues": [
+        "Enabled",
+        "Suspended"
+      ]
+    },
+    "S3BucketAccessControl": {
+      "AllowedValues": [
+        "AuthenticatedRead",
+        "AwsExecRead",
+        "BucketOwnerFullControl",
+        "BucketOwnerRead",
+        "LogDeliveryWrite",
+        "Private",
+        "PublicRead",
+        "PublicReadWrite"
+      ]
+    },
+    "S3BucketSSEAlgorithm": {
+      "AllowedValues": [
+        "AES256",
+        "aws:kms"
+      ]
+    },
+    "S3BucketTopicConfigurationEvent": {
+      "AllowedValues": [
+        "s3:ObjectCreated:*",
+        "s3:ObjectCreated:CompleteMultipartUpload",
+        "s3:ObjectCreated:Copy",
+        "s3:ObjectCreated:Post",
+        "s3:ObjectCreated:Put",
+        "s3:ObjectRemoved:*",
+        "s3:ObjectRemoved:Delete",
+        "s3:ObjectRemoved:DeleteMarkerCreated",
+        "s3:ObjectRestore:Completed",
+        "s3:ObjectRestore:Post",
+        "s3:ReducedRedundancyLostObject"
+      ]
     },
     "S3BucketVersioningConfigurationStatus": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/eu-west-3.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-3.json
@@ -22860,7 +22860,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sns-subscription.html#cfn-sns-protocol",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "SnsSubscriptionProtocol"
+          }
         },
         "RawMessageDelivery": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sns-subscription.html#cfn-sns-subscription-rawmessagedelivery",
@@ -24910,6 +24913,18 @@
           "AWS::EC2::SecurityGroup"
         ]
       }
+    },
+    "SnsSubscriptionProtocol": {
+      "AllowedValues": [
+        "application",
+        "email-json",
+        "email",
+        "http",
+        "https",
+        "lambda",
+        "sms",
+        "sqs"
+      ]
     },
     "SsmDocumentName": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/eu-west-3.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-3.json
@@ -11386,7 +11386,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-accelerateconfiguration.html#cfn-s3-bucket-accelerateconfiguration-accelerationstatus",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "S3BucketAccelerationStatus"
+          }
         }
       }
     },
@@ -11830,7 +11833,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-redirectallrequeststo.html#cfn-s3-websiteconfiguration-redirectallrequeststo-protocol",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "HttpProtocol"
+          }
         }
       }
     },
@@ -12104,7 +12110,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-serversideencryptionbydefault.html#cfn-s3-bucket-serversideencryptionbydefault-ssealgorithm",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "S3BucketSSEAlgorithm"
+          }
         }
       }
     },
@@ -12176,7 +12185,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-notificationconfig-topicconfig.html#cfn-s3-bucket-notificationconfig-topicconfig-event",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "S3BucketTopicConfigurationEvent"
+          }
         },
         "Filter": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-notificationconfig-topicconfig.html#cfn-s3-bucket-notificationconfig-topicconfig-filter",
@@ -22707,7 +22719,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket.html#cfn-s3-bucket-accesscontrol",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "S3BucketAccessControl"
+          }
         },
         "AnalyticsConfigurations": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket.html#cfn-s3-bucket-analyticsconfigurations",
@@ -24512,6 +24527,12 @@
         "SFTP"
       ]
     },
+    "HttpProtocol": {
+      "AllowedValues": [
+        "http",
+        "https"
+      ]
+    },
     "IamInstanceProfile": {
       "GetAtt": {},
       "Ref": {
@@ -24751,6 +24772,45 @@
           "AWS::ApiGateway::RestApi"
         ]
       }
+    },
+    "S3BucketAccelerationStatus": {
+      "AllowedValues": [
+        "Enabled",
+        "Suspended"
+      ]
+    },
+    "S3BucketAccessControl": {
+      "AllowedValues": [
+        "AuthenticatedRead",
+        "AwsExecRead",
+        "BucketOwnerFullControl",
+        "BucketOwnerRead",
+        "LogDeliveryWrite",
+        "Private",
+        "PublicRead",
+        "PublicReadWrite"
+      ]
+    },
+    "S3BucketSSEAlgorithm": {
+      "AllowedValues": [
+        "AES256",
+        "aws:kms"
+      ]
+    },
+    "S3BucketTopicConfigurationEvent": {
+      "AllowedValues": [
+        "s3:ObjectCreated:*",
+        "s3:ObjectCreated:CompleteMultipartUpload",
+        "s3:ObjectCreated:Copy",
+        "s3:ObjectCreated:Post",
+        "s3:ObjectCreated:Put",
+        "s3:ObjectRemoved:*",
+        "s3:ObjectRemoved:Delete",
+        "s3:ObjectRemoved:DeleteMarkerCreated",
+        "s3:ObjectRestore:Completed",
+        "s3:ObjectRestore:Post",
+        "s3:ReducedRedundancyLostObject"
+      ]
     },
     "S3BucketVersioningConfigurationStatus": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/sa-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/sa-east-1.json
@@ -23820,7 +23820,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sns-subscription.html#cfn-sns-protocol",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "SnsSubscriptionProtocol"
+          }
         },
         "RawMessageDelivery": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sns-subscription.html#cfn-sns-subscription-rawmessagedelivery",
@@ -25819,6 +25822,18 @@
           "AWS::EC2::SecurityGroup"
         ]
       }
+    },
+    "SnsSubscriptionProtocol": {
+      "AllowedValues": [
+        "application",
+        "email-json",
+        "email",
+        "http",
+        "https",
+        "lambda",
+        "sms",
+        "sqs"
+      ]
     },
     "SsmDocumentName": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/sa-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/sa-east-1.json
@@ -11865,7 +11865,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-accelerateconfiguration.html#cfn-s3-bucket-accelerateconfiguration-accelerationstatus",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "S3BucketAccelerationStatus"
+          }
         }
       }
     },
@@ -12309,7 +12312,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-redirectallrequeststo.html#cfn-s3-websiteconfiguration-redirectallrequeststo-protocol",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "HttpProtocol"
+          }
         }
       }
     },
@@ -12583,7 +12589,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-serversideencryptionbydefault.html#cfn-s3-bucket-serversideencryptionbydefault-ssealgorithm",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "S3BucketSSEAlgorithm"
+          }
         }
       }
     },
@@ -12655,7 +12664,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-notificationconfig-topicconfig.html#cfn-s3-bucket-notificationconfig-topicconfig-event",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "S3BucketTopicConfigurationEvent"
+          }
         },
         "Filter": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-notificationconfig-topicconfig.html#cfn-s3-bucket-notificationconfig-topicconfig-filter",
@@ -23656,7 +23668,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket.html#cfn-s3-bucket-accesscontrol",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "S3BucketAccessControl"
+          }
         },
         "AnalyticsConfigurations": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket.html#cfn-s3-bucket-analyticsconfigurations",
@@ -25421,6 +25436,12 @@
         "SFTP"
       ]
     },
+    "HttpProtocol": {
+      "AllowedValues": [
+        "http",
+        "https"
+      ]
+    },
     "IamInstanceProfile": {
       "GetAtt": {},
       "Ref": {
@@ -25660,6 +25681,45 @@
           "AWS::ApiGateway::RestApi"
         ]
       }
+    },
+    "S3BucketAccelerationStatus": {
+      "AllowedValues": [
+        "Enabled",
+        "Suspended"
+      ]
+    },
+    "S3BucketAccessControl": {
+      "AllowedValues": [
+        "AuthenticatedRead",
+        "AwsExecRead",
+        "BucketOwnerFullControl",
+        "BucketOwnerRead",
+        "LogDeliveryWrite",
+        "Private",
+        "PublicRead",
+        "PublicReadWrite"
+      ]
+    },
+    "S3BucketSSEAlgorithm": {
+      "AllowedValues": [
+        "AES256",
+        "aws:kms"
+      ]
+    },
+    "S3BucketTopicConfigurationEvent": {
+      "AllowedValues": [
+        "s3:ObjectCreated:*",
+        "s3:ObjectCreated:CompleteMultipartUpload",
+        "s3:ObjectCreated:Copy",
+        "s3:ObjectCreated:Post",
+        "s3:ObjectCreated:Put",
+        "s3:ObjectRemoved:*",
+        "s3:ObjectRemoved:Delete",
+        "s3:ObjectRemoved:DeleteMarkerCreated",
+        "s3:ObjectRestore:Completed",
+        "s3:ObjectRestore:Post",
+        "s3:ReducedRedundancyLostObject"
+      ]
     },
     "S3BucketVersioningConfigurationStatus": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/us-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-1.json
@@ -31458,7 +31458,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sns-subscription.html#cfn-sns-protocol",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "SnsSubscriptionProtocol"
+          }
         },
         "RawMessageDelivery": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sns-subscription.html#cfn-sns-subscription-rawmessagedelivery",
@@ -34007,6 +34010,18 @@
           "AWS::EC2::SecurityGroup"
         ]
       }
+    },
+    "SnsSubscriptionProtocol": {
+      "AllowedValues": [
+        "application",
+        "email-json",
+        "email",
+        "http",
+        "https",
+        "lambda",
+        "sms",
+        "sqs"
+      ]
     },
     "SsmDocumentName": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/us-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-1.json
@@ -15508,7 +15508,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-accelerateconfiguration.html#cfn-s3-bucket-accelerateconfiguration-accelerationstatus",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "S3BucketAccelerationStatus"
+          }
         }
       }
     },
@@ -15952,7 +15955,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-redirectallrequeststo.html#cfn-s3-websiteconfiguration-redirectallrequeststo-protocol",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "HttpProtocol"
+          }
         }
       }
     },
@@ -16226,7 +16232,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-serversideencryptionbydefault.html#cfn-s3-bucket-serversideencryptionbydefault-ssealgorithm",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "S3BucketSSEAlgorithm"
+          }
         }
       }
     },
@@ -16298,7 +16307,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-notificationconfig-topicconfig.html#cfn-s3-bucket-notificationconfig-topicconfig-event",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "S3BucketTopicConfigurationEvent"
+          }
         },
         "Filter": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-notificationconfig-topicconfig.html#cfn-s3-bucket-notificationconfig-topicconfig-filter",
@@ -31210,7 +31222,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket.html#cfn-s3-bucket-accesscontrol",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "S3BucketAccessControl"
+          }
         },
         "AnalyticsConfigurations": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket.html#cfn-s3-bucket-analyticsconfigurations",
@@ -33609,6 +33624,12 @@
         "SFTP"
       ]
     },
+    "HttpProtocol": {
+      "AllowedValues": [
+        "http",
+        "https"
+      ]
+    },
     "IamInstanceProfile": {
       "GetAtt": {},
       "Ref": {
@@ -33848,6 +33869,45 @@
           "AWS::ApiGateway::RestApi"
         ]
       }
+    },
+    "S3BucketAccelerationStatus": {
+      "AllowedValues": [
+        "Enabled",
+        "Suspended"
+      ]
+    },
+    "S3BucketAccessControl": {
+      "AllowedValues": [
+        "AuthenticatedRead",
+        "AwsExecRead",
+        "BucketOwnerFullControl",
+        "BucketOwnerRead",
+        "LogDeliveryWrite",
+        "Private",
+        "PublicRead",
+        "PublicReadWrite"
+      ]
+    },
+    "S3BucketSSEAlgorithm": {
+      "AllowedValues": [
+        "AES256",
+        "aws:kms"
+      ]
+    },
+    "S3BucketTopicConfigurationEvent": {
+      "AllowedValues": [
+        "s3:ObjectCreated:*",
+        "s3:ObjectCreated:CompleteMultipartUpload",
+        "s3:ObjectCreated:Copy",
+        "s3:ObjectCreated:Post",
+        "s3:ObjectCreated:Put",
+        "s3:ObjectRemoved:*",
+        "s3:ObjectRemoved:Delete",
+        "s3:ObjectRemoved:DeleteMarkerCreated",
+        "s3:ObjectRestore:Completed",
+        "s3:ObjectRestore:Post",
+        "s3:ReducedRedundancyLostObject"
+      ]
     },
     "S3BucketVersioningConfigurationStatus": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/us-east-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-2.json
@@ -15013,7 +15013,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-accelerateconfiguration.html#cfn-s3-bucket-accelerateconfiguration-accelerationstatus",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "S3BucketAccelerationStatus"
+          }
         }
       }
     },
@@ -15457,7 +15460,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-redirectallrequeststo.html#cfn-s3-websiteconfiguration-redirectallrequeststo-protocol",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "HttpProtocol"
+          }
         }
       }
     },
@@ -15731,7 +15737,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-serversideencryptionbydefault.html#cfn-s3-bucket-serversideencryptionbydefault-ssealgorithm",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "S3BucketSSEAlgorithm"
+          }
         }
       }
     },
@@ -15803,7 +15812,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-notificationconfig-topicconfig.html#cfn-s3-bucket-notificationconfig-topicconfig-event",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "S3BucketTopicConfigurationEvent"
+          }
         },
         "Filter": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-notificationconfig-topicconfig.html#cfn-s3-bucket-notificationconfig-topicconfig-filter",
@@ -29440,7 +29452,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket.html#cfn-s3-bucket-accesscontrol",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "S3BucketAccessControl"
+          }
         },
         "AnalyticsConfigurations": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket.html#cfn-s3-bucket-analyticsconfigurations",
@@ -31625,6 +31640,12 @@
         "SFTP"
       ]
     },
+    "HttpProtocol": {
+      "AllowedValues": [
+        "http",
+        "https"
+      ]
+    },
     "IamInstanceProfile": {
       "GetAtt": {},
       "Ref": {
@@ -31864,6 +31885,45 @@
           "AWS::ApiGateway::RestApi"
         ]
       }
+    },
+    "S3BucketAccelerationStatus": {
+      "AllowedValues": [
+        "Enabled",
+        "Suspended"
+      ]
+    },
+    "S3BucketAccessControl": {
+      "AllowedValues": [
+        "AuthenticatedRead",
+        "AwsExecRead",
+        "BucketOwnerFullControl",
+        "BucketOwnerRead",
+        "LogDeliveryWrite",
+        "Private",
+        "PublicRead",
+        "PublicReadWrite"
+      ]
+    },
+    "S3BucketSSEAlgorithm": {
+      "AllowedValues": [
+        "AES256",
+        "aws:kms"
+      ]
+    },
+    "S3BucketTopicConfigurationEvent": {
+      "AllowedValues": [
+        "s3:ObjectCreated:*",
+        "s3:ObjectCreated:CompleteMultipartUpload",
+        "s3:ObjectCreated:Copy",
+        "s3:ObjectCreated:Post",
+        "s3:ObjectCreated:Put",
+        "s3:ObjectRemoved:*",
+        "s3:ObjectRemoved:Delete",
+        "s3:ObjectRemoved:DeleteMarkerCreated",
+        "s3:ObjectRestore:Completed",
+        "s3:ObjectRestore:Post",
+        "s3:ReducedRedundancyLostObject"
+      ]
     },
     "S3BucketVersioningConfigurationStatus": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/us-east-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-2.json
@@ -29593,7 +29593,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sns-subscription.html#cfn-sns-protocol",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "SnsSubscriptionProtocol"
+          }
         },
         "RawMessageDelivery": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sns-subscription.html#cfn-sns-subscription-rawmessagedelivery",
@@ -32023,6 +32026,18 @@
           "AWS::EC2::SecurityGroup"
         ]
       }
+    },
+    "SnsSubscriptionProtocol": {
+      "AllowedValues": [
+        "application",
+        "email-json",
+        "email",
+        "http",
+        "https",
+        "lambda",
+        "sms",
+        "sqs"
+      ]
     },
     "SsmDocumentName": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
@@ -9609,7 +9609,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-accelerateconfiguration.html#cfn-s3-bucket-accelerateconfiguration-accelerationstatus",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "S3BucketAccelerationStatus"
+          }
         }
       }
     },
@@ -10053,7 +10056,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-redirectallrequeststo.html#cfn-s3-websiteconfiguration-redirectallrequeststo-protocol",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "HttpProtocol"
+          }
         }
       }
     },
@@ -10327,7 +10333,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-serversideencryptionbydefault.html#cfn-s3-bucket-serversideencryptionbydefault-ssealgorithm",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "S3BucketSSEAlgorithm"
+          }
         }
       }
     },
@@ -10399,7 +10408,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-notificationconfig-topicconfig.html#cfn-s3-bucket-notificationconfig-topicconfig-event",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "S3BucketTopicConfigurationEvent"
+          }
         },
         "Filter": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-notificationconfig-topicconfig.html#cfn-s3-bucket-notificationconfig-topicconfig-filter",
@@ -19852,7 +19864,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket.html#cfn-s3-bucket-accesscontrol",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "S3BucketAccessControl"
+          }
         },
         "AnalyticsConfigurations": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket.html#cfn-s3-bucket-analyticsconfigurations",
@@ -20743,6 +20758,12 @@
         "SFTP"
       ]
     },
+    "HttpProtocol": {
+      "AllowedValues": [
+        "http",
+        "https"
+      ]
+    },
     "IamInstanceProfile": {
       "GetAtt": {},
       "Ref": {
@@ -20982,6 +21003,45 @@
           "AWS::ApiGateway::RestApi"
         ]
       }
+    },
+    "S3BucketAccelerationStatus": {
+      "AllowedValues": [
+        "Enabled",
+        "Suspended"
+      ]
+    },
+    "S3BucketAccessControl": {
+      "AllowedValues": [
+        "AuthenticatedRead",
+        "AwsExecRead",
+        "BucketOwnerFullControl",
+        "BucketOwnerRead",
+        "LogDeliveryWrite",
+        "Private",
+        "PublicRead",
+        "PublicReadWrite"
+      ]
+    },
+    "S3BucketSSEAlgorithm": {
+      "AllowedValues": [
+        "AES256",
+        "aws:kms"
+      ]
+    },
+    "S3BucketTopicConfigurationEvent": {
+      "AllowedValues": [
+        "s3:ObjectCreated:*",
+        "s3:ObjectCreated:CompleteMultipartUpload",
+        "s3:ObjectCreated:Copy",
+        "s3:ObjectCreated:Post",
+        "s3:ObjectCreated:Put",
+        "s3:ObjectRemoved:*",
+        "s3:ObjectRemoved:Delete",
+        "s3:ObjectRemoved:DeleteMarkerCreated",
+        "s3:ObjectRestore:Completed",
+        "s3:ObjectRestore:Post",
+        "s3:ReducedRedundancyLostObject"
+      ]
     },
     "S3BucketVersioningConfigurationStatus": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
@@ -20016,7 +20016,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sns-subscription.html#cfn-sns-protocol",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "SnsSubscriptionProtocol"
+          }
         },
         "RawMessageDelivery": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sns-subscription.html#cfn-sns-subscription-rawmessagedelivery",
@@ -21141,6 +21144,18 @@
           "AWS::EC2::SecurityGroup"
         ]
       }
+    },
+    "SnsSubscriptionProtocol": {
+      "AllowedValues": [
+        "application",
+        "email-json",
+        "email",
+        "http",
+        "https",
+        "lambda",
+        "sms",
+        "sqs"
+      ]
     },
     "SsmDocumentName": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
@@ -9632,7 +9632,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-accelerateconfiguration.html#cfn-s3-bucket-accelerateconfiguration-accelerationstatus",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "S3BucketAccelerationStatus"
+          }
         }
       }
     },
@@ -10076,7 +10079,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-redirectallrequeststo.html#cfn-s3-websiteconfiguration-redirectallrequeststo-protocol",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "HttpProtocol"
+          }
         }
       }
     },
@@ -10350,7 +10356,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-serversideencryptionbydefault.html#cfn-s3-bucket-serversideencryptionbydefault-ssealgorithm",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "S3BucketSSEAlgorithm"
+          }
         }
       }
     },
@@ -10422,7 +10431,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-notificationconfig-topicconfig.html#cfn-s3-bucket-notificationconfig-topicconfig-event",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "S3BucketTopicConfigurationEvent"
+          }
         },
         "Filter": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-notificationconfig-topicconfig.html#cfn-s3-bucket-notificationconfig-topicconfig-filter",
@@ -19928,7 +19940,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket.html#cfn-s3-bucket-accesscontrol",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "S3BucketAccessControl"
+          }
         },
         "AnalyticsConfigurations": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket.html#cfn-s3-bucket-analyticsconfigurations",
@@ -20901,6 +20916,12 @@
         "SFTP"
       ]
     },
+    "HttpProtocol": {
+      "AllowedValues": [
+        "http",
+        "https"
+      ]
+    },
     "IamInstanceProfile": {
       "GetAtt": {},
       "Ref": {
@@ -21140,6 +21161,45 @@
           "AWS::ApiGateway::RestApi"
         ]
       }
+    },
+    "S3BucketAccelerationStatus": {
+      "AllowedValues": [
+        "Enabled",
+        "Suspended"
+      ]
+    },
+    "S3BucketAccessControl": {
+      "AllowedValues": [
+        "AuthenticatedRead",
+        "AwsExecRead",
+        "BucketOwnerFullControl",
+        "BucketOwnerRead",
+        "LogDeliveryWrite",
+        "Private",
+        "PublicRead",
+        "PublicReadWrite"
+      ]
+    },
+    "S3BucketSSEAlgorithm": {
+      "AllowedValues": [
+        "AES256",
+        "aws:kms"
+      ]
+    },
+    "S3BucketTopicConfigurationEvent": {
+      "AllowedValues": [
+        "s3:ObjectCreated:*",
+        "s3:ObjectCreated:CompleteMultipartUpload",
+        "s3:ObjectCreated:Copy",
+        "s3:ObjectCreated:Post",
+        "s3:ObjectCreated:Put",
+        "s3:ObjectRemoved:*",
+        "s3:ObjectRemoved:Delete",
+        "s3:ObjectRemoved:DeleteMarkerCreated",
+        "s3:ObjectRestore:Completed",
+        "s3:ObjectRestore:Post",
+        "s3:ReducedRedundancyLostObject"
+      ]
     },
     "S3BucketVersioningConfigurationStatus": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
@@ -20092,7 +20092,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sns-subscription.html#cfn-sns-protocol",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "SnsSubscriptionProtocol"
+          }
         },
         "RawMessageDelivery": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sns-subscription.html#cfn-sns-subscription-rawmessagedelivery",
@@ -21299,6 +21302,18 @@
           "AWS::EC2::SecurityGroup"
         ]
       }
+    },
+    "SnsSubscriptionProtocol": {
+      "AllowedValues": [
+        "application",
+        "email-json",
+        "email",
+        "http",
+        "https",
+        "lambda",
+        "sms",
+        "sqs"
+      ]
     },
     "SsmDocumentName": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/us-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-1.json
@@ -25080,7 +25080,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sns-subscription.html#cfn-sns-protocol",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "SnsSubscriptionProtocol"
+          }
         },
         "RawMessageDelivery": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sns-subscription.html#cfn-sns-subscription-rawmessagedelivery",
@@ -27279,6 +27282,18 @@
           "AWS::EC2::SecurityGroup"
         ]
       }
+    },
+    "SnsSubscriptionProtocol": {
+      "AllowedValues": [
+        "application",
+        "email-json",
+        "email",
+        "http",
+        "https",
+        "lambda",
+        "sms",
+        "sqs"
+      ]
     },
     "SsmDocumentName": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/us-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-1.json
@@ -12377,7 +12377,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-accelerateconfiguration.html#cfn-s3-bucket-accelerateconfiguration-accelerationstatus",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "S3BucketAccelerationStatus"
+          }
         }
       }
     },
@@ -12821,7 +12824,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-redirectallrequeststo.html#cfn-s3-websiteconfiguration-redirectallrequeststo-protocol",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "HttpProtocol"
+          }
         }
       }
     },
@@ -13095,7 +13101,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-serversideencryptionbydefault.html#cfn-s3-bucket-serversideencryptionbydefault-ssealgorithm",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "S3BucketSSEAlgorithm"
+          }
         }
       }
     },
@@ -13167,7 +13176,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-notificationconfig-topicconfig.html#cfn-s3-bucket-notificationconfig-topicconfig-event",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "S3BucketTopicConfigurationEvent"
+          }
         },
         "Filter": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-notificationconfig-topicconfig.html#cfn-s3-bucket-notificationconfig-topicconfig-filter",
@@ -24916,7 +24928,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket.html#cfn-s3-bucket-accesscontrol",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "S3BucketAccessControl"
+          }
         },
         "AnalyticsConfigurations": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket.html#cfn-s3-bucket-analyticsconfigurations",
@@ -26881,6 +26896,12 @@
         "SFTP"
       ]
     },
+    "HttpProtocol": {
+      "AllowedValues": [
+        "http",
+        "https"
+      ]
+    },
     "IamInstanceProfile": {
       "GetAtt": {},
       "Ref": {
@@ -27120,6 +27141,45 @@
           "AWS::ApiGateway::RestApi"
         ]
       }
+    },
+    "S3BucketAccelerationStatus": {
+      "AllowedValues": [
+        "Enabled",
+        "Suspended"
+      ]
+    },
+    "S3BucketAccessControl": {
+      "AllowedValues": [
+        "AuthenticatedRead",
+        "AwsExecRead",
+        "BucketOwnerFullControl",
+        "BucketOwnerRead",
+        "LogDeliveryWrite",
+        "Private",
+        "PublicRead",
+        "PublicReadWrite"
+      ]
+    },
+    "S3BucketSSEAlgorithm": {
+      "AllowedValues": [
+        "AES256",
+        "aws:kms"
+      ]
+    },
+    "S3BucketTopicConfigurationEvent": {
+      "AllowedValues": [
+        "s3:ObjectCreated:*",
+        "s3:ObjectCreated:CompleteMultipartUpload",
+        "s3:ObjectCreated:Copy",
+        "s3:ObjectCreated:Post",
+        "s3:ObjectCreated:Put",
+        "s3:ObjectRemoved:*",
+        "s3:ObjectRemoved:Delete",
+        "s3:ObjectRemoved:DeleteMarkerCreated",
+        "s3:ObjectRestore:Completed",
+        "s3:ObjectRestore:Post",
+        "s3:ReducedRedundancyLostObject"
+      ]
     },
     "S3BucketVersioningConfigurationStatus": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/us-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-2.json
@@ -15508,7 +15508,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-accelerateconfiguration.html#cfn-s3-bucket-accelerateconfiguration-accelerationstatus",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "S3BucketAccelerationStatus"
+          }
         }
       }
     },
@@ -15952,7 +15955,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-redirectallrequeststo.html#cfn-s3-websiteconfiguration-redirectallrequeststo-protocol",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "HttpProtocol"
+          }
         }
       }
     },
@@ -16226,7 +16232,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-serversideencryptionbydefault.html#cfn-s3-bucket-serversideencryptionbydefault-ssealgorithm",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "S3BucketSSEAlgorithm"
+          }
         }
       }
     },
@@ -16298,7 +16307,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-notificationconfig-topicconfig.html#cfn-s3-bucket-notificationconfig-topicconfig-event",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "S3BucketTopicConfigurationEvent"
+          }
         },
         "Filter": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-notificationconfig-topicconfig.html#cfn-s3-bucket-notificationconfig-topicconfig-filter",
@@ -31198,7 +31210,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket.html#cfn-s3-bucket-accesscontrol",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "S3BucketAccessControl"
+          }
         },
         "AnalyticsConfigurations": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket.html#cfn-s3-bucket-analyticsconfigurations",
@@ -33639,6 +33654,12 @@
         "SFTP"
       ]
     },
+    "HttpProtocol": {
+      "AllowedValues": [
+        "http",
+        "https"
+      ]
+    },
     "IamInstanceProfile": {
       "GetAtt": {},
       "Ref": {
@@ -33878,6 +33899,45 @@
           "AWS::ApiGateway::RestApi"
         ]
       }
+    },
+    "S3BucketAccelerationStatus": {
+      "AllowedValues": [
+        "Enabled",
+        "Suspended"
+      ]
+    },
+    "S3BucketAccessControl": {
+      "AllowedValues": [
+        "AuthenticatedRead",
+        "AwsExecRead",
+        "BucketOwnerFullControl",
+        "BucketOwnerRead",
+        "LogDeliveryWrite",
+        "Private",
+        "PublicRead",
+        "PublicReadWrite"
+      ]
+    },
+    "S3BucketSSEAlgorithm": {
+      "AllowedValues": [
+        "AES256",
+        "aws:kms"
+      ]
+    },
+    "S3BucketTopicConfigurationEvent": {
+      "AllowedValues": [
+        "s3:ObjectCreated:*",
+        "s3:ObjectCreated:CompleteMultipartUpload",
+        "s3:ObjectCreated:Copy",
+        "s3:ObjectCreated:Post",
+        "s3:ObjectCreated:Put",
+        "s3:ObjectRemoved:*",
+        "s3:ObjectRemoved:Delete",
+        "s3:ObjectRemoved:DeleteMarkerCreated",
+        "s3:ObjectRestore:Completed",
+        "s3:ObjectRestore:Post",
+        "s3:ReducedRedundancyLostObject"
+      ]
     },
     "S3BucketVersioningConfigurationStatus": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/us-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-2.json
@@ -31446,7 +31446,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sns-subscription.html#cfn-sns-protocol",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "SnsSubscriptionProtocol"
+          }
         },
         "RawMessageDelivery": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sns-subscription.html#cfn-sns-subscription-rawmessagedelivery",
@@ -34037,6 +34040,18 @@
           "AWS::EC2::SecurityGroup"
         ]
       }
+    },
+    "SnsSubscriptionProtocol": {
+      "AllowedValues": [
+        "application",
+        "email-json",
+        "email",
+        "http",
+        "https",
+        "lambda",
+        "sms",
+        "sqs"
+      ]
     },
     "SsmDocumentName": {
       "GetAtt": {},

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
@@ -628,6 +628,18 @@
         },
         "GetAtt": {}
       },
+      "SnsSubscriptionProtocol": {
+        "AllowedValues": [
+          "application",
+          "email-json",
+          "email",
+          "http",
+          "https",
+          "lambda",
+          "sms",
+          "sqs"
+        ]
+      },
       "SsmDocumentName": {
         "Ref": {
           "Parameters": [

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
@@ -244,6 +244,12 @@
           "SFTP"
         ]
       },
+      "HttpProtocol": {
+        "AllowedValues": [
+          "http",
+          "https"
+        ]
+      },
       "IamInstanceProfile": {
         "Ref": {
           "Parameters": [
@@ -484,10 +490,49 @@
         },
         "GetAtt": {}
       },
+      "S3BucketAccelerationStatus": {
+        "AllowedValues": [
+          "Enabled",
+          "Suspended"
+        ]
+      },
+      "S3BucketAccessControl": {
+        "AllowedValues": [
+          "AuthenticatedRead",
+          "AwsExecRead",
+          "BucketOwnerFullControl",
+          "BucketOwnerRead",
+          "LogDeliveryWrite",
+          "Private",
+          "PublicRead",
+          "PublicReadWrite"
+        ]
+      },
+      "S3BucketSSEAlgorithm": {
+        "AllowedValues": [
+          "AES256",
+          "aws:kms"
+        ]
+      },
       "S3BucketVersioningConfigurationStatus": {
         "AllowedValues": [
           "Enabled",
           "Suspended"
+        ]
+      },
+      "S3BucketTopicConfigurationEvent": {
+        "AllowedValues": [
+          "s3:ObjectCreated:*",
+          "s3:ObjectCreated:CompleteMultipartUpload",
+          "s3:ObjectCreated:Copy",
+          "s3:ObjectCreated:Post",
+          "s3:ObjectCreated:Put",
+          "s3:ObjectRemoved:*",
+          "s3:ObjectRemoved:Delete",
+          "s3:ObjectRemoved:DeleteMarkerCreated",
+          "s3:ObjectRestore:Completed",
+          "s3:ObjectRestore:Post",
+          "s3:ReducedRedundancyLostObject"
         ]
       },
       "ScalingInstructionPredictiveScalingMaxCapacityBehavior": {

--- a/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
@@ -918,5 +918,12 @@
     "value": {
       "ValueType": "S3BucketAccessControl"
     }
+  },
+  {
+    "op": "add",
+    "path": "/ResourceTypes/AWS::SNS::Subscription/Properties/Protocol/Value",
+    "value": {
+      "ValueType": "SnsSubscriptionProtocol"
+    }
   }
 ]

--- a/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
@@ -134,6 +134,35 @@
   },
   {
     "op": "add",
+    "path": "/PropertyTypes/AWS::S3::Bucket.AccelerateConfiguration/Properties/AccelerationStatus/Value",
+    "value": {
+      "ValueType": "S3BucketAccelerationStatus"
+    }
+  },
+
+  {
+    "op": "add",
+    "path": "/PropertyTypes/AWS::S3::Bucket.RedirectAllRequestsTo/Properties/Protocol/Value",
+    "value": {
+      "ValueType": "HttpProtocol"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/PropertyTypes/AWS::S3::Bucket.ServerSideEncryptionByDefault/Properties/SSEAlgorithm/Value",
+    "value": {
+      "ValueType": "S3BucketSSEAlgorithm"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/PropertyTypes/AWS::S3::Bucket.TopicConfiguration/Properties/Event/Value",
+    "value": {
+      "ValueType": "S3BucketTopicConfigurationEvent"
+    }
+  },
+  {
+    "op": "add",
     "path": "/PropertyTypes/AWS::S3::Bucket.VersioningConfiguration/Properties/Status/Value",
     "value": {
       "ValueType": "S3BucketVersioningConfigurationStatus"
@@ -881,6 +910,13 @@
     "path": "/ResourceTypes/AWS::OpsWorks::Stack/Properties/VpcId/Value",
     "value": {
       "ValueType": "VpcId"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/ResourceTypes/AWS::S3::Bucket/Properties/AccessControl/Value",
+    "value": {
+      "ValueType": "S3BucketAccessControl"
     }
   }
 ]

--- a/test/fixtures/templates/bad/resources/properties/allowed_values.yaml
+++ b/test/fixtures/templates/bad/resources/properties/allowed_values.yaml
@@ -193,6 +193,11 @@ Resources:
         RedirectAllRequestsTo:
           HostName: "example.com"
           Protocol: "tcp" # Invalid AllowedValue
+  SnsSubscription:
+    Type: "AWS::SNS::Subscription"
+    Properties:
+      Protocol: "mail" # Invalid AllowedValue
+      TopicArn: "TopicArn"
   Vpc:
     Type: AWS::EC2::VPC
     Properties:

--- a/test/fixtures/templates/bad/resources/properties/allowed_values.yaml
+++ b/test/fixtures/templates/bad/resources/properties/allowed_values.yaml
@@ -175,8 +175,24 @@ Resources:
   S3Bucket:
     Type: "AWS::S3::Bucket"
     Properties:
+      AccelerateConfiguration:
+        AccelerationStatus: "Disabled" # Inalid AllowedValue
+      AccessControl: "PrivateRead" # Invalid AllowedValue
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: "KMS" # Invalid AllowedValue
+      NotificationConfiguration:
+        TopicConfigurations:
+          - Topic: "MyTopic"
+            Event: "s3:ObjectCreated:Get" # Invalid AllowedValue
       VersioningConfiguration:
         Status: "disabled" # Invalid AllowedValue
+      WebsiteConfiguration:
+        IndexDocument: "index.html"
+        RedirectAllRequestsTo:
+          HostName: "example.com"
+          Protocol: "tcp" # Invalid AllowedValue
   Vpc:
     Type: AWS::EC2::VPC
     Properties:

--- a/test/fixtures/templates/good/resources/properties/allowed_values.yaml
+++ b/test/fixtures/templates/good/resources/properties/allowed_values.yaml
@@ -175,8 +175,24 @@ Resources:
   S3Bucket:
     Type: "AWS::S3::Bucket"
     Properties:
+      AccessControl: "BucketOwnerFullControl" # Valid AllowedValue
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: "AES256" # Valid AllowedValue
+      AccelerateConfiguration:
+        AccelerationStatus: "Enabled" # Valid AllowedValue
+      NotificationConfiguration:
+        TopicConfigurations:
+          - Topic: "MyTopic"
+            Event: "s3:ObjectCreated:*" # Valid AllowedValue
       VersioningConfiguration:
         Status: "Enabled" # Valid AllowedValue
+      WebsiteConfiguration:
+        IndexDocument: "index.html"
+        RedirectAllRequestsTo:
+          HostName: "example.com"
+          Protocol: "https" # Valid AllowedValue
   Vpc:
     Type: "AWS::EC2::VPC"
     Properties:

--- a/test/fixtures/templates/good/resources/properties/allowed_values.yaml
+++ b/test/fixtures/templates/good/resources/properties/allowed_values.yaml
@@ -193,6 +193,11 @@ Resources:
         RedirectAllRequestsTo:
           HostName: "example.com"
           Protocol: "https" # Valid AllowedValue
+  SnsSubscription:
+    Type: "AWS::SNS::Subscription"
+    Properties:
+      Protocol: "http" # Valid AllowedValue
+      TopicArn: "TopicArn"
   Vpc:
     Type: "AWS::EC2::VPC"
     Properties:

--- a/test/rules/resources/properties/test_allowed_value.py
+++ b/test/rules/resources/properties/test_allowed_value.py
@@ -34,4 +34,4 @@ class TestAllowedValue(BaseRuleTestCase):
 
     def test_file_negative(self):
         """Test failure"""
-        self.helper_file_negative('test/fixtures/templates/bad/resources/properties/allowed_values.yaml', 42)
+        self.helper_file_negative('test/fixtures/templates/bad/resources/properties/allowed_values.yaml', 47)

--- a/test/rules/resources/properties/test_allowed_value.py
+++ b/test/rules/resources/properties/test_allowed_value.py
@@ -34,4 +34,4 @@ class TestAllowedValue(BaseRuleTestCase):
 
     def test_file_negative(self):
         """Test failure"""
-        self.helper_file_negative('test/fixtures/templates/bad/resources/properties/allowed_values.yaml', 47)
+        self.helper_file_negative('test/fixtures/templates/bad/resources/properties/allowed_values.yaml', 48)


### PR DESCRIPTION
Added a bunch of allowed values for `S3::Bucket` resources.

See: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-reference-s3.html

Not all are in there (There are quite a lot hidden in sub-resources) but this covers a portion of it already.  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
