### PR TITLE
Print complete strack trace when in Debug mode (E0002)

### DIFF
--- a/src/cfnlint/__init__.py
+++ b/src/cfnlint/__init__.py
@@ -18,6 +18,7 @@ import logging
 import sys
 import os
 import re
+import traceback
 from copy import deepcopy
 from datetime import datetime
 import six
@@ -182,11 +183,16 @@ class RulesCollection(object):
             return []
         except Exception as err:  # pylint: disable=W0703
             if self.is_rule_enabled('E0002'):
+                # In debug mode, print the error include complete stack trace
+                if LOGGER.getEffectiveLevel() == logging.DEBUG:
+                    error_message = traceback.format_exc()
+                else:
+                    error_message = str(err)
                 message = 'Unknown exception while processing rule {}: {}'
                 return [
                     cfnlint.Match(
                         1, 1, 1, 1,
-                        filename, cfnlint.RuleError(), message.format(rule_id, str(err)))]
+                        filename, cfnlint.RuleError(), message.format(rule_id, error_message))]
 
     def resource_property(self, filename, cfn, path, properties, resource_type, property_type):
         """Run loops in resource checks for embedded properties"""


### PR DESCRIPTION
If a rule itself fails, the error is outputted as rule `E0002` so all other rules continue and the entire linter is not broken with use unfriendly stack traces.

It's annoying for debugging though, this PR will print the entire stack trace if the linter is running in Debug mode (`--debug`).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
