### PR TITLE
Added configuration/values to OnlyOne and Exclusive

### DIFF
--- a/src/cfnlint/data/AdditionalSpecs/Exclusive.json
+++ b/src/cfnlint/data/AdditionalSpecs/Exclusive.json
@@ -25,6 +25,13 @@
         "Ebs"
       ]
     },
+    "AWS::S3::Bucket.WebsiteConfiguration": {
+      "RedirectAllRequestsTo": [
+        "ErrorDocument",
+        "IndexDocument",
+        "RoutingRules"
+      ]
+    },
     "AWS::EC2::SecurityGroup.Ingress": {
       "CidrIp": [
         "SourceSecurityGroupName",

--- a/src/cfnlint/data/AdditionalSpecs/OnlyOne.json
+++ b/src/cfnlint/data/AdditionalSpecs/OnlyOne.json
@@ -38,5 +38,25 @@
     ]
   },
   "ResourceTypes": {
+    "AWS::AutoScaling::AutoScalingGroup": [
+      [
+        "InstanceId",
+        "LaunchConfigurationName",
+        "LaunchTemplate",
+        "MixedInstancesPolicy"
+      ]
+    ],
+    "AWS::Route53::RecordSet": [
+      [
+        "HostedZoneId",
+        "HostedZoneName"
+      ]
+    ],
+    "AWS::Route53::RecordSetGroup": [
+      [
+        "HostedZoneId",
+        "HostedZoneName"
+      ]
+    ]
   }
 }

--- a/test/fixtures/templates/bad/resources/properties/allowed_values.yaml
+++ b/test/fixtures/templates/bad/resources/properties/allowed_values.yaml
@@ -15,6 +15,8 @@ Parameters:
       - "io1"
       - "gp2"
       - "ssd" # Invalid AllowedValue
+  ImageId:
+    Type: "AWS::EC2::Image::Id"
 Resources:
   AmazonMQBroker:
     Type: "AWS::AmazonMQ::Broker"
@@ -91,6 +93,7 @@ Resources:
     Type: "AWS::AutoScaling::AutoScalingGroup"
     Properties:
       HealthCheckType: "elb" # Invalid AlllowedValue
+      LaunchConfigurationName: "launch-configuration"
       LifecycleHookSpecificationList:
         - DefaultResult: " ABANDON" # Invalid AlllowedValue
           LifecycleHookName: "hook"
@@ -104,7 +107,7 @@ Resources:
         - DeviceName: /dev/sdm
           Ebs:
             VolumeType: !Ref "AutoScalingLaunchConfigurationVolume" # Invalid AllowedValue
-      ImageId: "ami-1234"
+      ImageId: !Ref "ImageId"
       InstanceType: "t2.4xlarge"
       PlacementTenancy: "Standard" # Invalid AllowedValue
   AutoScalingLifecycleHook:
@@ -180,9 +183,10 @@ Resources:
   Route53RecordSet:
     Type: "AWS::Route53::RecordSet"
     Properties:
+      Failover: "primary" # Invalid AllowedValue
       GeoLocation:
         ContinentCode: "US" # Invalid AllowedValue
-      Failover: "primary" # Invalid AllowedValue
+      HostedZoneName: "www.example.com"
       Name: "www.example.com"
       Type: "AA" # Invalid AllowedValue
       ResourceRecords:

--- a/test/fixtures/templates/good/resources/properties/allowed_values.yaml
+++ b/test/fixtures/templates/good/resources/properties/allowed_values.yaml
@@ -15,6 +15,8 @@ Parameters:
       - "io1"
       - "gp2"
       - "standard"
+  ImageId:
+    Type: "AWS::EC2::Image::Id"
 Resources:
   AmazonMQBroker:
     Type: "AWS::AmazonMQ::Broker"
@@ -91,6 +93,7 @@ Resources:
     Type: "AWS::AutoScaling::AutoScalingGroup"
     Properties:
       HealthCheckType: "ELB" # Valid AlllowedValue
+      LaunchConfigurationName: "launch-configuration"
       LifecycleHookSpecificationList:
         - DefaultResult: "ABANDON" # Valid AlllowedValue
           LifecycleHookName: "hook"
@@ -104,7 +107,7 @@ Resources:
         - DeviceName: /dev/sdm
           Ebs:
             VolumeType: !Ref "AutoScalingLaunchConfigurationVolume" # Valid AllowedValue
-      ImageId: "ami-1234"
+      ImageId: !Ref "ImageId"
       InstanceType: "t2.small"
       PlacementTenancy: "default" # Valid AllowedValue
   AutoScalingLifecycleHook:
@@ -183,6 +186,7 @@ Resources:
       Failover: "PRIMARY" # Valid AllowedValue
       GeoLocation:
         ContinentCode: "EU" # Valid AllowedValue
+      HostedZoneName: "www.example.com"
       Name: "www.example.com"
       Type: "A" # Valid AllowedValue
       ResourceRecords:
@@ -230,7 +234,6 @@ Resources:
       VersioningConfiguration:
         Status: "Enabled" # Valid AllowedValue
       WebsiteConfiguration:
-        IndexDocument: "index.html"
         RedirectAllRequestsTo:
           HostName: "example.com"
           Protocol: "https" # Valid AllowedValue


### PR DESCRIPTION
While working on the allowed values and uploading a "valid" template came across these errors: 
![image](https://user-images.githubusercontent.com/35613489/51048588-aad2d900-15cb-11e9-86a8-04afe7836e78.png)

Add 2 errors to the "OnlyOne" rule, see the documentation for more info: 
* https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordsetgroup.html#cfn-route53-recordsetgroup-hostedzoneid
* https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-group.html#cfn-as-group-launchconfigurationname

Added another to the Exclusive, documentation:
* https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration.html#cfn-s3-websiteconfiguration-redirectallrequeststo

Also made some minor tweaks to the `allowed_values` test stacks to make the deployment a bit easier

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
