### PR TITLE
AWS::Batch::ComputeEnvironment InstanceRole is to InstanceProfile

### DIFF
--- a/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
@@ -2293,7 +2293,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "InstanceTypes": {
@@ -31561,6 +31561,9 @@
       "Ref": {
         "Parameters": [
           "String"
+        ],
+        "Resources": [
+          "AWS::IAM::Role"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
@@ -2293,7 +2293,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamRole"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "InstanceTypes": {

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
@@ -2293,7 +2293,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "InstanceTypes": {
@@ -6194,7 +6194,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         }
       }
@@ -18780,7 +18780,7 @@
           "Required": false,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "ImageId": {
@@ -21746,7 +21746,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "ImageId": {
@@ -23661,7 +23661,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "KerberosAttributes": {
@@ -31540,6 +31540,9 @@
       "Ref": {
         "Parameters": [
           "String"
+        ],
+        "Resources": [
+          "AWS::IAM::InstanceProfile"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
@@ -2060,7 +2060,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "InstanceTypes": {
@@ -29086,6 +29086,9 @@
       "Ref": {
         "Parameters": [
           "String"
+        ],
+        "Resources": [
+          "AWS::IAM::Role"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
@@ -2060,7 +2060,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamRole"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "InstanceTypes": {

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
@@ -2060,7 +2060,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "InstanceTypes": {
@@ -5884,7 +5884,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         }
       }
@@ -17146,7 +17146,7 @@
           "Required": false,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "ImageId": {
@@ -19901,7 +19901,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "ImageId": {
@@ -21816,7 +21816,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "KerberosAttributes": {
@@ -29065,6 +29065,9 @@
       "Ref": {
         "Parameters": [
           "String"
+        ],
+        "Resources": [
+          "AWS::IAM::InstanceProfile"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
@@ -12151,7 +12151,7 @@
           "Required": false,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "ImageId": {
@@ -13840,7 +13840,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "ImageId": {
@@ -15543,7 +15543,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "KerberosAttributes": {
@@ -20986,6 +20986,9 @@
       "Ref": {
         "Parameters": [
           "String"
+        ],
+        "Resources": [
+          "AWS::IAM::InstanceProfile"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
@@ -21007,6 +21007,9 @@
       "Ref": {
         "Parameters": [
           "String"
+        ],
+        "Resources": [
+          "AWS::IAM::Role"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/ap-south-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-south-1.json
@@ -1922,7 +1922,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "InstanceTypes": {
@@ -5324,7 +5324,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         }
       }
@@ -16370,7 +16370,7 @@
           "Required": false,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "ImageId": {
@@ -18741,7 +18741,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "ImageId": {
@@ -20656,7 +20656,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "KerberosAttributes": {
@@ -27905,6 +27905,9 @@
       "Ref": {
         "Parameters": [
           "String"
+        ],
+        "Resources": [
+          "AWS::IAM::InstanceProfile"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/ap-south-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-south-1.json
@@ -1922,7 +1922,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "InstanceTypes": {
@@ -27926,6 +27926,9 @@
       "Ref": {
         "Parameters": [
           "String"
+        ],
+        "Resources": [
+          "AWS::IAM::Role"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/ap-south-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-south-1.json
@@ -1922,7 +1922,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamRole"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "InstanceTypes": {

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
@@ -2218,7 +2218,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "InstanceTypes": {
@@ -5686,7 +5686,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         }
       }
@@ -17337,7 +17337,7 @@
           "Required": false,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "ImageId": {
@@ -19805,7 +19805,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "ImageId": {
@@ -21720,7 +21720,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "KerberosAttributes": {
@@ -29057,6 +29057,9 @@
       "Ref": {
         "Parameters": [
           "String"
+        ],
+        "Resources": [
+          "AWS::IAM::InstanceProfile"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
@@ -2218,7 +2218,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "InstanceTypes": {
@@ -29078,6 +29078,9 @@
       "Ref": {
         "Parameters": [
           "String"
+        ],
+        "Resources": [
+          "AWS::IAM::Role"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
@@ -2218,7 +2218,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamRole"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "InstanceTypes": {

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
@@ -2293,7 +2293,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "InstanceTypes": {
@@ -30026,6 +30026,9 @@
       "Ref": {
         "Parameters": [
           "String"
+        ],
+        "Resources": [
+          "AWS::IAM::Role"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
@@ -2293,7 +2293,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "InstanceTypes": {
@@ -6235,7 +6235,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         }
       }
@@ -17955,7 +17955,7 @@
           "Required": false,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "ImageId": {
@@ -20793,7 +20793,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "ImageId": {
@@ -22708,7 +22708,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "KerberosAttributes": {
@@ -30005,6 +30005,9 @@
       "Ref": {
         "Parameters": [
           "String"
+        ],
+        "Resources": [
+          "AWS::IAM::InstanceProfile"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
@@ -2293,7 +2293,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamRole"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "InstanceTypes": {

--- a/src/cfnlint/data/CloudSpecs/ca-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/ca-central-1.json
@@ -1756,7 +1756,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "InstanceTypes": {
@@ -26286,6 +26286,9 @@
       "Ref": {
         "Parameters": [
           "String"
+        ],
+        "Resources": [
+          "AWS::IAM::Role"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/ca-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/ca-central-1.json
@@ -1756,7 +1756,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamRole"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "InstanceTypes": {

--- a/src/cfnlint/data/CloudSpecs/ca-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/ca-central-1.json
@@ -1756,7 +1756,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "InstanceTypes": {
@@ -5158,7 +5158,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         }
       }
@@ -15196,7 +15196,7 @@
           "Required": false,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "ImageId": {
@@ -17567,7 +17567,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "ImageId": {
@@ -19482,7 +19482,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "KerberosAttributes": {
@@ -26265,6 +26265,9 @@
       "Ref": {
         "Parameters": [
           "String"
+        ],
+        "Resources": [
+          "AWS::IAM::InstanceProfile"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/eu-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-central-1.json
@@ -2218,7 +2218,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "InstanceTypes": {
@@ -6108,7 +6108,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         }
       }
@@ -18325,7 +18325,7 @@
           "Required": false,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "ImageId": {
@@ -21151,7 +21151,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "ImageId": {
@@ -23066,7 +23066,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "KerberosAttributes": {
@@ -30746,6 +30746,9 @@
       "Ref": {
         "Parameters": [
           "String"
+        ],
+        "Resources": [
+          "AWS::IAM::InstanceProfile"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/eu-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-central-1.json
@@ -2218,7 +2218,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "InstanceTypes": {
@@ -30767,6 +30767,9 @@
       "Ref": {
         "Parameters": [
           "String"
+        ],
+        "Resources": [
+          "AWS::IAM::Role"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/eu-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-central-1.json
@@ -2218,7 +2218,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamRole"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "InstanceTypes": {

--- a/src/cfnlint/data/CloudSpecs/eu-north-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-north-1.json
@@ -12100,7 +12100,7 @@
           "Required": false,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "ImageId": {
@@ -14114,7 +14114,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "ImageId": {
@@ -15867,7 +15867,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "KerberosAttributes": {
@@ -21338,6 +21338,9 @@
       "Ref": {
         "Parameters": [
           "String"
+        ],
+        "Resources": [
+          "AWS::IAM::InstanceProfile"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/eu-north-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-north-1.json
@@ -21359,6 +21359,9 @@
       "Ref": {
         "Parameters": [
           "String"
+        ],
+        "Resources": [
+          "AWS::IAM::Role"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/eu-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-1.json
@@ -2293,7 +2293,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "InstanceTypes": {
@@ -6555,7 +6555,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         }
       }
@@ -20099,7 +20099,7 @@
           "Required": false,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "ImageId": {
@@ -23277,7 +23277,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "ImageId": {
@@ -25192,7 +25192,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "KerberosAttributes": {
@@ -33598,6 +33598,9 @@
       "Ref": {
         "Parameters": [
           "String"
+        ],
+        "Resources": [
+          "AWS::IAM::InstanceProfile"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/eu-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-1.json
@@ -2293,7 +2293,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "InstanceTypes": {
@@ -33619,6 +33619,9 @@
       "Ref": {
         "Parameters": [
           "String"
+        ],
+        "Resources": [
+          "AWS::IAM::Role"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/eu-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-1.json
@@ -2293,7 +2293,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamRole"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "InstanceTypes": {

--- a/src/cfnlint/data/CloudSpecs/eu-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-2.json
@@ -1756,7 +1756,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "InstanceTypes": {
@@ -5597,7 +5597,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         }
       }
@@ -15698,7 +15698,7 @@
           "Required": false,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "ImageId": {
@@ -18483,7 +18483,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "ImageId": {
@@ -20398,7 +20398,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "KerberosAttributes": {
@@ -27566,6 +27566,9 @@
       "Ref": {
         "Parameters": [
           "String"
+        ],
+        "Resources": [
+          "AWS::IAM::InstanceProfile"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/eu-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-2.json
@@ -1756,7 +1756,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamRole"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "InstanceTypes": {

--- a/src/cfnlint/data/CloudSpecs/eu-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-2.json
@@ -1756,7 +1756,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "InstanceTypes": {
@@ -27587,6 +27587,9 @@
       "Ref": {
         "Parameters": [
           "String"
+        ],
+        "Resources": [
+          "AWS::IAM::Role"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/eu-west-3.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-3.json
@@ -1442,7 +1442,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamRole"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "InstanceTypes": {

--- a/src/cfnlint/data/CloudSpecs/eu-west-3.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-3.json
@@ -1442,7 +1442,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "InstanceTypes": {
@@ -24551,6 +24551,9 @@
       "Ref": {
         "Parameters": [
           "String"
+        ],
+        "Resources": [
+          "AWS::IAM::Role"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/eu-west-3.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-3.json
@@ -1442,7 +1442,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "InstanceTypes": {
@@ -4419,7 +4419,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         }
       }
@@ -14236,7 +14236,7 @@
           "Required": false,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "ImageId": {
@@ -16161,7 +16161,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "ImageId": {
@@ -18076,7 +18076,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "KerberosAttributes": {
@@ -24530,6 +24530,9 @@
       "Ref": {
         "Parameters": [
           "String"
+        ],
+        "Resources": [
+          "AWS::IAM::InstanceProfile"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/sa-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/sa-east-1.json
@@ -1442,7 +1442,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamRole"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "InstanceTypes": {

--- a/src/cfnlint/data/CloudSpecs/sa-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/sa-east-1.json
@@ -1442,7 +1442,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "InstanceTypes": {
@@ -25460,6 +25460,9 @@
       "Ref": {
         "Parameters": [
           "String"
+        ],
+        "Resources": [
+          "AWS::IAM::Role"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/sa-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/sa-east-1.json
@@ -1442,7 +1442,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "InstanceTypes": {
@@ -4844,7 +4844,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         }
       }
@@ -14759,7 +14759,7 @@
           "Required": false,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "ImageId": {
@@ -17104,7 +17104,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "ImageId": {
@@ -18850,7 +18850,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "KerberosAttributes": {
@@ -25439,6 +25439,9 @@
       "Ref": {
         "Parameters": [
           "String"
+        ],
+        "Resources": [
+          "AWS::IAM::InstanceProfile"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/us-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-1.json
@@ -2293,7 +2293,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "InstanceTypes": {
@@ -33648,6 +33648,9 @@
       "Ref": {
         "Parameters": [
           "String"
+        ],
+        "Resources": [
+          "AWS::IAM::Role"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/us-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-1.json
@@ -2293,7 +2293,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "InstanceTypes": {
@@ -6555,7 +6555,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         }
       }
@@ -20100,7 +20100,7 @@
           "Required": false,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "ImageId": {
@@ -23278,7 +23278,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "ImageId": {
@@ -25263,7 +25263,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "KerberosAttributes": {
@@ -33627,6 +33627,9 @@
       "Ref": {
         "Parameters": [
           "String"
+        ],
+        "Resources": [
+          "AWS::IAM::InstanceProfile"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/us-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-1.json
@@ -2293,7 +2293,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamRole"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "InstanceTypes": {

--- a/src/cfnlint/data/CloudSpecs/us-east-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-2.json
@@ -2135,7 +2135,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "InstanceTypes": {
@@ -6079,7 +6079,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         }
       }
@@ -18658,7 +18658,7 @@
           "Required": false,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "ImageId": {
@@ -21578,7 +21578,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "ImageId": {
@@ -23493,7 +23493,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "KerberosAttributes": {
@@ -31643,6 +31643,9 @@
       "Ref": {
         "Parameters": [
           "String"
+        ],
+        "Resources": [
+          "AWS::IAM::InstanceProfile"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/us-east-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-2.json
@@ -2135,7 +2135,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "InstanceTypes": {
@@ -31664,6 +31664,9 @@
       "Ref": {
         "Parameters": [
           "String"
+        ],
+        "Resources": [
+          "AWS::IAM::Role"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/us-east-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-2.json
@@ -2135,7 +2135,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamRole"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "InstanceTypes": {

--- a/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
@@ -20782,6 +20782,9 @@
       "Ref": {
         "Parameters": [
           "String"
+        ],
+        "Resources": [
+          "AWS::IAM::Role"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
@@ -11971,7 +11971,7 @@
           "Required": false,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "ImageId": {
@@ -13587,7 +13587,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "ImageId": {
@@ -15290,7 +15290,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "KerberosAttributes": {
@@ -20761,6 +20761,9 @@
       "Ref": {
         "Parameters": [
           "String"
+        ],
+        "Resources": [
+          "AWS::IAM::InstanceProfile"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
@@ -20940,6 +20940,9 @@
       "Ref": {
         "Parameters": [
           "String"
+        ],
+        "Resources": [
+          "AWS::IAM::Role"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
@@ -12018,7 +12018,7 @@
           "Required": false,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "ImageId": {
@@ -13634,7 +13634,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "ImageId": {
@@ -15337,7 +15337,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "KerberosAttributes": {
@@ -20919,6 +20919,9 @@
       "Ref": {
         "Parameters": [
           "String"
+        ],
+        "Resources": [
+          "AWS::IAM::InstanceProfile"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/us-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-1.json
@@ -1894,7 +1894,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "InstanceTypes": {
@@ -5356,7 +5356,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         }
       }
@@ -15562,7 +15562,7 @@
           "Required": false,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "ImageId": {
@@ -18114,7 +18114,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "ImageId": {
@@ -20029,7 +20029,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "KerberosAttributes": {
@@ -26899,6 +26899,9 @@
       "Ref": {
         "Parameters": [
           "String"
+        ],
+        "Resources": [
+          "AWS::IAM::InstanceProfile"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/us-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-1.json
@@ -1894,7 +1894,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "InstanceTypes": {
@@ -26920,6 +26920,9 @@
       "Ref": {
         "Parameters": [
           "String"
+        ],
+        "Resources": [
+          "AWS::IAM::Role"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/us-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-1.json
@@ -1894,7 +1894,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamRole"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "InstanceTypes": {

--- a/src/cfnlint/data/CloudSpecs/us-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-2.json
@@ -2293,7 +2293,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "InstanceTypes": {
@@ -33678,6 +33678,9 @@
       "Ref": {
         "Parameters": [
           "String"
+        ],
+        "Resources": [
+          "AWS::IAM::Role"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/us-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-2.json
@@ -2293,7 +2293,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamRole"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "InstanceTypes": {

--- a/src/cfnlint/data/CloudSpecs/us-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-2.json
@@ -2293,7 +2293,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "InstanceTypes": {
@@ -6555,7 +6555,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         }
       }
@@ -20118,7 +20118,7 @@
           "Required": false,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "ImageId": {
@@ -23296,7 +23296,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "ImageId": {
@@ -25251,7 +25251,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile"
+            "ValueType": "IamInstanceProfile.Arn"
           }
         },
         "KerberosAttributes": {
@@ -33657,6 +33657,9 @@
       "Ref": {
         "Parameters": [
           "String"
+        ],
+        "Resources": [
+          "AWS::IAM::InstanceProfile"
         ]
       }
     },

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
@@ -262,6 +262,9 @@
         "Ref": {
           "Parameters": [
             "String"
+          ],
+          "Resources": [
+            "AWS::IAM::InstanceProfile"
           ]
         }
       },

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
@@ -283,6 +283,9 @@
         "Ref": {
           "Parameters": [
             "String"
+          ],
+          "Resources": [
+            "AWS::IAM::Role"
           ]
         }
       },

--- a/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
@@ -87,7 +87,7 @@
     "op": "add",
     "path": "/PropertyTypes/AWS::Batch::ComputeEnvironment.ComputeResources/Properties/InstanceRole/Value",
     "value": {
-      "ValueType": "IamInstanceProfile"
+      "ValueType": "IamInstanceProfile.Arn"
     }
   },
   {
@@ -178,7 +178,7 @@
     "op": "add",
     "path": "/PropertyTypes/AWS::EC2::LaunchTemplate.IamInstanceProfile/Properties/Name/Value",
     "value": {
-      "ValueType": "IamInstanceProfile"
+      "ValueType": "IamInstanceProfile.Arn"
     }
   },
   {
@@ -392,7 +392,7 @@
     "op": "add",
     "path": "/ResourceTypes/AWS::AutoScaling::LaunchConfiguration/Properties/IamInstanceProfile/Value",
     "value": {
-      "ValueType": "IamInstanceProfile"
+      "ValueType": "IamInstanceProfile.Arn"
     }
   },
   {
@@ -484,7 +484,7 @@
     "op": "add",
     "path": "/ResourceTypes/AWS::EC2::Instance/Properties/IamInstanceProfile/Value",
     "value": {
-      "ValueType": "IamInstanceProfile"
+      "ValueType": "IamInstanceProfile.Arn"
     }
   },
   {
@@ -584,7 +584,7 @@
     "op": "add",
     "path": "/ResourceTypes/AWS::EMR::Cluster/Properties/JobFlowRole/Value",
     "value": {
-      "ValueType": "IamInstanceProfile"
+      "ValueType": "IamInstanceProfile.Arn"
     }
   },
   {

--- a/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
@@ -87,7 +87,7 @@
     "op": "add",
     "path": "/PropertyTypes/AWS::Batch::ComputeEnvironment.ComputeResources/Properties/InstanceRole/Value",
     "value": {
-      "ValueType": "IamRole"
+      "ValueType": "IamInstanceProfile"
     }
   },
   {

--- a/test/module/cfn_yaml/test_yaml.py
+++ b/test/module/cfn_yaml/test_yaml.py
@@ -39,7 +39,7 @@ class TestYamlParse(BaseTestCase):
             },
             "generic_bad": {
                 "filename": 'test/fixtures/templates/bad/generic.yaml',
-                "failures": 35
+                "failures": 34
             }
         }
 

--- a/test/module/test_rules_collections.py
+++ b/test/module/test_rules_collections.py
@@ -59,7 +59,7 @@ class TestTemplate(BaseTestCase):
         filename = 'test/fixtures/templates/bad/generic.yaml'
         template = cfnlint.decode.cfn_yaml.load(filename)
         cfn = Template(filename, template, ['us-east-1'])
-        expected_err_count = 35
+        expected_err_count = 34
         matches = []
         matches.extend(self.rules.run(filename, cfn))
         assert len(matches) == expected_err_count, 'Expected {} failures, got {}'.format(expected_err_count, len(matches))

--- a/test/rules/resources/properties/test_value_ref_getatt.py
+++ b/test/rules/resources/properties/test_value_ref_getatt.py
@@ -35,7 +35,7 @@ class TestValueRefGetAtt(BaseRuleTestCase):
 
     def test_file_negative(self):
         """Test failure"""
-        self.helper_file_negative('test/fixtures/templates/bad/generic.yaml', 2)
+        self.helper_file_negative('test/fixtures/templates/bad/generic.yaml', 1)
 
     def test_file_negative_value(self):
         """Test failure"""


### PR DESCRIPTION
*Issue #, if available:*
Fix #564

*Description of changes:*
- Fix Spec so that AWS::Batch::ComputeEnvironment InstanceRole goes to an InstanceProfile not an IAM Role

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
