### PR TITLE
Add Route53 allowed_values

### DIFF
--- a/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
@@ -14392,7 +14392,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-healthcheck-healthcheckconfig.html#cfn-route53-healthcheck-healthcheckconfig-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "Route53HealthCheckConfigType"
+          }
         }
       }
     },
@@ -14502,7 +14505,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-geolocation.html#cfn-route53-recordset-geolocation-continentcode",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "RecordSetGeoContinentCode"
+          }
         },
         "CountryCode": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-geolocation.html#cfn-route53-recordset-geolocation-countrycode",
@@ -14548,7 +14554,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-geolocation.html#cfn-route53-recordsetgroup-geolocation-continentcode",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "RecordSetGeoContinentCode"
+          }
         },
         "CountryCode": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-geolocation.html#cfn-route53-recordset-geolocation-countrycode",
@@ -14583,7 +14592,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-failover",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "RecordSetFailover"
+          }
         },
         "GeoLocation": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-geolocation",
@@ -29090,7 +29102,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-failover",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "RecordSetFailover"
+          }
         },
         "GeoLocation": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-geolocation",
@@ -29229,7 +29244,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-route53resolver-resolverendpoint.html#cfn-route53resolver-resolverendpoint-direction",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "Route53ResolverEndpointDirection"
+          }
         },
         "IpAddresses": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-route53resolver-resolverendpoint.html#cfn-route53resolver-resolverendpoint-ipaddresses",
@@ -29305,7 +29323,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-route53resolver-resolverrule.html#cfn-route53resolver-resolverrule-ruletype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "Route53ResolverRuleType"
+          }
         },
         "Tags": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-route53resolver-resolverrule.html#cfn-route53resolver-resolverrule-tags",
@@ -31885,6 +31906,23 @@
         ]
       }
     },
+    "RecordSetFailover": {
+      "AllowedValues": [
+        "PRIMARY",
+        "SECONDARY"
+      ]
+    },
+    "RecordSetGeoContinentCode": {
+      "AllowedValues": [
+        "AF",
+        "AN",
+        "AS",
+        "EU",
+        "NA",
+        "OC",
+        "SA"
+      ]
+    },
     "RecordSetType": {
       "AllowedValues": [
         "A",
@@ -31911,6 +31949,30 @@
           "AWS::ApiGateway::RestApi"
         ]
       }
+    },
+    "Route53HealthCheckConfigType": {
+      "AllowedValues": [
+        "CALCULATED",
+        "CLOUDWATCH_METRIC",
+        "HTTP_STR_MATCH",
+        "HTTP",
+        "HTTPS_STR_MATCH",
+        "HTTPS",
+        "TCP"
+      ]
+    },
+    "Route53ResolverEndpointDirection": {
+      "AllowedValues": [
+        "INBOUND",
+        "OUTBOUND"
+      ]
+    },
+    "Route53ResolverRuleType": {
+      "AllowedValues": [
+        "FORWARD",
+        "RECURSIVE",
+        "SYSTEM"
+      ]
     },
     "S3BucketAccelerationStatus": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
@@ -13458,7 +13458,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-healthcheck-healthcheckconfig.html#cfn-route53-healthcheck-healthcheckconfig-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "Route53HealthCheckConfigType"
+          }
         }
       }
     },
@@ -13568,7 +13571,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-geolocation.html#cfn-route53-recordset-geolocation-continentcode",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "RecordSetGeoContinentCode"
+          }
         },
         "CountryCode": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-geolocation.html#cfn-route53-recordset-geolocation-countrycode",
@@ -13614,7 +13620,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-geolocation.html#cfn-route53-recordsetgroup-geolocation-continentcode",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "RecordSetGeoContinentCode"
+          }
         },
         "CountryCode": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-geolocation.html#cfn-route53-recordset-geolocation-countrycode",
@@ -13649,7 +13658,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-failover",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "RecordSetFailover"
+          }
         },
         "GeoLocation": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-geolocation",
@@ -27038,7 +27050,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-failover",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "RecordSetFailover"
+          }
         },
         "GeoLocation": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-geolocation",
@@ -29410,6 +29425,23 @@
         ]
       }
     },
+    "RecordSetFailover": {
+      "AllowedValues": [
+        "PRIMARY",
+        "SECONDARY"
+      ]
+    },
+    "RecordSetGeoContinentCode": {
+      "AllowedValues": [
+        "AF",
+        "AN",
+        "AS",
+        "EU",
+        "NA",
+        "OC",
+        "SA"
+      ]
+    },
     "RecordSetType": {
       "AllowedValues": [
         "A",
@@ -29436,6 +29468,30 @@
           "AWS::ApiGateway::RestApi"
         ]
       }
+    },
+    "Route53HealthCheckConfigType": {
+      "AllowedValues": [
+        "CALCULATED",
+        "CLOUDWATCH_METRIC",
+        "HTTP_STR_MATCH",
+        "HTTP",
+        "HTTPS_STR_MATCH",
+        "HTTPS",
+        "TCP"
+      ]
+    },
+    "Route53ResolverEndpointDirection": {
+      "AllowedValues": [
+        "INBOUND",
+        "OUTBOUND"
+      ]
+    },
+    "Route53ResolverRuleType": {
+      "AllowedValues": [
+        "FORWARD",
+        "RECURSIVE",
+        "SYSTEM"
+      ]
     },
     "S3BucketAccelerationStatus": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
@@ -9487,7 +9487,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-healthcheck-healthcheckconfig.html#cfn-route53-healthcheck-healthcheckconfig-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "Route53HealthCheckConfigType"
+          }
         }
       }
     },
@@ -9597,7 +9600,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-geolocation.html#cfn-route53-recordset-geolocation-continentcode",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "RecordSetGeoContinentCode"
+          }
         },
         "CountryCode": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-geolocation.html#cfn-route53-recordset-geolocation-countrycode",
@@ -9643,7 +9649,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-geolocation.html#cfn-route53-recordsetgroup-geolocation-continentcode",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "RecordSetGeoContinentCode"
+          }
         },
         "CountryCode": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-geolocation.html#cfn-route53-recordset-geolocation-countrycode",
@@ -9678,7 +9687,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-failover",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "RecordSetFailover"
+          }
         },
         "GeoLocation": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-geolocation",
@@ -19975,7 +19987,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-failover",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "RecordSetFailover"
+          }
         },
         "GeoLocation": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-geolocation",
@@ -21205,6 +21220,23 @@
         ]
       }
     },
+    "RecordSetFailover": {
+      "AllowedValues": [
+        "PRIMARY",
+        "SECONDARY"
+      ]
+    },
+    "RecordSetGeoContinentCode": {
+      "AllowedValues": [
+        "AF",
+        "AN",
+        "AS",
+        "EU",
+        "NA",
+        "OC",
+        "SA"
+      ]
+    },
     "RecordSetType": {
       "AllowedValues": [
         "A",
@@ -21231,6 +21263,30 @@
           "AWS::ApiGateway::RestApi"
         ]
       }
+    },
+    "Route53HealthCheckConfigType": {
+      "AllowedValues": [
+        "CALCULATED",
+        "CLOUDWATCH_METRIC",
+        "HTTP_STR_MATCH",
+        "HTTP",
+        "HTTPS_STR_MATCH",
+        "HTTPS",
+        "TCP"
+      ]
+    },
+    "Route53ResolverEndpointDirection": {
+      "AllowedValues": [
+        "INBOUND",
+        "OUTBOUND"
+      ]
+    },
+    "Route53ResolverRuleType": {
+      "AllowedValues": [
+        "FORWARD",
+        "RECURSIVE",
+        "SYSTEM"
+      ]
     },
     "S3BucketAccelerationStatus": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ap-south-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-south-1.json
@@ -12898,7 +12898,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-healthcheck-healthcheckconfig.html#cfn-route53-healthcheck-healthcheckconfig-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "Route53HealthCheckConfigType"
+          }
         }
       }
     },
@@ -13008,7 +13011,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-geolocation.html#cfn-route53-recordset-geolocation-continentcode",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "RecordSetGeoContinentCode"
+          }
         },
         "CountryCode": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-geolocation.html#cfn-route53-recordset-geolocation-countrycode",
@@ -13054,7 +13060,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-geolocation.html#cfn-route53-recordsetgroup-geolocation-continentcode",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "RecordSetGeoContinentCode"
+          }
         },
         "CountryCode": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-geolocation.html#cfn-route53-recordset-geolocation-countrycode",
@@ -13089,7 +13098,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-failover",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "RecordSetFailover"
+          }
         },
         "GeoLocation": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-geolocation",
@@ -25878,7 +25890,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-failover",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "RecordSetFailover"
+          }
         },
         "GeoLocation": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-geolocation",
@@ -28250,6 +28265,23 @@
         ]
       }
     },
+    "RecordSetFailover": {
+      "AllowedValues": [
+        "PRIMARY",
+        "SECONDARY"
+      ]
+    },
+    "RecordSetGeoContinentCode": {
+      "AllowedValues": [
+        "AF",
+        "AN",
+        "AS",
+        "EU",
+        "NA",
+        "OC",
+        "SA"
+      ]
+    },
     "RecordSetType": {
       "AllowedValues": [
         "A",
@@ -28276,6 +28308,30 @@
           "AWS::ApiGateway::RestApi"
         ]
       }
+    },
+    "Route53HealthCheckConfigType": {
+      "AllowedValues": [
+        "CALCULATED",
+        "CLOUDWATCH_METRIC",
+        "HTTP_STR_MATCH",
+        "HTTP",
+        "HTTPS_STR_MATCH",
+        "HTTPS",
+        "TCP"
+      ]
+    },
+    "Route53ResolverEndpointDirection": {
+      "AllowedValues": [
+        "INBOUND",
+        "OUTBOUND"
+      ]
+    },
+    "Route53ResolverRuleType": {
+      "AllowedValues": [
+        "FORWARD",
+        "RECURSIVE",
+        "SYSTEM"
+      ]
     },
     "S3BucketAccelerationStatus": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
@@ -13260,7 +13260,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-healthcheck-healthcheckconfig.html#cfn-route53-healthcheck-healthcheckconfig-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "Route53HealthCheckConfigType"
+          }
         }
       }
     },
@@ -13370,7 +13373,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-geolocation.html#cfn-route53-recordset-geolocation-continentcode",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "RecordSetGeoContinentCode"
+          }
         },
         "CountryCode": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-geolocation.html#cfn-route53-recordset-geolocation-countrycode",
@@ -13416,7 +13422,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-geolocation.html#cfn-route53-recordsetgroup-geolocation-continentcode",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "RecordSetGeoContinentCode"
+          }
         },
         "CountryCode": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-geolocation.html#cfn-route53-recordset-geolocation-countrycode",
@@ -13451,7 +13460,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-failover",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "RecordSetFailover"
+          }
         },
         "GeoLocation": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-geolocation",
@@ -26861,7 +26873,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-failover",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "RecordSetFailover"
+          }
         },
         "GeoLocation": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-geolocation",
@@ -27000,7 +27015,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-route53resolver-resolverendpoint.html#cfn-route53resolver-resolverendpoint-direction",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "Route53ResolverEndpointDirection"
+          }
         },
         "IpAddresses": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-route53resolver-resolverendpoint.html#cfn-route53resolver-resolverendpoint-ipaddresses",
@@ -27076,7 +27094,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-route53resolver-resolverrule.html#cfn-route53resolver-resolverrule-ruletype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "Route53ResolverRuleType"
+          }
         },
         "Tags": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-route53resolver-resolverrule.html#cfn-route53resolver-resolverrule-tags",
@@ -29402,6 +29423,23 @@
         ]
       }
     },
+    "RecordSetFailover": {
+      "AllowedValues": [
+        "PRIMARY",
+        "SECONDARY"
+      ]
+    },
+    "RecordSetGeoContinentCode": {
+      "AllowedValues": [
+        "AF",
+        "AN",
+        "AS",
+        "EU",
+        "NA",
+        "OC",
+        "SA"
+      ]
+    },
     "RecordSetType": {
       "AllowedValues": [
         "A",
@@ -29428,6 +29466,30 @@
           "AWS::ApiGateway::RestApi"
         ]
       }
+    },
+    "Route53HealthCheckConfigType": {
+      "AllowedValues": [
+        "CALCULATED",
+        "CLOUDWATCH_METRIC",
+        "HTTP_STR_MATCH",
+        "HTTP",
+        "HTTPS_STR_MATCH",
+        "HTTPS",
+        "TCP"
+      ]
+    },
+    "Route53ResolverEndpointDirection": {
+      "AllowedValues": [
+        "INBOUND",
+        "OUTBOUND"
+      ]
+    },
+    "Route53ResolverRuleType": {
+      "AllowedValues": [
+        "FORWARD",
+        "RECURSIVE",
+        "SYSTEM"
+      ]
     },
     "S3BucketAccelerationStatus": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
@@ -13757,7 +13757,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-healthcheck-healthcheckconfig.html#cfn-route53-healthcheck-healthcheckconfig-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "Route53HealthCheckConfigType"
+          }
         }
       }
     },
@@ -13867,7 +13870,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-geolocation.html#cfn-route53-recordset-geolocation-continentcode",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "RecordSetGeoContinentCode"
+          }
         },
         "CountryCode": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-geolocation.html#cfn-route53-recordset-geolocation-countrycode",
@@ -13913,7 +13919,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-geolocation.html#cfn-route53-recordsetgroup-geolocation-continentcode",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "RecordSetGeoContinentCode"
+          }
         },
         "CountryCode": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-geolocation.html#cfn-route53-recordset-geolocation-countrycode",
@@ -13948,7 +13957,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-failover",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "RecordSetFailover"
+          }
         },
         "GeoLocation": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-geolocation",
@@ -27866,7 +27878,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-failover",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "RecordSetFailover"
+          }
         },
         "GeoLocation": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-geolocation",
@@ -30286,6 +30301,23 @@
         ]
       }
     },
+    "RecordSetFailover": {
+      "AllowedValues": [
+        "PRIMARY",
+        "SECONDARY"
+      ]
+    },
+    "RecordSetGeoContinentCode": {
+      "AllowedValues": [
+        "AF",
+        "AN",
+        "AS",
+        "EU",
+        "NA",
+        "OC",
+        "SA"
+      ]
+    },
     "RecordSetType": {
       "AllowedValues": [
         "A",
@@ -30312,6 +30344,30 @@
           "AWS::ApiGateway::RestApi"
         ]
       }
+    },
+    "Route53HealthCheckConfigType": {
+      "AllowedValues": [
+        "CALCULATED",
+        "CLOUDWATCH_METRIC",
+        "HTTP_STR_MATCH",
+        "HTTP",
+        "HTTPS_STR_MATCH",
+        "HTTPS",
+        "TCP"
+      ]
+    },
+    "Route53ResolverEndpointDirection": {
+      "AllowedValues": [
+        "INBOUND",
+        "OUTBOUND"
+      ]
+    },
+    "Route53ResolverRuleType": {
+      "AllowedValues": [
+        "FORWARD",
+        "RECURSIVE",
+        "SYSTEM"
+      ]
     },
     "S3BucketAccelerationStatus": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ca-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/ca-central-1.json
@@ -11952,7 +11952,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-healthcheck-healthcheckconfig.html#cfn-route53-healthcheck-healthcheckconfig-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "Route53HealthCheckConfigType"
+          }
         }
       }
     },
@@ -12062,7 +12065,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-geolocation.html#cfn-route53-recordset-geolocation-continentcode",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "RecordSetGeoContinentCode"
+          }
         },
         "CountryCode": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-geolocation.html#cfn-route53-recordset-geolocation-countrycode",
@@ -12108,7 +12114,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-geolocation.html#cfn-route53-recordsetgroup-geolocation-continentcode",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "RecordSetGeoContinentCode"
+          }
         },
         "CountryCode": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-geolocation.html#cfn-route53-recordset-geolocation-countrycode",
@@ -12143,7 +12152,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-failover",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "RecordSetFailover"
+          }
         },
         "GeoLocation": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-geolocation",
@@ -24281,7 +24293,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-failover",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "RecordSetFailover"
+          }
         },
         "GeoLocation": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-geolocation",
@@ -26610,6 +26625,23 @@
         ]
       }
     },
+    "RecordSetFailover": {
+      "AllowedValues": [
+        "PRIMARY",
+        "SECONDARY"
+      ]
+    },
+    "RecordSetGeoContinentCode": {
+      "AllowedValues": [
+        "AF",
+        "AN",
+        "AS",
+        "EU",
+        "NA",
+        "OC",
+        "SA"
+      ]
+    },
     "RecordSetType": {
       "AllowedValues": [
         "A",
@@ -26636,6 +26668,30 @@
           "AWS::ApiGateway::RestApi"
         ]
       }
+    },
+    "Route53HealthCheckConfigType": {
+      "AllowedValues": [
+        "CALCULATED",
+        "CLOUDWATCH_METRIC",
+        "HTTP_STR_MATCH",
+        "HTTP",
+        "HTTPS_STR_MATCH",
+        "HTTPS",
+        "TCP"
+      ]
+    },
+    "Route53ResolverEndpointDirection": {
+      "AllowedValues": [
+        "INBOUND",
+        "OUTBOUND"
+      ]
+    },
+    "Route53ResolverRuleType": {
+      "AllowedValues": [
+        "FORWARD",
+        "RECURSIVE",
+        "SYSTEM"
+      ]
     },
     "S3BucketAccelerationStatus": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/eu-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-central-1.json
@@ -14306,7 +14306,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-healthcheck-healthcheckconfig.html#cfn-route53-healthcheck-healthcheckconfig-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "Route53HealthCheckConfigType"
+          }
         }
       }
     },
@@ -14416,7 +14419,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-geolocation.html#cfn-route53-recordset-geolocation-continentcode",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "RecordSetGeoContinentCode"
+          }
         },
         "CountryCode": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-geolocation.html#cfn-route53-recordset-geolocation-countrycode",
@@ -14462,7 +14468,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-geolocation.html#cfn-route53-recordsetgroup-geolocation-continentcode",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "RecordSetGeoContinentCode"
+          }
         },
         "CountryCode": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-geolocation.html#cfn-route53-recordset-geolocation-countrycode",
@@ -14497,7 +14506,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-failover",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "RecordSetFailover"
+          }
         },
         "GeoLocation": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-geolocation",
@@ -28703,7 +28715,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-failover",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "RecordSetFailover"
+          }
         },
         "GeoLocation": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-geolocation",
@@ -31091,6 +31106,23 @@
         ]
       }
     },
+    "RecordSetFailover": {
+      "AllowedValues": [
+        "PRIMARY",
+        "SECONDARY"
+      ]
+    },
+    "RecordSetGeoContinentCode": {
+      "AllowedValues": [
+        "AF",
+        "AN",
+        "AS",
+        "EU",
+        "NA",
+        "OC",
+        "SA"
+      ]
+    },
     "RecordSetType": {
       "AllowedValues": [
         "A",
@@ -31117,6 +31149,30 @@
           "AWS::ApiGateway::RestApi"
         ]
       }
+    },
+    "Route53HealthCheckConfigType": {
+      "AllowedValues": [
+        "CALCULATED",
+        "CLOUDWATCH_METRIC",
+        "HTTP_STR_MATCH",
+        "HTTP",
+        "HTTPS_STR_MATCH",
+        "HTTPS",
+        "TCP"
+      ]
+    },
+    "Route53ResolverEndpointDirection": {
+      "AllowedValues": [
+        "INBOUND",
+        "OUTBOUND"
+      ]
+    },
+    "Route53ResolverRuleType": {
+      "AllowedValues": [
+        "FORWARD",
+        "RECURSIVE",
+        "SYSTEM"
+      ]
     },
     "S3BucketAccelerationStatus": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/eu-north-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-north-1.json
@@ -9488,7 +9488,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-healthcheck-healthcheckconfig.html#cfn-route53-healthcheck-healthcheckconfig-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "Route53HealthCheckConfigType"
+          }
         }
       }
     },
@@ -9598,7 +9601,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-geolocation.html#cfn-route53-recordset-geolocation-continentcode",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "RecordSetGeoContinentCode"
+          }
         },
         "CountryCode": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-geolocation.html#cfn-route53-recordset-geolocation-countrycode",
@@ -9644,7 +9650,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-geolocation.html#cfn-route53-recordsetgroup-geolocation-continentcode",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "RecordSetGeoContinentCode"
+          }
         },
         "CountryCode": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-geolocation.html#cfn-route53-recordset-geolocation-countrycode",
@@ -9679,7 +9688,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-failover",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "RecordSetFailover"
+          }
         },
         "GeoLocation": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-geolocation",
@@ -20363,7 +20375,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-failover",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "RecordSetFailover"
+          }
         },
         "GeoLocation": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-geolocation",
@@ -21621,6 +21636,23 @@
         ]
       }
     },
+    "RecordSetFailover": {
+      "AllowedValues": [
+        "PRIMARY",
+        "SECONDARY"
+      ]
+    },
+    "RecordSetGeoContinentCode": {
+      "AllowedValues": [
+        "AF",
+        "AN",
+        "AS",
+        "EU",
+        "NA",
+        "OC",
+        "SA"
+      ]
+    },
     "RecordSetType": {
       "AllowedValues": [
         "A",
@@ -21647,6 +21679,30 @@
           "AWS::ApiGateway::RestApi"
         ]
       }
+    },
+    "Route53HealthCheckConfigType": {
+      "AllowedValues": [
+        "CALCULATED",
+        "CLOUDWATCH_METRIC",
+        "HTTP_STR_MATCH",
+        "HTTP",
+        "HTTPS_STR_MATCH",
+        "HTTPS",
+        "TCP"
+      ]
+    },
+    "Route53ResolverEndpointDirection": {
+      "AllowedValues": [
+        "INBOUND",
+        "OUTBOUND"
+      ]
+    },
+    "Route53ResolverRuleType": {
+      "AllowedValues": [
+        "FORWARD",
+        "RECURSIVE",
+        "SYSTEM"
+      ]
     },
     "S3BucketAccelerationStatus": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/eu-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-1.json
@@ -15228,7 +15228,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-healthcheck-healthcheckconfig.html#cfn-route53-healthcheck-healthcheckconfig-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "Route53HealthCheckConfigType"
+          }
         }
       }
     },
@@ -15338,7 +15341,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-geolocation.html#cfn-route53-recordset-geolocation-continentcode",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "RecordSetGeoContinentCode"
+          }
         },
         "CountryCode": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-geolocation.html#cfn-route53-recordset-geolocation-countrycode",
@@ -15384,7 +15390,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-geolocation.html#cfn-route53-recordsetgroup-geolocation-continentcode",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "RecordSetGeoContinentCode"
+          }
         },
         "CountryCode": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-geolocation.html#cfn-route53-recordset-geolocation-countrycode",
@@ -15419,7 +15428,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-failover",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "RecordSetFailover"
+          }
         },
         "GeoLocation": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-geolocation",
@@ -31218,7 +31230,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-failover",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "RecordSetFailover"
+          }
         },
         "GeoLocation": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-geolocation",
@@ -31357,7 +31372,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-route53resolver-resolverendpoint.html#cfn-route53resolver-resolverendpoint-direction",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "Route53ResolverEndpointDirection"
+          }
         },
         "IpAddresses": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-route53resolver-resolverendpoint.html#cfn-route53resolver-resolverendpoint-ipaddresses",
@@ -31433,7 +31451,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-route53resolver-resolverrule.html#cfn-route53resolver-resolverrule-ruletype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "Route53ResolverRuleType"
+          }
         },
         "Tags": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-route53resolver-resolverrule.html#cfn-route53resolver-resolverrule-tags",
@@ -34187,6 +34208,23 @@
         ]
       }
     },
+    "RecordSetFailover": {
+      "AllowedValues": [
+        "PRIMARY",
+        "SECONDARY"
+      ]
+    },
+    "RecordSetGeoContinentCode": {
+      "AllowedValues": [
+        "AF",
+        "AN",
+        "AS",
+        "EU",
+        "NA",
+        "OC",
+        "SA"
+      ]
+    },
     "RecordSetType": {
       "AllowedValues": [
         "A",
@@ -34213,6 +34251,30 @@
           "AWS::ApiGateway::RestApi"
         ]
       }
+    },
+    "Route53HealthCheckConfigType": {
+      "AllowedValues": [
+        "CALCULATED",
+        "CLOUDWATCH_METRIC",
+        "HTTP_STR_MATCH",
+        "HTTP",
+        "HTTPS_STR_MATCH",
+        "HTTPS",
+        "TCP"
+      ]
+    },
+    "Route53ResolverEndpointDirection": {
+      "AllowedValues": [
+        "INBOUND",
+        "OUTBOUND"
+      ]
+    },
+    "Route53ResolverRuleType": {
+      "AllowedValues": [
+        "FORWARD",
+        "RECURSIVE",
+        "SYSTEM"
+      ]
     },
     "S3BucketAccelerationStatus": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/eu-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-2.json
@@ -12425,7 +12425,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-healthcheck-healthcheckconfig.html#cfn-route53-healthcheck-healthcheckconfig-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "Route53HealthCheckConfigType"
+          }
         }
       }
     },
@@ -12535,7 +12538,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-geolocation.html#cfn-route53-recordset-geolocation-continentcode",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "RecordSetGeoContinentCode"
+          }
         },
         "CountryCode": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-geolocation.html#cfn-route53-recordset-geolocation-countrycode",
@@ -12581,7 +12587,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-geolocation.html#cfn-route53-recordsetgroup-geolocation-continentcode",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "RecordSetGeoContinentCode"
+          }
         },
         "CountryCode": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-geolocation.html#cfn-route53-recordset-geolocation-countrycode",
@@ -12616,7 +12625,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-failover",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "RecordSetFailover"
+          }
         },
         "GeoLocation": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-geolocation",
@@ -25582,7 +25594,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-failover",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "RecordSetFailover"
+          }
         },
         "GeoLocation": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-geolocation",
@@ -27911,6 +27926,23 @@
         ]
       }
     },
+    "RecordSetFailover": {
+      "AllowedValues": [
+        "PRIMARY",
+        "SECONDARY"
+      ]
+    },
+    "RecordSetGeoContinentCode": {
+      "AllowedValues": [
+        "AF",
+        "AN",
+        "AS",
+        "EU",
+        "NA",
+        "OC",
+        "SA"
+      ]
+    },
     "RecordSetType": {
       "AllowedValues": [
         "A",
@@ -27937,6 +27969,30 @@
           "AWS::ApiGateway::RestApi"
         ]
       }
+    },
+    "Route53HealthCheckConfigType": {
+      "AllowedValues": [
+        "CALCULATED",
+        "CLOUDWATCH_METRIC",
+        "HTTP_STR_MATCH",
+        "HTTP",
+        "HTTPS_STR_MATCH",
+        "HTTPS",
+        "TCP"
+      ]
+    },
+    "Route53ResolverEndpointDirection": {
+      "AllowedValues": [
+        "INBOUND",
+        "OUTBOUND"
+      ]
+    },
+    "Route53ResolverRuleType": {
+      "AllowedValues": [
+        "FORWARD",
+        "RECURSIVE",
+        "SYSTEM"
+      ]
     },
     "S3BucketAccelerationStatus": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/eu-west-3.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-3.json
@@ -11107,7 +11107,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-healthcheck-healthcheckconfig.html#cfn-route53-healthcheck-healthcheckconfig-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "Route53HealthCheckConfigType"
+          }
         }
       }
     },
@@ -11217,7 +11220,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-geolocation.html#cfn-route53-recordset-geolocation-continentcode",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "RecordSetGeoContinentCode"
+          }
         },
         "CountryCode": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-geolocation.html#cfn-route53-recordset-geolocation-countrycode",
@@ -11263,7 +11269,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-geolocation.html#cfn-route53-recordsetgroup-geolocation-continentcode",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "RecordSetGeoContinentCode"
+          }
         },
         "CountryCode": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-geolocation.html#cfn-route53-recordset-geolocation-countrycode",
@@ -11298,7 +11307,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-failover",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "RecordSetFailover"
+          }
         },
         "GeoLocation": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-geolocation",
@@ -22636,7 +22648,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-failover",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "RecordSetFailover"
+          }
         },
         "GeoLocation": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-geolocation",
@@ -24811,6 +24826,23 @@
         ]
       }
     },
+    "RecordSetFailover": {
+      "AllowedValues": [
+        "PRIMARY",
+        "SECONDARY"
+      ]
+    },
+    "RecordSetGeoContinentCode": {
+      "AllowedValues": [
+        "AF",
+        "AN",
+        "AS",
+        "EU",
+        "NA",
+        "OC",
+        "SA"
+      ]
+    },
     "RecordSetType": {
       "AllowedValues": [
         "A",
@@ -24837,6 +24869,30 @@
           "AWS::ApiGateway::RestApi"
         ]
       }
+    },
+    "Route53HealthCheckConfigType": {
+      "AllowedValues": [
+        "CALCULATED",
+        "CLOUDWATCH_METRIC",
+        "HTTP_STR_MATCH",
+        "HTTP",
+        "HTTPS_STR_MATCH",
+        "HTTPS",
+        "TCP"
+      ]
+    },
+    "Route53ResolverEndpointDirection": {
+      "AllowedValues": [
+        "INBOUND",
+        "OUTBOUND"
+      ]
+    },
+    "Route53ResolverRuleType": {
+      "AllowedValues": [
+        "FORWARD",
+        "RECURSIVE",
+        "SYSTEM"
+      ]
     },
     "S3BucketAccelerationStatus": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/sa-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/sa-east-1.json
@@ -11638,7 +11638,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-healthcheck-healthcheckconfig.html#cfn-route53-healthcheck-healthcheckconfig-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "Route53HealthCheckConfigType"
+          }
         }
       }
     },
@@ -11748,7 +11751,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-geolocation.html#cfn-route53-recordset-geolocation-continentcode",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "RecordSetGeoContinentCode"
+          }
         },
         "CountryCode": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-geolocation.html#cfn-route53-recordset-geolocation-countrycode",
@@ -11794,7 +11800,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-geolocation.html#cfn-route53-recordsetgroup-geolocation-continentcode",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "RecordSetGeoContinentCode"
+          }
         },
         "CountryCode": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-geolocation.html#cfn-route53-recordset-geolocation-countrycode",
@@ -11829,7 +11838,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-failover",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "RecordSetFailover"
+          }
         },
         "GeoLocation": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-geolocation",
@@ -23649,7 +23661,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-failover",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "RecordSetFailover"
+          }
         },
         "GeoLocation": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-geolocation",
@@ -25784,6 +25799,23 @@
         ]
       }
     },
+    "RecordSetFailover": {
+      "AllowedValues": [
+        "PRIMARY",
+        "SECONDARY"
+      ]
+    },
+    "RecordSetGeoContinentCode": {
+      "AllowedValues": [
+        "AF",
+        "AN",
+        "AS",
+        "EU",
+        "NA",
+        "OC",
+        "SA"
+      ]
+    },
     "RecordSetType": {
       "AllowedValues": [
         "A",
@@ -25810,6 +25842,30 @@
           "AWS::ApiGateway::RestApi"
         ]
       }
+    },
+    "Route53HealthCheckConfigType": {
+      "AllowedValues": [
+        "CALCULATED",
+        "CLOUDWATCH_METRIC",
+        "HTTP_STR_MATCH",
+        "HTTP",
+        "HTTPS_STR_MATCH",
+        "HTTPS",
+        "TCP"
+      ]
+    },
+    "Route53ResolverEndpointDirection": {
+      "AllowedValues": [
+        "INBOUND",
+        "OUTBOUND"
+      ]
+    },
+    "Route53ResolverRuleType": {
+      "AllowedValues": [
+        "FORWARD",
+        "RECURSIVE",
+        "SYSTEM"
+      ]
     },
     "S3BucketAccelerationStatus": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/us-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-1.json
@@ -15247,7 +15247,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-healthcheck-healthcheckconfig.html#cfn-route53-healthcheck-healthcheckconfig-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "Route53HealthCheckConfigType"
+          }
         }
       }
     },
@@ -15357,7 +15360,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-geolocation.html#cfn-route53-recordset-geolocation-continentcode",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "RecordSetGeoContinentCode"
+          }
         },
         "CountryCode": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-geolocation.html#cfn-route53-recordset-geolocation-countrycode",
@@ -15403,7 +15409,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-geolocation.html#cfn-route53-recordsetgroup-geolocation-continentcode",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "RecordSetGeoContinentCode"
+          }
         },
         "CountryCode": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-geolocation.html#cfn-route53-recordset-geolocation-countrycode",
@@ -15438,7 +15447,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-failover",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "RecordSetFailover"
+          }
         },
         "GeoLocation": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-geolocation",
@@ -31289,7 +31301,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-failover",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "RecordSetFailover"
+          }
         },
         "GeoLocation": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-geolocation",
@@ -31428,7 +31443,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-route53resolver-resolverendpoint.html#cfn-route53resolver-resolverendpoint-direction",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "Route53ResolverEndpointDirection"
+          }
         },
         "IpAddresses": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-route53resolver-resolverendpoint.html#cfn-route53resolver-resolverendpoint-ipaddresses",
@@ -31504,7 +31522,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-route53resolver-resolverrule.html#cfn-route53resolver-resolverrule-ruletype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "Route53ResolverRuleType"
+          }
         },
         "Tags": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-route53resolver-resolverrule.html#cfn-route53resolver-resolverrule-tags",
@@ -34216,6 +34237,23 @@
         ]
       }
     },
+    "RecordSetFailover": {
+      "AllowedValues": [
+        "PRIMARY",
+        "SECONDARY"
+      ]
+    },
+    "RecordSetGeoContinentCode": {
+      "AllowedValues": [
+        "AF",
+        "AN",
+        "AS",
+        "EU",
+        "NA",
+        "OC",
+        "SA"
+      ]
+    },
     "RecordSetType": {
       "AllowedValues": [
         "A",
@@ -34242,6 +34280,30 @@
           "AWS::ApiGateway::RestApi"
         ]
       }
+    },
+    "Route53HealthCheckConfigType": {
+      "AllowedValues": [
+        "CALCULATED",
+        "CLOUDWATCH_METRIC",
+        "HTTP_STR_MATCH",
+        "HTTP",
+        "HTTPS_STR_MATCH",
+        "HTTPS",
+        "TCP"
+      ]
+    },
+    "Route53ResolverEndpointDirection": {
+      "AllowedValues": [
+        "INBOUND",
+        "OUTBOUND"
+      ]
+    },
+    "Route53ResolverRuleType": {
+      "AllowedValues": [
+        "FORWARD",
+        "RECURSIVE",
+        "SYSTEM"
+      ]
     },
     "S3BucketAccelerationStatus": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/us-east-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-2.json
@@ -14752,7 +14752,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-healthcheck-healthcheckconfig.html#cfn-route53-healthcheck-healthcheckconfig-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "Route53HealthCheckConfigType"
+          }
         }
       }
     },
@@ -14862,7 +14865,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-geolocation.html#cfn-route53-recordset-geolocation-continentcode",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "RecordSetGeoContinentCode"
+          }
         },
         "CountryCode": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-geolocation.html#cfn-route53-recordset-geolocation-countrycode",
@@ -14908,7 +14914,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-geolocation.html#cfn-route53-recordsetgroup-geolocation-continentcode",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "RecordSetGeoContinentCode"
+          }
         },
         "CountryCode": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-geolocation.html#cfn-route53-recordset-geolocation-countrycode",
@@ -14943,7 +14952,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-failover",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "RecordSetFailover"
+          }
         },
         "GeoLocation": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-geolocation",
@@ -29516,7 +29528,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-failover",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "RecordSetFailover"
+          }
         },
         "GeoLocation": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-geolocation",
@@ -29655,7 +29670,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-route53resolver-resolverendpoint.html#cfn-route53resolver-resolverendpoint-direction",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "Route53ResolverEndpointDirection"
+          }
         },
         "IpAddresses": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-route53resolver-resolverendpoint.html#cfn-route53resolver-resolverendpoint-ipaddresses",
@@ -29731,7 +29749,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-route53resolver-resolverrule.html#cfn-route53resolver-resolverrule-ruletype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "Route53ResolverRuleType"
+          }
         },
         "Tags": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-route53resolver-resolverrule.html#cfn-route53resolver-resolverrule-tags",
@@ -32229,6 +32250,23 @@
         ]
       }
     },
+    "RecordSetFailover": {
+      "AllowedValues": [
+        "PRIMARY",
+        "SECONDARY"
+      ]
+    },
+    "RecordSetGeoContinentCode": {
+      "AllowedValues": [
+        "AF",
+        "AN",
+        "AS",
+        "EU",
+        "NA",
+        "OC",
+        "SA"
+      ]
+    },
     "RecordSetType": {
       "AllowedValues": [
         "A",
@@ -32255,6 +32293,30 @@
           "AWS::ApiGateway::RestApi"
         ]
       }
+    },
+    "Route53HealthCheckConfigType": {
+      "AllowedValues": [
+        "CALCULATED",
+        "CLOUDWATCH_METRIC",
+        "HTTP_STR_MATCH",
+        "HTTP",
+        "HTTPS_STR_MATCH",
+        "HTTPS",
+        "TCP"
+      ]
+    },
+    "Route53ResolverEndpointDirection": {
+      "AllowedValues": [
+        "INBOUND",
+        "OUTBOUND"
+      ]
+    },
+    "Route53ResolverRuleType": {
+      "AllowedValues": [
+        "FORWARD",
+        "RECURSIVE",
+        "SYSTEM"
+      ]
     },
     "S3BucketAccelerationStatus": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
@@ -9296,7 +9296,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-healthcheck-healthcheckconfig.html#cfn-route53-healthcheck-healthcheckconfig-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "Route53HealthCheckConfigType"
+          }
         }
       }
     },
@@ -9406,7 +9409,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-geolocation.html#cfn-route53-recordset-geolocation-continentcode",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "RecordSetGeoContinentCode"
+          }
         },
         "CountryCode": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-geolocation.html#cfn-route53-recordset-geolocation-countrycode",
@@ -9452,7 +9458,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-geolocation.html#cfn-route53-recordsetgroup-geolocation-continentcode",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "RecordSetGeoContinentCode"
+          }
         },
         "CountryCode": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-geolocation.html#cfn-route53-recordset-geolocation-countrycode",
@@ -9487,7 +9496,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-failover",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "RecordSetFailover"
+          }
         },
         "GeoLocation": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-geolocation",
@@ -19663,7 +19675,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-failover",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "RecordSetFailover"
+          }
         },
         "GeoLocation": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-geolocation",
@@ -20921,6 +20936,23 @@
         ]
       }
     },
+    "RecordSetFailover": {
+      "AllowedValues": [
+        "PRIMARY",
+        "SECONDARY"
+      ]
+    },
+    "RecordSetGeoContinentCode": {
+      "AllowedValues": [
+        "AF",
+        "AN",
+        "AS",
+        "EU",
+        "NA",
+        "OC",
+        "SA"
+      ]
+    },
     "RecordSetType": {
       "AllowedValues": [
         "A",
@@ -20947,6 +20979,30 @@
           "AWS::ApiGateway::RestApi"
         ]
       }
+    },
+    "Route53HealthCheckConfigType": {
+      "AllowedValues": [
+        "CALCULATED",
+        "CLOUDWATCH_METRIC",
+        "HTTP_STR_MATCH",
+        "HTTP",
+        "HTTPS_STR_MATCH",
+        "HTTPS",
+        "TCP"
+      ]
+    },
+    "Route53ResolverEndpointDirection": {
+      "AllowedValues": [
+        "INBOUND",
+        "OUTBOUND"
+      ]
+    },
+    "Route53ResolverRuleType": {
+      "AllowedValues": [
+        "FORWARD",
+        "RECURSIVE",
+        "SYSTEM"
+      ]
     },
     "S3BucketAccelerationStatus": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
@@ -9353,7 +9353,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-healthcheck-healthcheckconfig.html#cfn-route53-healthcheck-healthcheckconfig-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "Route53HealthCheckConfigType"
+          }
         }
       }
     },
@@ -9463,7 +9466,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-geolocation.html#cfn-route53-recordset-geolocation-continentcode",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "RecordSetGeoContinentCode"
+          }
         },
         "CountryCode": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-geolocation.html#cfn-route53-recordset-geolocation-countrycode",
@@ -9509,7 +9515,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-geolocation.html#cfn-route53-recordsetgroup-geolocation-continentcode",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "RecordSetGeoContinentCode"
+          }
         },
         "CountryCode": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-geolocation.html#cfn-route53-recordset-geolocation-countrycode",
@@ -9544,7 +9553,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-failover",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "RecordSetFailover"
+          }
         },
         "GeoLocation": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-geolocation",
@@ -19857,7 +19869,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-failover",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "RecordSetFailover"
+          }
         },
         "GeoLocation": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-geolocation",
@@ -21197,6 +21212,23 @@
         ]
       }
     },
+    "RecordSetFailover": {
+      "AllowedValues": [
+        "PRIMARY",
+        "SECONDARY"
+      ]
+    },
+    "RecordSetGeoContinentCode": {
+      "AllowedValues": [
+        "AF",
+        "AN",
+        "AS",
+        "EU",
+        "NA",
+        "OC",
+        "SA"
+      ]
+    },
     "RecordSetType": {
       "AllowedValues": [
         "A",
@@ -21223,6 +21255,30 @@
           "AWS::ApiGateway::RestApi"
         ]
       }
+    },
+    "Route53HealthCheckConfigType": {
+      "AllowedValues": [
+        "CALCULATED",
+        "CLOUDWATCH_METRIC",
+        "HTTP_STR_MATCH",
+        "HTTP",
+        "HTTPS_STR_MATCH",
+        "HTTPS",
+        "TCP"
+      ]
+    },
+    "Route53ResolverEndpointDirection": {
+      "AllowedValues": [
+        "INBOUND",
+        "OUTBOUND"
+      ]
+    },
+    "Route53ResolverRuleType": {
+      "AllowedValues": [
+        "FORWARD",
+        "RECURSIVE",
+        "SYSTEM"
+      ]
     },
     "S3BucketAccelerationStatus": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/us-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-1.json
@@ -12150,7 +12150,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-healthcheck-healthcheckconfig.html#cfn-route53-healthcheck-healthcheckconfig-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "Route53HealthCheckConfigType"
+          }
         }
       }
     },
@@ -12260,7 +12263,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-geolocation.html#cfn-route53-recordset-geolocation-continentcode",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "RecordSetGeoContinentCode"
+          }
         },
         "CountryCode": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-geolocation.html#cfn-route53-recordset-geolocation-countrycode",
@@ -12306,7 +12312,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-geolocation.html#cfn-route53-recordsetgroup-geolocation-continentcode",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "RecordSetGeoContinentCode"
+          }
         },
         "CountryCode": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-geolocation.html#cfn-route53-recordset-geolocation-countrycode",
@@ -12341,7 +12350,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-failover",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "RecordSetFailover"
+          }
         },
         "GeoLocation": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-geolocation",
@@ -24909,7 +24921,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-failover",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "RecordSetFailover"
+          }
         },
         "GeoLocation": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-geolocation",
@@ -27244,6 +27259,23 @@
         ]
       }
     },
+    "RecordSetFailover": {
+      "AllowedValues": [
+        "PRIMARY",
+        "SECONDARY"
+      ]
+    },
+    "RecordSetGeoContinentCode": {
+      "AllowedValues": [
+        "AF",
+        "AN",
+        "AS",
+        "EU",
+        "NA",
+        "OC",
+        "SA"
+      ]
+    },
     "RecordSetType": {
       "AllowedValues": [
         "A",
@@ -27270,6 +27302,30 @@
           "AWS::ApiGateway::RestApi"
         ]
       }
+    },
+    "Route53HealthCheckConfigType": {
+      "AllowedValues": [
+        "CALCULATED",
+        "CLOUDWATCH_METRIC",
+        "HTTP_STR_MATCH",
+        "HTTP",
+        "HTTPS_STR_MATCH",
+        "HTTPS",
+        "TCP"
+      ]
+    },
+    "Route53ResolverEndpointDirection": {
+      "AllowedValues": [
+        "INBOUND",
+        "OUTBOUND"
+      ]
+    },
+    "Route53ResolverRuleType": {
+      "AllowedValues": [
+        "FORWARD",
+        "RECURSIVE",
+        "SYSTEM"
+      ]
     },
     "S3BucketAccelerationStatus": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/us-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-2.json
@@ -15247,7 +15247,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-healthcheck-healthcheckconfig.html#cfn-route53-healthcheck-healthcheckconfig-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "Route53HealthCheckConfigType"
+          }
         }
       }
     },
@@ -15357,7 +15360,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-geolocation.html#cfn-route53-recordset-geolocation-continentcode",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "RecordSetGeoContinentCode"
+          }
         },
         "CountryCode": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-geolocation.html#cfn-route53-recordset-geolocation-countrycode",
@@ -15403,7 +15409,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-geolocation.html#cfn-route53-recordsetgroup-geolocation-continentcode",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "RecordSetGeoContinentCode"
+          }
         },
         "CountryCode": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset-geolocation.html#cfn-route53-recordset-geolocation-countrycode",
@@ -15438,7 +15447,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-failover",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "RecordSetFailover"
+          }
         },
         "GeoLocation": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-geolocation",
@@ -31277,7 +31289,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-failover",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "RecordSetFailover"
+          }
         },
         "GeoLocation": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-geolocation",
@@ -31416,7 +31431,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-route53resolver-resolverendpoint.html#cfn-route53resolver-resolverendpoint-direction",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "Route53ResolverEndpointDirection"
+          }
         },
         "IpAddresses": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-route53resolver-resolverendpoint.html#cfn-route53resolver-resolverendpoint-ipaddresses",
@@ -31492,7 +31510,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-route53resolver-resolverrule.html#cfn-route53resolver-resolverrule-ruletype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "Route53ResolverRuleType"
+          }
         },
         "Tags": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-route53resolver-resolverrule.html#cfn-route53resolver-resolverrule-tags",
@@ -34246,6 +34267,23 @@
         ]
       }
     },
+    "RecordSetFailover": {
+      "AllowedValues": [
+        "PRIMARY",
+        "SECONDARY"
+      ]
+    },
+    "RecordSetGeoContinentCode": {
+      "AllowedValues": [
+        "AF",
+        "AN",
+        "AS",
+        "EU",
+        "NA",
+        "OC",
+        "SA"
+      ]
+    },
     "RecordSetType": {
       "AllowedValues": [
         "A",
@@ -34272,6 +34310,30 @@
           "AWS::ApiGateway::RestApi"
         ]
       }
+    },
+    "Route53HealthCheckConfigType": {
+      "AllowedValues": [
+        "CALCULATED",
+        "CLOUDWATCH_METRIC",
+        "HTTP_STR_MATCH",
+        "HTTP",
+        "HTTPS_STR_MATCH",
+        "HTTPS",
+        "TCP"
+      ]
+    },
+    "Route53ResolverEndpointDirection": {
+      "AllowedValues": [
+        "INBOUND",
+        "OUTBOUND"
+      ]
+    },
+    "Route53ResolverRuleType": {
+      "AllowedValues": [
+        "FORWARD",
+        "RECURSIVE",
+        "SYSTEM"
+      ]
     },
     "S3BucketAccelerationStatus": {
       "AllowedValues": [

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
@@ -463,6 +463,23 @@
           "XssMatch"
         ]
       },
+      "RecordSetGeoContinentCode": {
+        "AllowedValues": [
+          "AF",
+          "AN",
+          "AS",
+          "EU",
+          "NA",
+          "OC",
+          "SA"
+        ]
+      },
+      "RecordSetFailover": {
+        "AllowedValues": [
+          "PRIMARY",
+          "SECONDARY"
+        ]
+      },
       "RecordSetType": {
         "AllowedValues": [
           "A",
@@ -477,6 +494,30 @@
           "SPF",
           "SRV",
           "TXT"
+        ]
+      },
+      "Route53HealthCheckConfigType": {
+        "AllowedValues": [
+          "CALCULATED",
+          "CLOUDWATCH_METRIC",
+          "HTTP_STR_MATCH",
+          "HTTP",
+          "HTTPS_STR_MATCH",
+          "HTTPS",
+          "TCP"
+        ]
+      },
+      "Route53ResolverEndpointDirection": {
+        "AllowedValues": [
+          "INBOUND",
+          "OUTBOUND"
+        ]
+      },
+      "Route53ResolverRuleType": {
+        "AllowedValues": [
+          "FORWARD",
+          "RECURSIVE",
+          "SYSTEM"
         ]
       },
       "RestApiId": {

--- a/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
@@ -134,6 +134,13 @@
   },
   {
     "op": "add",
+    "path": "/PropertyTypes/AWS::Route53::HealthCheck.HealthCheckConfig/Properties/Type/Value",
+    "value": {
+      "ValueType": "Route53HealthCheckConfigType"
+    }
+  },
+  {
+    "op": "add",
     "path": "/PropertyTypes/AWS::S3::Bucket.AccelerateConfiguration/Properties/AccelerationStatus/Value",
     "value": {
       "ValueType": "S3BucketAccelerationStatus"
@@ -229,6 +236,27 @@
     "path": "/PropertyTypes/AWS::ElasticBeanstalk::Application.ApplicationResourceLifecycleConfig/Properties/ServiceRole/Value",
     "value": {
       "ValueType": "IamRole.Arn"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/PropertyTypes/AWS::Route53::RecordSet.GeoLocation/Properties/ContinentCode/Value",
+    "value": {
+      "ValueType": "RecordSetGeoContinentCode"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/PropertyTypes/AWS::Route53::RecordSetGroup.GeoLocation/Properties/ContinentCode/Value",
+    "value": {
+      "ValueType": "RecordSetGeoContinentCode"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/PropertyTypes/AWS::Route53::RecordSetGroup.RecordSet/Properties/Failover/Value",
+    "value": {
+      "ValueType": "RecordSetFailover"
     }
   },
   {
@@ -728,9 +756,30 @@
   },
   {
     "op": "add",
+    "path": "/ResourceTypes/AWS::Route53::RecordSet/Properties/Failover/Value",
+    "value": {
+      "ValueType": "RecordSetFailover"
+    }
+  },
+  {
+    "op": "add",
     "path": "/ResourceTypes/AWS::Route53::RecordSet/Properties/Type/Value",
     "value": {
       "ValueType": "RecordSetType"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/ResourceTypes/AWS::Route53Resolver::ResolverEndpoint/Properties/Direction/Value",
+    "value": {
+      "ValueType": "Route53ResolverEndpointDirection"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/ResourceTypes/AWS::Route53Resolver::ResolverRule/Properties/RuleType/Value",
+    "value": {
+      "ValueType": "Route53ResolverRuleType"
     }
   },
   {
@@ -845,10 +894,6 @@
       "ValueType": "AutoScalingPolicyType"
     }
   },
-
-
-
-
   {
     "op": "add",
     "path": "/ResourceTypes/AWS::EC2::EgressOnlyInternetGateway/Properties/VpcId/Value",

--- a/test/fixtures/templates/bad/resources/properties/allowed_values.yaml
+++ b/test/fixtures/templates/bad/resources/properties/allowed_values.yaml
@@ -154,21 +154,7 @@ Resources:
     Properties:
       EndpointType: "random" # Invalid AllowedValue
       EngineName: "database" # Invalid AllowedValue
-      SslMode: "ssl" # Valid AllowedValue
-  GlueConnection:
-    Type: "AWS::Glue::Connection"
-    Properties:
-      CatalogId: !Ref "AWS::AccountId"
-      ConnectionInput:
-        ConnectionProperties: "{}"
-        ConnectionType: "FTP" # Invalid AllowedValue
-  RecordSet:
-    Type: "AWS::Route53::RecordSet"
-    Properties:
-      Name: "www.example.com"
-      Type: "X" # AllowedValue
-      ResourceRecords:
-        - ''
+      SslMode: "ssl" # Invalid AllowedValue
   EC2Instance:
     Type: "AWS::EC2::Instance"
     Properties:
@@ -179,6 +165,54 @@ Resources:
         - DeviceName: "/dev/sdm"
           Ebs:
             VolumeType: "magnetic" # Invalid AllowedValue
+  GlueConnection:
+    Type: "AWS::Glue::Connection"
+    Properties:
+      CatalogId: !Ref "AWS::AccountId"
+      ConnectionInput:
+        ConnectionProperties: "{}"
+        ConnectionType: "FTP" # Invalid AllowedValue
+  Route53HealthCheck:
+    Type: "AWS::Route53::HealthCheck"
+    Properties:
+      HealthCheckConfig:
+        Type: "HTTP_MATCH" # Invalid AllowedValue
+  Route53RecordSet:
+    Type: "AWS::Route53::RecordSet"
+    Properties:
+      GeoLocation:
+        ContinentCode: "US" # Invalid AllowedValue
+      Failover: "primary" # Invalid AllowedValue
+      Name: "www.example.com"
+      Type: "AA" # Invalid AllowedValue
+      ResourceRecords:
+        - '127.0.0.1'
+  Route53RecordSetGroup:
+    Type: "AWS::Route53::RecordSetGroup"
+    Properties:
+      HostedZoneName: "www.example.com"
+      RecordSets:
+        - Failover: "Secondary" # Invalid AllowedValue
+          GeoLocation:
+            ContinentCode: "A" # Invalid AllowedValue
+          Name: "www.example.com"
+          Type: "ABC" # Invalid AllowedValue
+          ResourceRecords:
+            - 'www.example.com'
+  Route53ResolverEndpoint:
+    Type: "AWS::Route53Resolver::ResolverEndpoint"
+    Properties:
+      Direction: "left" # Invalid AlowedValue
+      IpAddresses:
+        - Ip: '127.0.0.1'
+          SubnetId: "SubnetId"
+      SecurityGroupIds:
+        - "sg"
+  Route53ResolverRule:
+    Type: "AWS::Route53Resolver::ResolverRule"
+    Properties:
+      DomainName: "example.com"
+      RuleType: "default" # Invalid AllowedValue
   S3Bucket:
     Type: "AWS::S3::Bucket"
     Properties:

--- a/test/fixtures/templates/good/resources/properties/allowed_values.yaml
+++ b/test/fixtures/templates/good/resources/properties/allowed_values.yaml
@@ -172,13 +172,47 @@ Resources:
       ConnectionInput:
         ConnectionProperties: "{}"
         ConnectionType: "SFTP" # Valid AllowedValue
-  RecordSet:
+  Route53HealthCheck:
+    Type: "AWS::Route53::HealthCheck"
+    Properties:
+      HealthCheckConfig:
+        Type: "CLOUDWATCH_METRIC"
+  Route53RecordSet:
     Type: "AWS::Route53::RecordSet"
     Properties:
+      Failover: "PRIMARY" # Valid AllowedValue
+      GeoLocation:
+        ContinentCode: "EU" # Valid AllowedValue
       Name: "www.example.com"
       Type: "A" # Valid AllowedValue
       ResourceRecords:
         - '127.0.0.1'
+  Route53RecordSetGroup:
+    Type: "AWS::Route53::RecordSetGroup"
+    Properties:
+      HostedZoneName: "www.example.com"
+      RecordSets:
+        - Failover: "SECONDARY" # Valid AllowedValue
+          GeoLocation:
+            ContinentCode: "AF" # Valid AllowedValue
+          Name: "www.example.com"
+          Type: "CNAME" # Valid AllowedValue
+          ResourceRecords:
+            - 'www.example.com'
+  Route53ResolverEndpoint:
+    Type: "AWS::Route53Resolver::ResolverEndpoint"
+    Properties:
+      Direction: "INBOUND" # Valid AlowedValue
+      IpAddresses:
+        - Ip: '127.0.0.1'
+          SubnetId: "SubnetId"
+      SecurityGroupIds:
+        - "sg"
+  Route53ResolverRule:
+    Type: "AWS::Route53Resolver::ResolverRule"
+    Properties:
+      DomainName: "example.com"
+      RuleType: "SYSTEM" # Valid AllowedValue
   S3Bucket:
     Type: "AWS::S3::Bucket"
     Properties:

--- a/test/rules/resources/properties/test_allowed_value.py
+++ b/test/rules/resources/properties/test_allowed_value.py
@@ -34,4 +34,4 @@ class TestAllowedValue(BaseRuleTestCase):
 
     def test_file_negative(self):
         """Test failure"""
-        self.helper_file_negative('test/fixtures/templates/bad/resources/properties/allowed_values.yaml', 49)
+        self.helper_file_negative('test/fixtures/templates/bad/resources/properties/allowed_values.yaml', 57)


### PR DESCRIPTION
*Issue https://github.com/awslabs/cfn-python-lint/issues/50, if available:*

Add the AllowedValues for all Route53 resources:

See also: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-reference-route53.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
