### PR TITLE
Don't fail on regex that isn't supported by Python

### DIFF
--- a/src/cfnlint/rules/parameters/Default.py
+++ b/src/cfnlint/rules/parameters/Default.py
@@ -33,8 +33,11 @@ class Default(CloudFormationLintRule):
             Check allowed value against allowed pattern
         """
         message = 'Default should be allowed by AllowedPattern'
-        if not re.match(allowed_pattern, str(allowed_value)):
-            return([RuleMatch(path, message)])
+        try:
+            if not re.match(allowed_pattern, str(allowed_value)):
+                return([RuleMatch(path, message)])
+        except re.error as ex:
+            self.logger.debug('Regex pattern "%s" isn\'t supported by Python: %s', allowed_pattern, ex)
 
         return []
 

--- a/test/fixtures/templates/good/parameters/default.yaml
+++ b/test/fixtures/templates/good/parameters/default.yaml
@@ -28,4 +28,10 @@ Parameters:
     Type: String
     Default: abc
     MaxLength: 3
+  ArtifactoryDbAdmin:
+    AllowedPattern: "[a-z0-9]{6,16}+"  # doesn't fail on a python bad regex
+    ConstraintDescription: Alphanumeric string between 6 and 12 characters.
+    Description: Remote PostGreSQL database's master user account.
+    Type: String
+    Default: abcdef
 Resources: {}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Fix rule E2015 to not fail on an AllowedPattern when the regex isn't supported by Python

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
