### PR TITLE
Add CodeDeploy Allowed values

### DIFF
--- a/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
@@ -3725,7 +3725,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentconfig-minimumhealthyhosts.html#cfn-codedeploy-deploymentconfig-minimumhealthyhosts-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployConfigMinimumHealthyHostsType"
+          }
         },
         "Value": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentconfig-minimumhealthyhosts.html#cfn-codedeploy-deploymentconfig-minimumhealthyhosts-value",
@@ -3786,7 +3789,10 @@
           "PrimitiveItemType": "String",
           "Required": false,
           "Type": "List",
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployAutoRollbackConfigurationEvents"
+          }
         }
       }
     },
@@ -3820,13 +3826,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentgroup-deploymentstyle.html#cfn-codedeploy-deploymentgroup-deploymentstyle-deploymentoption",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployDeploymentStyleOption"
+          }
         },
         "DeploymentType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentgroup-deploymentstyle.html#cfn-codedeploy-deploymentgroup-deploymentstyle-deploymenttype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployDeploymentStyleType"
+          }
         }
       }
     },
@@ -4055,7 +4067,10 @@
           "PrimitiveItemType": "String",
           "Required": false,
           "Type": "List",
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployTriggerConfigEvent"
+          }
         },
         "TriggerName": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentgroup-triggerconfig.html#cfn-codedeploy-deploymentgroup-triggerconfig-triggername",
@@ -14342,7 +14357,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-healthcheck-healthcheckconfig.html#cfn-route53-healthcheck-healthcheckconfig-insufficientdatahealthstatus",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Route53HealthCheckConfigHealthStatus"
+          }
         },
         "Inverted": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-healthcheck-healthcheckconfig.html#cfn-route53-healthcheck-healthcheckconfig-inverted",
@@ -19793,7 +19811,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codedeploy-application.html#cfn-codedeploy-application-computeplatform",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CodeDeployApplicationPlatform"
+          }
         }
       }
     },
@@ -31632,6 +31653,52 @@
         ]
       }
     },
+    "CodeDeployApplicationPlatform": {
+      "AllowedValues": [
+        "ECS",
+        "Lambda",
+        "Server"
+      ]
+    },
+    "CodeDeployAutoRollbackConfigurationEvents": {
+      "AllowedValues": [
+        "DEPLOYMENT_FAILURE",
+        "DEPLOYMENT_STOP_ON_ALARM",
+        "DEPLOYMENT_STOP_ON_REQUEST"
+      ]
+    },
+    "CodeDeployConfigMinimumHealthyHostsType": {
+      "AllowedValues": [
+        "FLEET_PERCENT",
+        "HOST_COUNT"
+      ]
+    },
+    "CodeDeployDeploymentStyleOption": {
+      "AllowedValues": [
+        "WITH_TRAFFIC_CONTROL",
+        "WITHOUT_TRAFFIC_CONTROL"
+      ]
+    },
+    "CodeDeployDeploymentStyleType": {
+      "AllowedValues": [
+        "BLUE_GREEN",
+        "IN_PLACE"
+      ]
+    },
+    "CodeDeployTriggerConfigEvent": {
+      "AllowedValues": [
+        "DeploymentFailure",
+        "DeploymentReady",
+        "DeploymentRollback",
+        "DeploymentStart",
+        "DeploymentStop",
+        "DeploymentSuccess",
+        "InstanceFailure",
+        "InstanceReady",
+        "InstanceStart",
+        "InstanceSuccess"
+      ]
+    },
     "DmsEndpointEngineName": {
       "AllowedValues": [
         "aurora-postgresql",
@@ -31949,6 +32016,13 @@
           "AWS::ApiGateway::RestApi"
         ]
       }
+    },
+    "Route53HealthCheckConfigHealthStatus": {
+      "AllowedValues": [
+        "Healthy",
+        "LastKnownStatus",
+        "Unhealthy"
+      ]
     },
     "Route53HealthCheckConfigType": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
@@ -3475,7 +3475,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentconfig-minimumhealthyhosts.html#cfn-codedeploy-deploymentconfig-minimumhealthyhosts-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployConfigMinimumHealthyHostsType"
+          }
         },
         "Value": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentconfig-minimumhealthyhosts.html#cfn-codedeploy-deploymentconfig-minimumhealthyhosts-value",
@@ -3536,7 +3539,10 @@
           "PrimitiveItemType": "String",
           "Required": false,
           "Type": "List",
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployAutoRollbackConfigurationEvents"
+          }
         }
       }
     },
@@ -3570,13 +3576,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentgroup-deploymentstyle.html#cfn-codedeploy-deploymentgroup-deploymentstyle-deploymentoption",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployDeploymentStyleOption"
+          }
         },
         "DeploymentType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentgroup-deploymentstyle.html#cfn-codedeploy-deploymentgroup-deploymentstyle-deploymenttype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployDeploymentStyleType"
+          }
         }
       }
     },
@@ -3805,7 +3817,10 @@
           "PrimitiveItemType": "String",
           "Required": false,
           "Type": "List",
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployTriggerConfigEvent"
+          }
         },
         "TriggerName": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentgroup-triggerconfig.html#cfn-codedeploy-deploymentgroup-triggerconfig-triggername",
@@ -13408,7 +13423,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-healthcheck-healthcheckconfig.html#cfn-route53-healthcheck-healthcheckconfig-insufficientdatahealthstatus",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Route53HealthCheckConfigHealthStatus"
+          }
         },
         "Inverted": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-healthcheck-healthcheckconfig.html#cfn-route53-healthcheck-healthcheckconfig-inverted",
@@ -18129,7 +18147,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codedeploy-application.html#cfn-codedeploy-application-computeplatform",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CodeDeployApplicationPlatform"
+          }
         }
       }
     },
@@ -29151,6 +29172,52 @@
         ]
       }
     },
+    "CodeDeployApplicationPlatform": {
+      "AllowedValues": [
+        "ECS",
+        "Lambda",
+        "Server"
+      ]
+    },
+    "CodeDeployAutoRollbackConfigurationEvents": {
+      "AllowedValues": [
+        "DEPLOYMENT_FAILURE",
+        "DEPLOYMENT_STOP_ON_ALARM",
+        "DEPLOYMENT_STOP_ON_REQUEST"
+      ]
+    },
+    "CodeDeployConfigMinimumHealthyHostsType": {
+      "AllowedValues": [
+        "FLEET_PERCENT",
+        "HOST_COUNT"
+      ]
+    },
+    "CodeDeployDeploymentStyleOption": {
+      "AllowedValues": [
+        "WITH_TRAFFIC_CONTROL",
+        "WITHOUT_TRAFFIC_CONTROL"
+      ]
+    },
+    "CodeDeployDeploymentStyleType": {
+      "AllowedValues": [
+        "BLUE_GREEN",
+        "IN_PLACE"
+      ]
+    },
+    "CodeDeployTriggerConfigEvent": {
+      "AllowedValues": [
+        "DeploymentFailure",
+        "DeploymentReady",
+        "DeploymentRollback",
+        "DeploymentStart",
+        "DeploymentStop",
+        "DeploymentSuccess",
+        "InstanceFailure",
+        "InstanceReady",
+        "InstanceStart",
+        "InstanceSuccess"
+      ]
+    },
     "DmsEndpointEngineName": {
       "AllowedValues": [
         "aurora-postgresql",
@@ -29468,6 +29535,13 @@
           "AWS::ApiGateway::RestApi"
         ]
       }
+    },
+    "Route53HealthCheckConfigHealthStatus": {
+      "AllowedValues": [
+        "Healthy",
+        "LastKnownStatus",
+        "Unhealthy"
+      ]
     },
     "Route53HealthCheckConfigType": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
@@ -1582,7 +1582,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentconfig-minimumhealthyhosts.html#cfn-codedeploy-deploymentconfig-minimumhealthyhosts-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployConfigMinimumHealthyHostsType"
+          }
         },
         "Value": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentconfig-minimumhealthyhosts.html#cfn-codedeploy-deploymentconfig-minimumhealthyhosts-value",
@@ -1643,7 +1646,10 @@
           "PrimitiveItemType": "String",
           "Required": false,
           "Type": "List",
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployAutoRollbackConfigurationEvents"
+          }
         }
       }
     },
@@ -1677,13 +1683,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentgroup-deploymentstyle.html#cfn-codedeploy-deploymentgroup-deploymentstyle-deploymentoption",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployDeploymentStyleOption"
+          }
         },
         "DeploymentType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentgroup-deploymentstyle.html#cfn-codedeploy-deploymentgroup-deploymentstyle-deploymenttype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployDeploymentStyleType"
+          }
         }
       }
     },
@@ -1912,7 +1924,10 @@
           "PrimitiveItemType": "String",
           "Required": false,
           "Type": "List",
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployTriggerConfigEvent"
+          }
         },
         "TriggerName": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentgroup-triggerconfig.html#cfn-codedeploy-deploymentgroup-triggerconfig-triggername",
@@ -9437,7 +9452,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-healthcheck-healthcheckconfig.html#cfn-route53-healthcheck-healthcheckconfig-insufficientdatahealthstatus",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Route53HealthCheckConfigHealthStatus"
+          }
         },
         "Inverted": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-healthcheck-healthcheckconfig.html#cfn-route53-healthcheck-healthcheckconfig-inverted",
@@ -12851,7 +12869,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codedeploy-application.html#cfn-codedeploy-application-computeplatform",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CodeDeployApplicationPlatform"
+          }
         }
       }
     },
@@ -20946,6 +20967,52 @@
         ]
       }
     },
+    "CodeDeployApplicationPlatform": {
+      "AllowedValues": [
+        "ECS",
+        "Lambda",
+        "Server"
+      ]
+    },
+    "CodeDeployAutoRollbackConfigurationEvents": {
+      "AllowedValues": [
+        "DEPLOYMENT_FAILURE",
+        "DEPLOYMENT_STOP_ON_ALARM",
+        "DEPLOYMENT_STOP_ON_REQUEST"
+      ]
+    },
+    "CodeDeployConfigMinimumHealthyHostsType": {
+      "AllowedValues": [
+        "FLEET_PERCENT",
+        "HOST_COUNT"
+      ]
+    },
+    "CodeDeployDeploymentStyleOption": {
+      "AllowedValues": [
+        "WITH_TRAFFIC_CONTROL",
+        "WITHOUT_TRAFFIC_CONTROL"
+      ]
+    },
+    "CodeDeployDeploymentStyleType": {
+      "AllowedValues": [
+        "BLUE_GREEN",
+        "IN_PLACE"
+      ]
+    },
+    "CodeDeployTriggerConfigEvent": {
+      "AllowedValues": [
+        "DeploymentFailure",
+        "DeploymentReady",
+        "DeploymentRollback",
+        "DeploymentStart",
+        "DeploymentStop",
+        "DeploymentSuccess",
+        "InstanceFailure",
+        "InstanceReady",
+        "InstanceStart",
+        "InstanceSuccess"
+      ]
+    },
     "DmsEndpointEngineName": {
       "AllowedValues": [
         "aurora-postgresql",
@@ -21263,6 +21330,13 @@
           "AWS::ApiGateway::RestApi"
         ]
       }
+    },
+    "Route53HealthCheckConfigHealthStatus": {
+      "AllowedValues": [
+        "Healthy",
+        "LastKnownStatus",
+        "Unhealthy"
+      ]
     },
     "Route53HealthCheckConfigType": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ap-south-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-south-1.json
@@ -3337,7 +3337,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentconfig-minimumhealthyhosts.html#cfn-codedeploy-deploymentconfig-minimumhealthyhosts-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployConfigMinimumHealthyHostsType"
+          }
         },
         "Value": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentconfig-minimumhealthyhosts.html#cfn-codedeploy-deploymentconfig-minimumhealthyhosts-value",
@@ -3398,7 +3401,10 @@
           "PrimitiveItemType": "String",
           "Required": false,
           "Type": "List",
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployAutoRollbackConfigurationEvents"
+          }
         }
       }
     },
@@ -3432,13 +3438,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentgroup-deploymentstyle.html#cfn-codedeploy-deploymentgroup-deploymentstyle-deploymentoption",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployDeploymentStyleOption"
+          }
         },
         "DeploymentType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentgroup-deploymentstyle.html#cfn-codedeploy-deploymentgroup-deploymentstyle-deploymenttype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployDeploymentStyleType"
+          }
         }
       }
     },
@@ -3667,7 +3679,10 @@
           "PrimitiveItemType": "String",
           "Required": false,
           "Type": "List",
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployTriggerConfigEvent"
+          }
         },
         "TriggerName": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentgroup-triggerconfig.html#cfn-codedeploy-deploymentgroup-triggerconfig-triggername",
@@ -12848,7 +12863,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-healthcheck-healthcheckconfig.html#cfn-route53-healthcheck-healthcheckconfig-insufficientdatahealthstatus",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Route53HealthCheckConfigHealthStatus"
+          }
         },
         "Inverted": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-healthcheck-healthcheckconfig.html#cfn-route53-healthcheck-healthcheckconfig-inverted",
@@ -17353,7 +17371,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codedeploy-application.html#cfn-codedeploy-application-computeplatform",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CodeDeployApplicationPlatform"
+          }
         }
       }
     },
@@ -27991,6 +28012,52 @@
         ]
       }
     },
+    "CodeDeployApplicationPlatform": {
+      "AllowedValues": [
+        "ECS",
+        "Lambda",
+        "Server"
+      ]
+    },
+    "CodeDeployAutoRollbackConfigurationEvents": {
+      "AllowedValues": [
+        "DEPLOYMENT_FAILURE",
+        "DEPLOYMENT_STOP_ON_ALARM",
+        "DEPLOYMENT_STOP_ON_REQUEST"
+      ]
+    },
+    "CodeDeployConfigMinimumHealthyHostsType": {
+      "AllowedValues": [
+        "FLEET_PERCENT",
+        "HOST_COUNT"
+      ]
+    },
+    "CodeDeployDeploymentStyleOption": {
+      "AllowedValues": [
+        "WITH_TRAFFIC_CONTROL",
+        "WITHOUT_TRAFFIC_CONTROL"
+      ]
+    },
+    "CodeDeployDeploymentStyleType": {
+      "AllowedValues": [
+        "BLUE_GREEN",
+        "IN_PLACE"
+      ]
+    },
+    "CodeDeployTriggerConfigEvent": {
+      "AllowedValues": [
+        "DeploymentFailure",
+        "DeploymentReady",
+        "DeploymentRollback",
+        "DeploymentStart",
+        "DeploymentStop",
+        "DeploymentSuccess",
+        "InstanceFailure",
+        "InstanceReady",
+        "InstanceStart",
+        "InstanceSuccess"
+      ]
+    },
     "DmsEndpointEngineName": {
       "AllowedValues": [
         "aurora-postgresql",
@@ -28308,6 +28375,13 @@
           "AWS::ApiGateway::RestApi"
         ]
       }
+    },
+    "Route53HealthCheckConfigHealthStatus": {
+      "AllowedValues": [
+        "Healthy",
+        "LastKnownStatus",
+        "Unhealthy"
+      ]
     },
     "Route53HealthCheckConfigType": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
@@ -3650,7 +3650,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentconfig-minimumhealthyhosts.html#cfn-codedeploy-deploymentconfig-minimumhealthyhosts-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployConfigMinimumHealthyHostsType"
+          }
         },
         "Value": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentconfig-minimumhealthyhosts.html#cfn-codedeploy-deploymentconfig-minimumhealthyhosts-value",
@@ -3711,7 +3714,10 @@
           "PrimitiveItemType": "String",
           "Required": false,
           "Type": "List",
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployAutoRollbackConfigurationEvents"
+          }
         }
       }
     },
@@ -3745,13 +3751,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentgroup-deploymentstyle.html#cfn-codedeploy-deploymentgroup-deploymentstyle-deploymentoption",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployDeploymentStyleOption"
+          }
         },
         "DeploymentType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentgroup-deploymentstyle.html#cfn-codedeploy-deploymentgroup-deploymentstyle-deploymenttype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployDeploymentStyleType"
+          }
         }
       }
     },
@@ -3980,7 +3992,10 @@
           "PrimitiveItemType": "String",
           "Required": false,
           "Type": "List",
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployTriggerConfigEvent"
+          }
         },
         "TriggerName": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentgroup-triggerconfig.html#cfn-codedeploy-deploymentgroup-triggerconfig-triggername",
@@ -13210,7 +13225,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-healthcheck-healthcheckconfig.html#cfn-route53-healthcheck-healthcheckconfig-insufficientdatahealthstatus",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Route53HealthCheckConfigHealthStatus"
+          }
         },
         "Inverted": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-healthcheck-healthcheckconfig.html#cfn-route53-healthcheck-healthcheckconfig-inverted",
@@ -18376,7 +18394,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codedeploy-application.html#cfn-codedeploy-application-computeplatform",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CodeDeployApplicationPlatform"
+          }
         }
       }
     },
@@ -29149,6 +29170,52 @@
         ]
       }
     },
+    "CodeDeployApplicationPlatform": {
+      "AllowedValues": [
+        "ECS",
+        "Lambda",
+        "Server"
+      ]
+    },
+    "CodeDeployAutoRollbackConfigurationEvents": {
+      "AllowedValues": [
+        "DEPLOYMENT_FAILURE",
+        "DEPLOYMENT_STOP_ON_ALARM",
+        "DEPLOYMENT_STOP_ON_REQUEST"
+      ]
+    },
+    "CodeDeployConfigMinimumHealthyHostsType": {
+      "AllowedValues": [
+        "FLEET_PERCENT",
+        "HOST_COUNT"
+      ]
+    },
+    "CodeDeployDeploymentStyleOption": {
+      "AllowedValues": [
+        "WITH_TRAFFIC_CONTROL",
+        "WITHOUT_TRAFFIC_CONTROL"
+      ]
+    },
+    "CodeDeployDeploymentStyleType": {
+      "AllowedValues": [
+        "BLUE_GREEN",
+        "IN_PLACE"
+      ]
+    },
+    "CodeDeployTriggerConfigEvent": {
+      "AllowedValues": [
+        "DeploymentFailure",
+        "DeploymentReady",
+        "DeploymentRollback",
+        "DeploymentStart",
+        "DeploymentStop",
+        "DeploymentSuccess",
+        "InstanceFailure",
+        "InstanceReady",
+        "InstanceStart",
+        "InstanceSuccess"
+      ]
+    },
     "DmsEndpointEngineName": {
       "AllowedValues": [
         "aurora-postgresql",
@@ -29466,6 +29533,13 @@
           "AWS::ApiGateway::RestApi"
         ]
       }
+    },
+    "Route53HealthCheckConfigHealthStatus": {
+      "AllowedValues": [
+        "Healthy",
+        "LastKnownStatus",
+        "Unhealthy"
+      ]
     },
     "Route53HealthCheckConfigType": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
@@ -3725,7 +3725,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentconfig-minimumhealthyhosts.html#cfn-codedeploy-deploymentconfig-minimumhealthyhosts-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployConfigMinimumHealthyHostsType"
+          }
         },
         "Value": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentconfig-minimumhealthyhosts.html#cfn-codedeploy-deploymentconfig-minimumhealthyhosts-value",
@@ -3786,7 +3789,10 @@
           "PrimitiveItemType": "String",
           "Required": false,
           "Type": "List",
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployAutoRollbackConfigurationEvents"
+          }
         }
       }
     },
@@ -3820,13 +3826,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentgroup-deploymentstyle.html#cfn-codedeploy-deploymentgroup-deploymentstyle-deploymentoption",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployDeploymentStyleOption"
+          }
         },
         "DeploymentType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentgroup-deploymentstyle.html#cfn-codedeploy-deploymentgroup-deploymentstyle-deploymenttype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployDeploymentStyleType"
+          }
         }
       }
     },
@@ -4055,7 +4067,10 @@
           "PrimitiveItemType": "String",
           "Required": false,
           "Type": "List",
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployTriggerConfigEvent"
+          }
         },
         "TriggerName": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentgroup-triggerconfig.html#cfn-codedeploy-deploymentgroup-triggerconfig-triggername",
@@ -13707,7 +13722,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-healthcheck-healthcheckconfig.html#cfn-route53-healthcheck-healthcheckconfig-insufficientdatahealthstatus",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Route53HealthCheckConfigHealthStatus"
+          }
         },
         "Inverted": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-healthcheck-healthcheckconfig.html#cfn-route53-healthcheck-healthcheckconfig-inverted",
@@ -18916,7 +18934,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codedeploy-application.html#cfn-codedeploy-application-computeplatform",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CodeDeployApplicationPlatform"
+          }
         }
       }
     },
@@ -30027,6 +30048,52 @@
         ]
       }
     },
+    "CodeDeployApplicationPlatform": {
+      "AllowedValues": [
+        "ECS",
+        "Lambda",
+        "Server"
+      ]
+    },
+    "CodeDeployAutoRollbackConfigurationEvents": {
+      "AllowedValues": [
+        "DEPLOYMENT_FAILURE",
+        "DEPLOYMENT_STOP_ON_ALARM",
+        "DEPLOYMENT_STOP_ON_REQUEST"
+      ]
+    },
+    "CodeDeployConfigMinimumHealthyHostsType": {
+      "AllowedValues": [
+        "FLEET_PERCENT",
+        "HOST_COUNT"
+      ]
+    },
+    "CodeDeployDeploymentStyleOption": {
+      "AllowedValues": [
+        "WITH_TRAFFIC_CONTROL",
+        "WITHOUT_TRAFFIC_CONTROL"
+      ]
+    },
+    "CodeDeployDeploymentStyleType": {
+      "AllowedValues": [
+        "BLUE_GREEN",
+        "IN_PLACE"
+      ]
+    },
+    "CodeDeployTriggerConfigEvent": {
+      "AllowedValues": [
+        "DeploymentFailure",
+        "DeploymentReady",
+        "DeploymentRollback",
+        "DeploymentStart",
+        "DeploymentStop",
+        "DeploymentSuccess",
+        "InstanceFailure",
+        "InstanceReady",
+        "InstanceStart",
+        "InstanceSuccess"
+      ]
+    },
     "DmsEndpointEngineName": {
       "AllowedValues": [
         "aurora-postgresql",
@@ -30344,6 +30411,13 @@
           "AWS::ApiGateway::RestApi"
         ]
       }
+    },
+    "Route53HealthCheckConfigHealthStatus": {
+      "AllowedValues": [
+        "Healthy",
+        "LastKnownStatus",
+        "Unhealthy"
+      ]
     },
     "Route53HealthCheckConfigType": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ca-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/ca-central-1.json
@@ -3171,7 +3171,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentconfig-minimumhealthyhosts.html#cfn-codedeploy-deploymentconfig-minimumhealthyhosts-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployConfigMinimumHealthyHostsType"
+          }
         },
         "Value": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentconfig-minimumhealthyhosts.html#cfn-codedeploy-deploymentconfig-minimumhealthyhosts-value",
@@ -3232,7 +3235,10 @@
           "PrimitiveItemType": "String",
           "Required": false,
           "Type": "List",
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployAutoRollbackConfigurationEvents"
+          }
         }
       }
     },
@@ -3266,13 +3272,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentgroup-deploymentstyle.html#cfn-codedeploy-deploymentgroup-deploymentstyle-deploymentoption",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployDeploymentStyleOption"
+          }
         },
         "DeploymentType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentgroup-deploymentstyle.html#cfn-codedeploy-deploymentgroup-deploymentstyle-deploymenttype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployDeploymentStyleType"
+          }
         }
       }
     },
@@ -3501,7 +3513,10 @@
           "PrimitiveItemType": "String",
           "Required": false,
           "Type": "List",
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployTriggerConfigEvent"
+          }
         },
         "TriggerName": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentgroup-triggerconfig.html#cfn-codedeploy-deploymentgroup-triggerconfig-triggername",
@@ -11902,7 +11917,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-healthcheck-healthcheckconfig.html#cfn-route53-healthcheck-healthcheckconfig-insufficientdatahealthstatus",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Route53HealthCheckConfigHealthStatus"
+          }
         },
         "Inverted": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-healthcheck-healthcheckconfig.html#cfn-route53-healthcheck-healthcheckconfig-inverted",
@@ -16179,7 +16197,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codedeploy-application.html#cfn-codedeploy-application-computeplatform",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CodeDeployApplicationPlatform"
+          }
         }
       }
     },
@@ -26351,6 +26372,52 @@
         ]
       }
     },
+    "CodeDeployApplicationPlatform": {
+      "AllowedValues": [
+        "ECS",
+        "Lambda",
+        "Server"
+      ]
+    },
+    "CodeDeployAutoRollbackConfigurationEvents": {
+      "AllowedValues": [
+        "DEPLOYMENT_FAILURE",
+        "DEPLOYMENT_STOP_ON_ALARM",
+        "DEPLOYMENT_STOP_ON_REQUEST"
+      ]
+    },
+    "CodeDeployConfigMinimumHealthyHostsType": {
+      "AllowedValues": [
+        "FLEET_PERCENT",
+        "HOST_COUNT"
+      ]
+    },
+    "CodeDeployDeploymentStyleOption": {
+      "AllowedValues": [
+        "WITH_TRAFFIC_CONTROL",
+        "WITHOUT_TRAFFIC_CONTROL"
+      ]
+    },
+    "CodeDeployDeploymentStyleType": {
+      "AllowedValues": [
+        "BLUE_GREEN",
+        "IN_PLACE"
+      ]
+    },
+    "CodeDeployTriggerConfigEvent": {
+      "AllowedValues": [
+        "DeploymentFailure",
+        "DeploymentReady",
+        "DeploymentRollback",
+        "DeploymentStart",
+        "DeploymentStop",
+        "DeploymentSuccess",
+        "InstanceFailure",
+        "InstanceReady",
+        "InstanceStart",
+        "InstanceSuccess"
+      ]
+    },
     "DmsEndpointEngineName": {
       "AllowedValues": [
         "aurora-postgresql",
@@ -26668,6 +26735,13 @@
           "AWS::ApiGateway::RestApi"
         ]
       }
+    },
+    "Route53HealthCheckConfigHealthStatus": {
+      "AllowedValues": [
+        "Healthy",
+        "LastKnownStatus",
+        "Unhealthy"
+      ]
     },
     "Route53HealthCheckConfigType": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/eu-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-central-1.json
@@ -3650,7 +3650,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentconfig-minimumhealthyhosts.html#cfn-codedeploy-deploymentconfig-minimumhealthyhosts-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployConfigMinimumHealthyHostsType"
+          }
         },
         "Value": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentconfig-minimumhealthyhosts.html#cfn-codedeploy-deploymentconfig-minimumhealthyhosts-value",
@@ -3711,7 +3714,10 @@
           "PrimitiveItemType": "String",
           "Required": false,
           "Type": "List",
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployAutoRollbackConfigurationEvents"
+          }
         }
       }
     },
@@ -3745,13 +3751,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentgroup-deploymentstyle.html#cfn-codedeploy-deploymentgroup-deploymentstyle-deploymentoption",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployDeploymentStyleOption"
+          }
         },
         "DeploymentType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentgroup-deploymentstyle.html#cfn-codedeploy-deploymentgroup-deploymentstyle-deploymenttype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployDeploymentStyleType"
+          }
         }
       }
     },
@@ -3980,7 +3992,10 @@
           "PrimitiveItemType": "String",
           "Required": false,
           "Type": "List",
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployTriggerConfigEvent"
+          }
         },
         "TriggerName": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentgroup-triggerconfig.html#cfn-codedeploy-deploymentgroup-triggerconfig-triggername",
@@ -14256,7 +14271,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-healthcheck-healthcheckconfig.html#cfn-route53-healthcheck-healthcheckconfig-insufficientdatahealthstatus",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Route53HealthCheckConfigHealthStatus"
+          }
         },
         "Inverted": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-healthcheck-healthcheckconfig.html#cfn-route53-healthcheck-healthcheckconfig-inverted",
@@ -19338,7 +19356,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codedeploy-application.html#cfn-codedeploy-application-computeplatform",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CodeDeployApplicationPlatform"
+          }
         }
       }
     },
@@ -30832,6 +30853,52 @@
         ]
       }
     },
+    "CodeDeployApplicationPlatform": {
+      "AllowedValues": [
+        "ECS",
+        "Lambda",
+        "Server"
+      ]
+    },
+    "CodeDeployAutoRollbackConfigurationEvents": {
+      "AllowedValues": [
+        "DEPLOYMENT_FAILURE",
+        "DEPLOYMENT_STOP_ON_ALARM",
+        "DEPLOYMENT_STOP_ON_REQUEST"
+      ]
+    },
+    "CodeDeployConfigMinimumHealthyHostsType": {
+      "AllowedValues": [
+        "FLEET_PERCENT",
+        "HOST_COUNT"
+      ]
+    },
+    "CodeDeployDeploymentStyleOption": {
+      "AllowedValues": [
+        "WITH_TRAFFIC_CONTROL",
+        "WITHOUT_TRAFFIC_CONTROL"
+      ]
+    },
+    "CodeDeployDeploymentStyleType": {
+      "AllowedValues": [
+        "BLUE_GREEN",
+        "IN_PLACE"
+      ]
+    },
+    "CodeDeployTriggerConfigEvent": {
+      "AllowedValues": [
+        "DeploymentFailure",
+        "DeploymentReady",
+        "DeploymentRollback",
+        "DeploymentStart",
+        "DeploymentStop",
+        "DeploymentSuccess",
+        "InstanceFailure",
+        "InstanceReady",
+        "InstanceStart",
+        "InstanceSuccess"
+      ]
+    },
     "DmsEndpointEngineName": {
       "AllowedValues": [
         "aurora-postgresql",
@@ -31149,6 +31216,13 @@
           "AWS::ApiGateway::RestApi"
         ]
       }
+    },
+    "Route53HealthCheckConfigHealthStatus": {
+      "AllowedValues": [
+        "Healthy",
+        "LastKnownStatus",
+        "Unhealthy"
+      ]
     },
     "Route53HealthCheckConfigType": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/eu-north-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-north-1.json
@@ -1582,7 +1582,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentconfig-minimumhealthyhosts.html#cfn-codedeploy-deploymentconfig-minimumhealthyhosts-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployConfigMinimumHealthyHostsType"
+          }
         },
         "Value": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentconfig-minimumhealthyhosts.html#cfn-codedeploy-deploymentconfig-minimumhealthyhosts-value",
@@ -1643,7 +1646,10 @@
           "PrimitiveItemType": "String",
           "Required": false,
           "Type": "List",
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployAutoRollbackConfigurationEvents"
+          }
         }
       }
     },
@@ -1677,13 +1683,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentgroup-deploymentstyle.html#cfn-codedeploy-deploymentgroup-deploymentstyle-deploymentoption",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployDeploymentStyleOption"
+          }
         },
         "DeploymentType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentgroup-deploymentstyle.html#cfn-codedeploy-deploymentgroup-deploymentstyle-deploymenttype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployDeploymentStyleType"
+          }
         }
       }
     },
@@ -1912,7 +1924,10 @@
           "PrimitiveItemType": "String",
           "Required": false,
           "Type": "List",
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployTriggerConfigEvent"
+          }
         },
         "TriggerName": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentgroup-triggerconfig.html#cfn-codedeploy-deploymentgroup-triggerconfig-triggername",
@@ -9438,7 +9453,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-healthcheck-healthcheckconfig.html#cfn-route53-healthcheck-healthcheckconfig-insufficientdatahealthstatus",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Route53HealthCheckConfigHealthStatus"
+          }
         },
         "Inverted": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-healthcheck-healthcheckconfig.html#cfn-route53-healthcheck-healthcheckconfig-inverted",
@@ -12869,7 +12887,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codedeploy-application.html#cfn-codedeploy-application-computeplatform",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CodeDeployApplicationPlatform"
+          }
         }
       }
     },
@@ -21362,6 +21383,52 @@
         ]
       }
     },
+    "CodeDeployApplicationPlatform": {
+      "AllowedValues": [
+        "ECS",
+        "Lambda",
+        "Server"
+      ]
+    },
+    "CodeDeployAutoRollbackConfigurationEvents": {
+      "AllowedValues": [
+        "DEPLOYMENT_FAILURE",
+        "DEPLOYMENT_STOP_ON_ALARM",
+        "DEPLOYMENT_STOP_ON_REQUEST"
+      ]
+    },
+    "CodeDeployConfigMinimumHealthyHostsType": {
+      "AllowedValues": [
+        "FLEET_PERCENT",
+        "HOST_COUNT"
+      ]
+    },
+    "CodeDeployDeploymentStyleOption": {
+      "AllowedValues": [
+        "WITH_TRAFFIC_CONTROL",
+        "WITHOUT_TRAFFIC_CONTROL"
+      ]
+    },
+    "CodeDeployDeploymentStyleType": {
+      "AllowedValues": [
+        "BLUE_GREEN",
+        "IN_PLACE"
+      ]
+    },
+    "CodeDeployTriggerConfigEvent": {
+      "AllowedValues": [
+        "DeploymentFailure",
+        "DeploymentReady",
+        "DeploymentRollback",
+        "DeploymentStart",
+        "DeploymentStop",
+        "DeploymentSuccess",
+        "InstanceFailure",
+        "InstanceReady",
+        "InstanceStart",
+        "InstanceSuccess"
+      ]
+    },
     "DmsEndpointEngineName": {
       "AllowedValues": [
         "aurora-postgresql",
@@ -21679,6 +21746,13 @@
           "AWS::ApiGateway::RestApi"
         ]
       }
+    },
+    "Route53HealthCheckConfigHealthStatus": {
+      "AllowedValues": [
+        "Healthy",
+        "LastKnownStatus",
+        "Unhealthy"
+      ]
     },
     "Route53HealthCheckConfigType": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/eu-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-1.json
@@ -4086,7 +4086,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentconfig-minimumhealthyhosts.html#cfn-codedeploy-deploymentconfig-minimumhealthyhosts-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployConfigMinimumHealthyHostsType"
+          }
         },
         "Value": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentconfig-minimumhealthyhosts.html#cfn-codedeploy-deploymentconfig-minimumhealthyhosts-value",
@@ -4147,7 +4150,10 @@
           "PrimitiveItemType": "String",
           "Required": false,
           "Type": "List",
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployAutoRollbackConfigurationEvents"
+          }
         }
       }
     },
@@ -4181,13 +4187,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentgroup-deploymentstyle.html#cfn-codedeploy-deploymentgroup-deploymentstyle-deploymentoption",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployDeploymentStyleOption"
+          }
         },
         "DeploymentType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentgroup-deploymentstyle.html#cfn-codedeploy-deploymentgroup-deploymentstyle-deploymenttype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployDeploymentStyleType"
+          }
         }
       }
     },
@@ -4416,7 +4428,10 @@
           "PrimitiveItemType": "String",
           "Required": false,
           "Type": "List",
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployTriggerConfigEvent"
+          }
         },
         "TriggerName": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentgroup-triggerconfig.html#cfn-codedeploy-deploymentgroup-triggerconfig-triggername",
@@ -15178,7 +15193,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-healthcheck-healthcheckconfig.html#cfn-route53-healthcheck-healthcheckconfig-insufficientdatahealthstatus",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Route53HealthCheckConfigHealthStatus"
+          }
         },
         "Inverted": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-healthcheck-healthcheckconfig.html#cfn-route53-healthcheck-healthcheckconfig-inverted",
@@ -21327,7 +21345,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codedeploy-application.html#cfn-codedeploy-application-computeplatform",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CodeDeployApplicationPlatform"
+          }
         }
       }
     },
@@ -33934,6 +33955,52 @@
         ]
       }
     },
+    "CodeDeployApplicationPlatform": {
+      "AllowedValues": [
+        "ECS",
+        "Lambda",
+        "Server"
+      ]
+    },
+    "CodeDeployAutoRollbackConfigurationEvents": {
+      "AllowedValues": [
+        "DEPLOYMENT_FAILURE",
+        "DEPLOYMENT_STOP_ON_ALARM",
+        "DEPLOYMENT_STOP_ON_REQUEST"
+      ]
+    },
+    "CodeDeployConfigMinimumHealthyHostsType": {
+      "AllowedValues": [
+        "FLEET_PERCENT",
+        "HOST_COUNT"
+      ]
+    },
+    "CodeDeployDeploymentStyleOption": {
+      "AllowedValues": [
+        "WITH_TRAFFIC_CONTROL",
+        "WITHOUT_TRAFFIC_CONTROL"
+      ]
+    },
+    "CodeDeployDeploymentStyleType": {
+      "AllowedValues": [
+        "BLUE_GREEN",
+        "IN_PLACE"
+      ]
+    },
+    "CodeDeployTriggerConfigEvent": {
+      "AllowedValues": [
+        "DeploymentFailure",
+        "DeploymentReady",
+        "DeploymentRollback",
+        "DeploymentStart",
+        "DeploymentStop",
+        "DeploymentSuccess",
+        "InstanceFailure",
+        "InstanceReady",
+        "InstanceStart",
+        "InstanceSuccess"
+      ]
+    },
     "DmsEndpointEngineName": {
       "AllowedValues": [
         "aurora-postgresql",
@@ -34251,6 +34318,13 @@
           "AWS::ApiGateway::RestApi"
         ]
       }
+    },
+    "Route53HealthCheckConfigHealthStatus": {
+      "AllowedValues": [
+        "Healthy",
+        "LastKnownStatus",
+        "Unhealthy"
+      ]
     },
     "Route53HealthCheckConfigType": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/eu-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-2.json
@@ -3188,7 +3188,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentconfig-minimumhealthyhosts.html#cfn-codedeploy-deploymentconfig-minimumhealthyhosts-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployConfigMinimumHealthyHostsType"
+          }
         },
         "Value": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentconfig-minimumhealthyhosts.html#cfn-codedeploy-deploymentconfig-minimumhealthyhosts-value",
@@ -3249,7 +3252,10 @@
           "PrimitiveItemType": "String",
           "Required": false,
           "Type": "List",
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployAutoRollbackConfigurationEvents"
+          }
         }
       }
     },
@@ -3283,13 +3289,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentgroup-deploymentstyle.html#cfn-codedeploy-deploymentgroup-deploymentstyle-deploymentoption",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployDeploymentStyleOption"
+          }
         },
         "DeploymentType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentgroup-deploymentstyle.html#cfn-codedeploy-deploymentgroup-deploymentstyle-deploymenttype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployDeploymentStyleType"
+          }
         }
       }
     },
@@ -3518,7 +3530,10 @@
           "PrimitiveItemType": "String",
           "Required": false,
           "Type": "List",
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployTriggerConfigEvent"
+          }
         },
         "TriggerName": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentgroup-triggerconfig.html#cfn-codedeploy-deploymentgroup-triggerconfig-triggername",
@@ -12375,7 +12390,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-healthcheck-healthcheckconfig.html#cfn-route53-healthcheck-healthcheckconfig-insufficientdatahealthstatus",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Route53HealthCheckConfigHealthStatus"
+          }
         },
         "Inverted": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-healthcheck-healthcheckconfig.html#cfn-route53-healthcheck-healthcheckconfig-inverted",
@@ -16711,7 +16729,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codedeploy-application.html#cfn-codedeploy-application-computeplatform",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CodeDeployApplicationPlatform"
+          }
         }
       }
     },
@@ -27652,6 +27673,52 @@
         ]
       }
     },
+    "CodeDeployApplicationPlatform": {
+      "AllowedValues": [
+        "ECS",
+        "Lambda",
+        "Server"
+      ]
+    },
+    "CodeDeployAutoRollbackConfigurationEvents": {
+      "AllowedValues": [
+        "DEPLOYMENT_FAILURE",
+        "DEPLOYMENT_STOP_ON_ALARM",
+        "DEPLOYMENT_STOP_ON_REQUEST"
+      ]
+    },
+    "CodeDeployConfigMinimumHealthyHostsType": {
+      "AllowedValues": [
+        "FLEET_PERCENT",
+        "HOST_COUNT"
+      ]
+    },
+    "CodeDeployDeploymentStyleOption": {
+      "AllowedValues": [
+        "WITH_TRAFFIC_CONTROL",
+        "WITHOUT_TRAFFIC_CONTROL"
+      ]
+    },
+    "CodeDeployDeploymentStyleType": {
+      "AllowedValues": [
+        "BLUE_GREEN",
+        "IN_PLACE"
+      ]
+    },
+    "CodeDeployTriggerConfigEvent": {
+      "AllowedValues": [
+        "DeploymentFailure",
+        "DeploymentReady",
+        "DeploymentRollback",
+        "DeploymentStart",
+        "DeploymentStop",
+        "DeploymentSuccess",
+        "InstanceFailure",
+        "InstanceReady",
+        "InstanceStart",
+        "InstanceSuccess"
+      ]
+    },
     "DmsEndpointEngineName": {
       "AllowedValues": [
         "aurora-postgresql",
@@ -27969,6 +28036,13 @@
           "AWS::ApiGateway::RestApi"
         ]
       }
+    },
+    "Route53HealthCheckConfigHealthStatus": {
+      "AllowedValues": [
+        "Healthy",
+        "LastKnownStatus",
+        "Unhealthy"
+      ]
     },
     "Route53HealthCheckConfigType": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/eu-west-3.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-3.json
@@ -2658,7 +2658,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentconfig-minimumhealthyhosts.html#cfn-codedeploy-deploymentconfig-minimumhealthyhosts-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployConfigMinimumHealthyHostsType"
+          }
         },
         "Value": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentconfig-minimumhealthyhosts.html#cfn-codedeploy-deploymentconfig-minimumhealthyhosts-value",
@@ -2719,7 +2722,10 @@
           "PrimitiveItemType": "String",
           "Required": false,
           "Type": "List",
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployAutoRollbackConfigurationEvents"
+          }
         }
       }
     },
@@ -2753,13 +2759,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentgroup-deploymentstyle.html#cfn-codedeploy-deploymentgroup-deploymentstyle-deploymentoption",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployDeploymentStyleOption"
+          }
         },
         "DeploymentType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentgroup-deploymentstyle.html#cfn-codedeploy-deploymentgroup-deploymentstyle-deploymenttype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployDeploymentStyleType"
+          }
         }
       }
     },
@@ -2988,7 +3000,10 @@
           "PrimitiveItemType": "String",
           "Required": false,
           "Type": "List",
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployTriggerConfigEvent"
+          }
         },
         "TriggerName": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentgroup-triggerconfig.html#cfn-codedeploy-deploymentgroup-triggerconfig-triggername",
@@ -11057,7 +11072,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-healthcheck-healthcheckconfig.html#cfn-route53-healthcheck-healthcheckconfig-insufficientdatahealthstatus",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Route53HealthCheckConfigHealthStatus"
+          }
         },
         "Inverted": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-healthcheck-healthcheckconfig.html#cfn-route53-healthcheck-healthcheckconfig-inverted",
@@ -15136,7 +15154,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codedeploy-application.html#cfn-codedeploy-application-computeplatform",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CodeDeployApplicationPlatform"
+          }
         }
       }
     },
@@ -24552,6 +24573,52 @@
         ]
       }
     },
+    "CodeDeployApplicationPlatform": {
+      "AllowedValues": [
+        "ECS",
+        "Lambda",
+        "Server"
+      ]
+    },
+    "CodeDeployAutoRollbackConfigurationEvents": {
+      "AllowedValues": [
+        "DEPLOYMENT_FAILURE",
+        "DEPLOYMENT_STOP_ON_ALARM",
+        "DEPLOYMENT_STOP_ON_REQUEST"
+      ]
+    },
+    "CodeDeployConfigMinimumHealthyHostsType": {
+      "AllowedValues": [
+        "FLEET_PERCENT",
+        "HOST_COUNT"
+      ]
+    },
+    "CodeDeployDeploymentStyleOption": {
+      "AllowedValues": [
+        "WITH_TRAFFIC_CONTROL",
+        "WITHOUT_TRAFFIC_CONTROL"
+      ]
+    },
+    "CodeDeployDeploymentStyleType": {
+      "AllowedValues": [
+        "BLUE_GREEN",
+        "IN_PLACE"
+      ]
+    },
+    "CodeDeployTriggerConfigEvent": {
+      "AllowedValues": [
+        "DeploymentFailure",
+        "DeploymentReady",
+        "DeploymentRollback",
+        "DeploymentStart",
+        "DeploymentStop",
+        "DeploymentSuccess",
+        "InstanceFailure",
+        "InstanceReady",
+        "InstanceStart",
+        "InstanceSuccess"
+      ]
+    },
     "DmsEndpointEngineName": {
       "AllowedValues": [
         "aurora-postgresql",
@@ -24869,6 +24936,13 @@
           "AWS::ApiGateway::RestApi"
         ]
       }
+    },
+    "Route53HealthCheckConfigHealthStatus": {
+      "AllowedValues": [
+        "Healthy",
+        "LastKnownStatus",
+        "Unhealthy"
+      ]
     },
     "Route53HealthCheckConfigType": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/sa-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/sa-east-1.json
@@ -2857,7 +2857,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentconfig-minimumhealthyhosts.html#cfn-codedeploy-deploymentconfig-minimumhealthyhosts-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployConfigMinimumHealthyHostsType"
+          }
         },
         "Value": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentconfig-minimumhealthyhosts.html#cfn-codedeploy-deploymentconfig-minimumhealthyhosts-value",
@@ -2918,7 +2921,10 @@
           "PrimitiveItemType": "String",
           "Required": false,
           "Type": "List",
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployAutoRollbackConfigurationEvents"
+          }
         }
       }
     },
@@ -2952,13 +2958,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentgroup-deploymentstyle.html#cfn-codedeploy-deploymentgroup-deploymentstyle-deploymentoption",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployDeploymentStyleOption"
+          }
         },
         "DeploymentType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentgroup-deploymentstyle.html#cfn-codedeploy-deploymentgroup-deploymentstyle-deploymenttype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployDeploymentStyleType"
+          }
         }
       }
     },
@@ -3187,7 +3199,10 @@
           "PrimitiveItemType": "String",
           "Required": false,
           "Type": "List",
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployTriggerConfigEvent"
+          }
         },
         "TriggerName": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentgroup-triggerconfig.html#cfn-codedeploy-deploymentgroup-triggerconfig-triggername",
@@ -11588,7 +11603,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-healthcheck-healthcheckconfig.html#cfn-route53-healthcheck-healthcheckconfig-insufficientdatahealthstatus",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Route53HealthCheckConfigHealthStatus"
+          }
         },
         "Inverted": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-healthcheck-healthcheckconfig.html#cfn-route53-healthcheck-healthcheckconfig-inverted",
@@ -15716,7 +15734,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codedeploy-application.html#cfn-codedeploy-application-computeplatform",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CodeDeployApplicationPlatform"
+          }
         }
       }
     },
@@ -25525,6 +25546,52 @@
         ]
       }
     },
+    "CodeDeployApplicationPlatform": {
+      "AllowedValues": [
+        "ECS",
+        "Lambda",
+        "Server"
+      ]
+    },
+    "CodeDeployAutoRollbackConfigurationEvents": {
+      "AllowedValues": [
+        "DEPLOYMENT_FAILURE",
+        "DEPLOYMENT_STOP_ON_ALARM",
+        "DEPLOYMENT_STOP_ON_REQUEST"
+      ]
+    },
+    "CodeDeployConfigMinimumHealthyHostsType": {
+      "AllowedValues": [
+        "FLEET_PERCENT",
+        "HOST_COUNT"
+      ]
+    },
+    "CodeDeployDeploymentStyleOption": {
+      "AllowedValues": [
+        "WITH_TRAFFIC_CONTROL",
+        "WITHOUT_TRAFFIC_CONTROL"
+      ]
+    },
+    "CodeDeployDeploymentStyleType": {
+      "AllowedValues": [
+        "BLUE_GREEN",
+        "IN_PLACE"
+      ]
+    },
+    "CodeDeployTriggerConfigEvent": {
+      "AllowedValues": [
+        "DeploymentFailure",
+        "DeploymentReady",
+        "DeploymentRollback",
+        "DeploymentStart",
+        "DeploymentStop",
+        "DeploymentSuccess",
+        "InstanceFailure",
+        "InstanceReady",
+        "InstanceStart",
+        "InstanceSuccess"
+      ]
+    },
     "DmsEndpointEngineName": {
       "AllowedValues": [
         "aurora-postgresql",
@@ -25842,6 +25909,13 @@
           "AWS::ApiGateway::RestApi"
         ]
       }
+    },
+    "Route53HealthCheckConfigHealthStatus": {
+      "AllowedValues": [
+        "Healthy",
+        "LastKnownStatus",
+        "Unhealthy"
+      ]
     },
     "Route53HealthCheckConfigType": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/us-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-1.json
@@ -4086,7 +4086,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentconfig-minimumhealthyhosts.html#cfn-codedeploy-deploymentconfig-minimumhealthyhosts-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployConfigMinimumHealthyHostsType"
+          }
         },
         "Value": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentconfig-minimumhealthyhosts.html#cfn-codedeploy-deploymentconfig-minimumhealthyhosts-value",
@@ -4147,7 +4150,10 @@
           "PrimitiveItemType": "String",
           "Required": false,
           "Type": "List",
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployAutoRollbackConfigurationEvents"
+          }
         }
       }
     },
@@ -4181,13 +4187,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentgroup-deploymentstyle.html#cfn-codedeploy-deploymentgroup-deploymentstyle-deploymentoption",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployDeploymentStyleOption"
+          }
         },
         "DeploymentType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentgroup-deploymentstyle.html#cfn-codedeploy-deploymentgroup-deploymentstyle-deploymenttype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployDeploymentStyleType"
+          }
         }
       }
     },
@@ -4416,7 +4428,10 @@
           "PrimitiveItemType": "String",
           "Required": false,
           "Type": "List",
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployTriggerConfigEvent"
+          }
         },
         "TriggerName": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentgroup-triggerconfig.html#cfn-codedeploy-deploymentgroup-triggerconfig-triggername",
@@ -15197,7 +15212,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-healthcheck-healthcheckconfig.html#cfn-route53-healthcheck-healthcheckconfig-insufficientdatahealthstatus",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Route53HealthCheckConfigHealthStatus"
+          }
         },
         "Inverted": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-healthcheck-healthcheckconfig.html#cfn-route53-healthcheck-healthcheckconfig-inverted",
@@ -21328,7 +21346,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codedeploy-application.html#cfn-codedeploy-application-computeplatform",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CodeDeployApplicationPlatform"
+          }
         }
       }
     },
@@ -33963,6 +33984,52 @@
         ]
       }
     },
+    "CodeDeployApplicationPlatform": {
+      "AllowedValues": [
+        "ECS",
+        "Lambda",
+        "Server"
+      ]
+    },
+    "CodeDeployAutoRollbackConfigurationEvents": {
+      "AllowedValues": [
+        "DEPLOYMENT_FAILURE",
+        "DEPLOYMENT_STOP_ON_ALARM",
+        "DEPLOYMENT_STOP_ON_REQUEST"
+      ]
+    },
+    "CodeDeployConfigMinimumHealthyHostsType": {
+      "AllowedValues": [
+        "FLEET_PERCENT",
+        "HOST_COUNT"
+      ]
+    },
+    "CodeDeployDeploymentStyleOption": {
+      "AllowedValues": [
+        "WITH_TRAFFIC_CONTROL",
+        "WITHOUT_TRAFFIC_CONTROL"
+      ]
+    },
+    "CodeDeployDeploymentStyleType": {
+      "AllowedValues": [
+        "BLUE_GREEN",
+        "IN_PLACE"
+      ]
+    },
+    "CodeDeployTriggerConfigEvent": {
+      "AllowedValues": [
+        "DeploymentFailure",
+        "DeploymentReady",
+        "DeploymentRollback",
+        "DeploymentStart",
+        "DeploymentStop",
+        "DeploymentSuccess",
+        "InstanceFailure",
+        "InstanceReady",
+        "InstanceStart",
+        "InstanceSuccess"
+      ]
+    },
     "DmsEndpointEngineName": {
       "AllowedValues": [
         "aurora-postgresql",
@@ -34280,6 +34347,13 @@
           "AWS::ApiGateway::RestApi"
         ]
       }
+    },
+    "Route53HealthCheckConfigHealthStatus": {
+      "AllowedValues": [
+        "Healthy",
+        "LastKnownStatus",
+        "Unhealthy"
+      ]
     },
     "Route53HealthCheckConfigType": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/us-east-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-2.json
@@ -3621,7 +3621,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentconfig-minimumhealthyhosts.html#cfn-codedeploy-deploymentconfig-minimumhealthyhosts-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployConfigMinimumHealthyHostsType"
+          }
         },
         "Value": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentconfig-minimumhealthyhosts.html#cfn-codedeploy-deploymentconfig-minimumhealthyhosts-value",
@@ -3682,7 +3685,10 @@
           "PrimitiveItemType": "String",
           "Required": false,
           "Type": "List",
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployAutoRollbackConfigurationEvents"
+          }
         }
       }
     },
@@ -3716,13 +3722,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentgroup-deploymentstyle.html#cfn-codedeploy-deploymentgroup-deploymentstyle-deploymentoption",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployDeploymentStyleOption"
+          }
         },
         "DeploymentType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentgroup-deploymentstyle.html#cfn-codedeploy-deploymentgroup-deploymentstyle-deploymenttype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployDeploymentStyleType"
+          }
         }
       }
     },
@@ -3951,7 +3963,10 @@
           "PrimitiveItemType": "String",
           "Required": false,
           "Type": "List",
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployTriggerConfigEvent"
+          }
         },
         "TriggerName": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentgroup-triggerconfig.html#cfn-codedeploy-deploymentgroup-triggerconfig-triggername",
@@ -14702,7 +14717,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-healthcheck-healthcheckconfig.html#cfn-route53-healthcheck-healthcheckconfig-insufficientdatahealthstatus",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Route53HealthCheckConfigHealthStatus"
+          }
         },
         "Inverted": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-healthcheck-healthcheckconfig.html#cfn-route53-healthcheck-healthcheckconfig-inverted",
@@ -19765,7 +19783,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codedeploy-application.html#cfn-codedeploy-application-computeplatform",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CodeDeployApplicationPlatform"
+          }
         }
       }
     },
@@ -31976,6 +31997,52 @@
         ]
       }
     },
+    "CodeDeployApplicationPlatform": {
+      "AllowedValues": [
+        "ECS",
+        "Lambda",
+        "Server"
+      ]
+    },
+    "CodeDeployAutoRollbackConfigurationEvents": {
+      "AllowedValues": [
+        "DEPLOYMENT_FAILURE",
+        "DEPLOYMENT_STOP_ON_ALARM",
+        "DEPLOYMENT_STOP_ON_REQUEST"
+      ]
+    },
+    "CodeDeployConfigMinimumHealthyHostsType": {
+      "AllowedValues": [
+        "FLEET_PERCENT",
+        "HOST_COUNT"
+      ]
+    },
+    "CodeDeployDeploymentStyleOption": {
+      "AllowedValues": [
+        "WITH_TRAFFIC_CONTROL",
+        "WITHOUT_TRAFFIC_CONTROL"
+      ]
+    },
+    "CodeDeployDeploymentStyleType": {
+      "AllowedValues": [
+        "BLUE_GREEN",
+        "IN_PLACE"
+      ]
+    },
+    "CodeDeployTriggerConfigEvent": {
+      "AllowedValues": [
+        "DeploymentFailure",
+        "DeploymentReady",
+        "DeploymentRollback",
+        "DeploymentStart",
+        "DeploymentStop",
+        "DeploymentSuccess",
+        "InstanceFailure",
+        "InstanceReady",
+        "InstanceStart",
+        "InstanceSuccess"
+      ]
+    },
     "DmsEndpointEngineName": {
       "AllowedValues": [
         "aurora-postgresql",
@@ -32293,6 +32360,13 @@
           "AWS::ApiGateway::RestApi"
         ]
       }
+    },
+    "Route53HealthCheckConfigHealthStatus": {
+      "AllowedValues": [
+        "Healthy",
+        "LastKnownStatus",
+        "Unhealthy"
+      ]
     },
     "Route53HealthCheckConfigType": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
@@ -1582,7 +1582,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentconfig-minimumhealthyhosts.html#cfn-codedeploy-deploymentconfig-minimumhealthyhosts-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployConfigMinimumHealthyHostsType"
+          }
         },
         "Value": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentconfig-minimumhealthyhosts.html#cfn-codedeploy-deploymentconfig-minimumhealthyhosts-value",
@@ -1643,7 +1646,10 @@
           "PrimitiveItemType": "String",
           "Required": false,
           "Type": "List",
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployAutoRollbackConfigurationEvents"
+          }
         }
       }
     },
@@ -1677,13 +1683,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentgroup-deploymentstyle.html#cfn-codedeploy-deploymentgroup-deploymentstyle-deploymentoption",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployDeploymentStyleOption"
+          }
         },
         "DeploymentType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentgroup-deploymentstyle.html#cfn-codedeploy-deploymentgroup-deploymentstyle-deploymenttype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployDeploymentStyleType"
+          }
         }
       }
     },
@@ -1912,7 +1924,10 @@
           "PrimitiveItemType": "String",
           "Required": false,
           "Type": "List",
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployTriggerConfigEvent"
+          }
         },
         "TriggerName": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentgroup-triggerconfig.html#cfn-codedeploy-deploymentgroup-triggerconfig-triggername",
@@ -9257,7 +9272,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-healthcheck-healthcheckconfig.html#cfn-route53-healthcheck-healthcheckconfig-insufficientdatahealthstatus",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Route53HealthCheckConfigHealthStatus"
+          }
         },
         "Inverted": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-healthcheck-healthcheckconfig.html#cfn-route53-healthcheck-healthcheckconfig-inverted",
@@ -12671,7 +12689,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codedeploy-application.html#cfn-codedeploy-application-computeplatform",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CodeDeployApplicationPlatform"
+          }
         }
       }
     },
@@ -20721,6 +20742,52 @@
         ]
       }
     },
+    "CodeDeployApplicationPlatform": {
+      "AllowedValues": [
+        "ECS",
+        "Lambda",
+        "Server"
+      ]
+    },
+    "CodeDeployAutoRollbackConfigurationEvents": {
+      "AllowedValues": [
+        "DEPLOYMENT_FAILURE",
+        "DEPLOYMENT_STOP_ON_ALARM",
+        "DEPLOYMENT_STOP_ON_REQUEST"
+      ]
+    },
+    "CodeDeployConfigMinimumHealthyHostsType": {
+      "AllowedValues": [
+        "FLEET_PERCENT",
+        "HOST_COUNT"
+      ]
+    },
+    "CodeDeployDeploymentStyleOption": {
+      "AllowedValues": [
+        "WITH_TRAFFIC_CONTROL",
+        "WITHOUT_TRAFFIC_CONTROL"
+      ]
+    },
+    "CodeDeployDeploymentStyleType": {
+      "AllowedValues": [
+        "BLUE_GREEN",
+        "IN_PLACE"
+      ]
+    },
+    "CodeDeployTriggerConfigEvent": {
+      "AllowedValues": [
+        "DeploymentFailure",
+        "DeploymentReady",
+        "DeploymentRollback",
+        "DeploymentStart",
+        "DeploymentStop",
+        "DeploymentSuccess",
+        "InstanceFailure",
+        "InstanceReady",
+        "InstanceStart",
+        "InstanceSuccess"
+      ]
+    },
     "DmsEndpointEngineName": {
       "AllowedValues": [
         "aurora-postgresql",
@@ -21038,6 +21105,13 @@
           "AWS::ApiGateway::RestApi"
         ]
       }
+    },
+    "Route53HealthCheckConfigHealthStatus": {
+      "AllowedValues": [
+        "Healthy",
+        "LastKnownStatus",
+        "Unhealthy"
+      ]
     },
     "Route53HealthCheckConfigType": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
@@ -1582,7 +1582,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentconfig-minimumhealthyhosts.html#cfn-codedeploy-deploymentconfig-minimumhealthyhosts-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployConfigMinimumHealthyHostsType"
+          }
         },
         "Value": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentconfig-minimumhealthyhosts.html#cfn-codedeploy-deploymentconfig-minimumhealthyhosts-value",
@@ -1643,7 +1646,10 @@
           "PrimitiveItemType": "String",
           "Required": false,
           "Type": "List",
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployAutoRollbackConfigurationEvents"
+          }
         }
       }
     },
@@ -1677,13 +1683,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentgroup-deploymentstyle.html#cfn-codedeploy-deploymentgroup-deploymentstyle-deploymentoption",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployDeploymentStyleOption"
+          }
         },
         "DeploymentType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentgroup-deploymentstyle.html#cfn-codedeploy-deploymentgroup-deploymentstyle-deploymenttype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployDeploymentStyleType"
+          }
         }
       }
     },
@@ -1912,7 +1924,10 @@
           "PrimitiveItemType": "String",
           "Required": false,
           "Type": "List",
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployTriggerConfigEvent"
+          }
         },
         "TriggerName": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentgroup-triggerconfig.html#cfn-codedeploy-deploymentgroup-triggerconfig-triggername",
@@ -9303,7 +9318,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-healthcheck-healthcheckconfig.html#cfn-route53-healthcheck-healthcheckconfig-insufficientdatahealthstatus",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Route53HealthCheckConfigHealthStatus"
+          }
         },
         "Inverted": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-healthcheck-healthcheckconfig.html#cfn-route53-healthcheck-healthcheckconfig-inverted",
@@ -12741,7 +12759,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codedeploy-application.html#cfn-codedeploy-application-computeplatform",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CodeDeployApplicationPlatform"
+          }
         }
       }
     },
@@ -20938,6 +20959,52 @@
         ]
       }
     },
+    "CodeDeployApplicationPlatform": {
+      "AllowedValues": [
+        "ECS",
+        "Lambda",
+        "Server"
+      ]
+    },
+    "CodeDeployAutoRollbackConfigurationEvents": {
+      "AllowedValues": [
+        "DEPLOYMENT_FAILURE",
+        "DEPLOYMENT_STOP_ON_ALARM",
+        "DEPLOYMENT_STOP_ON_REQUEST"
+      ]
+    },
+    "CodeDeployConfigMinimumHealthyHostsType": {
+      "AllowedValues": [
+        "FLEET_PERCENT",
+        "HOST_COUNT"
+      ]
+    },
+    "CodeDeployDeploymentStyleOption": {
+      "AllowedValues": [
+        "WITH_TRAFFIC_CONTROL",
+        "WITHOUT_TRAFFIC_CONTROL"
+      ]
+    },
+    "CodeDeployDeploymentStyleType": {
+      "AllowedValues": [
+        "BLUE_GREEN",
+        "IN_PLACE"
+      ]
+    },
+    "CodeDeployTriggerConfigEvent": {
+      "AllowedValues": [
+        "DeploymentFailure",
+        "DeploymentReady",
+        "DeploymentRollback",
+        "DeploymentStart",
+        "DeploymentStop",
+        "DeploymentSuccess",
+        "InstanceFailure",
+        "InstanceReady",
+        "InstanceStart",
+        "InstanceSuccess"
+      ]
+    },
     "DmsEndpointEngineName": {
       "AllowedValues": [
         "aurora-postgresql",
@@ -21255,6 +21322,13 @@
           "AWS::ApiGateway::RestApi"
         ]
       }
+    },
+    "Route53HealthCheckConfigHealthStatus": {
+      "AllowedValues": [
+        "Healthy",
+        "LastKnownStatus",
+        "Unhealthy"
+      ]
     },
     "Route53HealthCheckConfigType": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/us-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-1.json
@@ -3309,7 +3309,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentconfig-minimumhealthyhosts.html#cfn-codedeploy-deploymentconfig-minimumhealthyhosts-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployConfigMinimumHealthyHostsType"
+          }
         },
         "Value": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentconfig-minimumhealthyhosts.html#cfn-codedeploy-deploymentconfig-minimumhealthyhosts-value",
@@ -3370,7 +3373,10 @@
           "PrimitiveItemType": "String",
           "Required": false,
           "Type": "List",
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployAutoRollbackConfigurationEvents"
+          }
         }
       }
     },
@@ -3404,13 +3410,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentgroup-deploymentstyle.html#cfn-codedeploy-deploymentgroup-deploymentstyle-deploymentoption",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployDeploymentStyleOption"
+          }
         },
         "DeploymentType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentgroup-deploymentstyle.html#cfn-codedeploy-deploymentgroup-deploymentstyle-deploymenttype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployDeploymentStyleType"
+          }
         }
       }
     },
@@ -3639,7 +3651,10 @@
           "PrimitiveItemType": "String",
           "Required": false,
           "Type": "List",
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployTriggerConfigEvent"
+          }
         },
         "TriggerName": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentgroup-triggerconfig.html#cfn-codedeploy-deploymentgroup-triggerconfig-triggername",
@@ -12100,7 +12115,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-healthcheck-healthcheckconfig.html#cfn-route53-healthcheck-healthcheckconfig-insufficientdatahealthstatus",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Route53HealthCheckConfigHealthStatus"
+          }
         },
         "Inverted": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-healthcheck-healthcheckconfig.html#cfn-route53-healthcheck-healthcheckconfig-inverted",
@@ -16545,7 +16563,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codedeploy-application.html#cfn-codedeploy-application-computeplatform",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CodeDeployApplicationPlatform"
+          }
         }
       }
     },
@@ -26985,6 +27006,52 @@
         ]
       }
     },
+    "CodeDeployApplicationPlatform": {
+      "AllowedValues": [
+        "ECS",
+        "Lambda",
+        "Server"
+      ]
+    },
+    "CodeDeployAutoRollbackConfigurationEvents": {
+      "AllowedValues": [
+        "DEPLOYMENT_FAILURE",
+        "DEPLOYMENT_STOP_ON_ALARM",
+        "DEPLOYMENT_STOP_ON_REQUEST"
+      ]
+    },
+    "CodeDeployConfigMinimumHealthyHostsType": {
+      "AllowedValues": [
+        "FLEET_PERCENT",
+        "HOST_COUNT"
+      ]
+    },
+    "CodeDeployDeploymentStyleOption": {
+      "AllowedValues": [
+        "WITH_TRAFFIC_CONTROL",
+        "WITHOUT_TRAFFIC_CONTROL"
+      ]
+    },
+    "CodeDeployDeploymentStyleType": {
+      "AllowedValues": [
+        "BLUE_GREEN",
+        "IN_PLACE"
+      ]
+    },
+    "CodeDeployTriggerConfigEvent": {
+      "AllowedValues": [
+        "DeploymentFailure",
+        "DeploymentReady",
+        "DeploymentRollback",
+        "DeploymentStart",
+        "DeploymentStop",
+        "DeploymentSuccess",
+        "InstanceFailure",
+        "InstanceReady",
+        "InstanceStart",
+        "InstanceSuccess"
+      ]
+    },
     "DmsEndpointEngineName": {
       "AllowedValues": [
         "aurora-postgresql",
@@ -27302,6 +27369,13 @@
           "AWS::ApiGateway::RestApi"
         ]
       }
+    },
+    "Route53HealthCheckConfigHealthStatus": {
+      "AllowedValues": [
+        "Healthy",
+        "LastKnownStatus",
+        "Unhealthy"
+      ]
     },
     "Route53HealthCheckConfigType": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/us-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-2.json
@@ -4086,7 +4086,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentconfig-minimumhealthyhosts.html#cfn-codedeploy-deploymentconfig-minimumhealthyhosts-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployConfigMinimumHealthyHostsType"
+          }
         },
         "Value": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentconfig-minimumhealthyhosts.html#cfn-codedeploy-deploymentconfig-minimumhealthyhosts-value",
@@ -4147,7 +4150,10 @@
           "PrimitiveItemType": "String",
           "Required": false,
           "Type": "List",
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployAutoRollbackConfigurationEvents"
+          }
         }
       }
     },
@@ -4181,13 +4187,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentgroup-deploymentstyle.html#cfn-codedeploy-deploymentgroup-deploymentstyle-deploymentoption",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployDeploymentStyleOption"
+          }
         },
         "DeploymentType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentgroup-deploymentstyle.html#cfn-codedeploy-deploymentgroup-deploymentstyle-deploymenttype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployDeploymentStyleType"
+          }
         }
       }
     },
@@ -4416,7 +4428,10 @@
           "PrimitiveItemType": "String",
           "Required": false,
           "Type": "List",
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodeDeployTriggerConfigEvent"
+          }
         },
         "TriggerName": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentgroup-triggerconfig.html#cfn-codedeploy-deploymentgroup-triggerconfig-triggername",
@@ -15197,7 +15212,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-healthcheck-healthcheckconfig.html#cfn-route53-healthcheck-healthcheckconfig-insufficientdatahealthstatus",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Route53HealthCheckConfigHealthStatus"
+          }
         },
         "Inverted": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-healthcheck-healthcheckconfig.html#cfn-route53-healthcheck-healthcheckconfig-inverted",
@@ -21346,7 +21364,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codedeploy-application.html#cfn-codedeploy-application-computeplatform",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CodeDeployApplicationPlatform"
+          }
         }
       }
     },
@@ -33993,6 +34014,52 @@
         ]
       }
     },
+    "CodeDeployApplicationPlatform": {
+      "AllowedValues": [
+        "ECS",
+        "Lambda",
+        "Server"
+      ]
+    },
+    "CodeDeployAutoRollbackConfigurationEvents": {
+      "AllowedValues": [
+        "DEPLOYMENT_FAILURE",
+        "DEPLOYMENT_STOP_ON_ALARM",
+        "DEPLOYMENT_STOP_ON_REQUEST"
+      ]
+    },
+    "CodeDeployConfigMinimumHealthyHostsType": {
+      "AllowedValues": [
+        "FLEET_PERCENT",
+        "HOST_COUNT"
+      ]
+    },
+    "CodeDeployDeploymentStyleOption": {
+      "AllowedValues": [
+        "WITH_TRAFFIC_CONTROL",
+        "WITHOUT_TRAFFIC_CONTROL"
+      ]
+    },
+    "CodeDeployDeploymentStyleType": {
+      "AllowedValues": [
+        "BLUE_GREEN",
+        "IN_PLACE"
+      ]
+    },
+    "CodeDeployTriggerConfigEvent": {
+      "AllowedValues": [
+        "DeploymentFailure",
+        "DeploymentReady",
+        "DeploymentRollback",
+        "DeploymentStart",
+        "DeploymentStop",
+        "DeploymentSuccess",
+        "InstanceFailure",
+        "InstanceReady",
+        "InstanceStart",
+        "InstanceSuccess"
+      ]
+    },
     "DmsEndpointEngineName": {
       "AllowedValues": [
         "aurora-postgresql",
@@ -34310,6 +34377,13 @@
           "AWS::ApiGateway::RestApi"
         ]
       }
+    },
+    "Route53HealthCheckConfigHealthStatus": {
+      "AllowedValues": [
+        "Healthy",
+        "LastKnownStatus",
+        "Unhealthy"
+      ]
     },
     "Route53HealthCheckConfigType": {
       "AllowedValues": [

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
@@ -189,6 +189,52 @@
           "TargetTrackingScaling"
         ]
       },
+      "CodeDeployApplicationPlatform": {
+        "AllowedValues": [
+          "ECS",
+          "Lambda",
+          "Server"
+        ]
+      },
+      "CodeDeployAutoRollbackConfigurationEvents": {
+        "AllowedValues": [
+          "DEPLOYMENT_FAILURE",
+          "DEPLOYMENT_STOP_ON_ALARM",
+          "DEPLOYMENT_STOP_ON_REQUEST"
+        ]
+      },
+      "CodeDeployConfigMinimumHealthyHostsType": {
+        "AllowedValues": [
+          "FLEET_PERCENT",
+          "HOST_COUNT"
+        ]
+      },
+      "CodeDeployDeploymentStyleOption": {
+        "AllowedValues": [
+          "WITH_TRAFFIC_CONTROL",
+          "WITHOUT_TRAFFIC_CONTROL"
+        ]
+      },
+      "CodeDeployDeploymentStyleType": {
+        "AllowedValues": [
+          "BLUE_GREEN",
+          "IN_PLACE"
+        ]
+      },
+      "CodeDeployTriggerConfigEvent": {
+        "AllowedValues": [
+          "DeploymentFailure",
+          "DeploymentReady",
+          "DeploymentRollback",
+          "DeploymentStart",
+          "DeploymentStop",
+          "DeploymentSuccess",
+          "InstanceFailure",
+          "InstanceReady",
+          "InstanceStart",
+          "InstanceSuccess"
+        ]
+      },
       "DmsEndpointEngineName": {
         "AllowedValues": [
           "aurora-postgresql",
@@ -494,6 +540,13 @@
           "SPF",
           "SRV",
           "TXT"
+        ]
+      },
+      "Route53HealthCheckConfigHealthStatus": {
+        "AllowedValues": [
+          "Healthy",
+          "LastKnownStatus",
+          "Unhealthy"
         ]
       },
       "Route53HealthCheckConfigType": {

--- a/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
@@ -113,6 +113,41 @@
   },
   {
     "op": "add",
+    "path": "/PropertyTypes/AWS::CodeDeploy::DeploymentConfig.MinimumHealthyHosts/Properties/Type/Value",
+    "value": {
+      "ValueType": "CodeDeployConfigMinimumHealthyHostsType"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/PropertyTypes/AWS::CodeDeploy::DeploymentGroup.AutoRollbackConfiguration/Properties/Events/Value",
+    "value": {
+      "ValueType": "CodeDeployAutoRollbackConfigurationEvents"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/PropertyTypes/AWS::CodeDeploy::DeploymentGroup.DeploymentStyle/Properties/DeploymentOption/Value",
+    "value": {
+      "ValueType": "CodeDeployDeploymentStyleOption"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/PropertyTypes/AWS::CodeDeploy::DeploymentGroup.DeploymentStyle/Properties/DeploymentType/Value",
+    "value": {
+      "ValueType": "CodeDeployDeploymentStyleType"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/PropertyTypes/AWS::CodeDeploy::DeploymentGroup.TriggerConfig/Properties/TriggerEvents/Value",
+    "value": {
+      "ValueType": "CodeDeployTriggerConfigEvent"
+    }
+  },
+  {
+    "op": "add",
     "path": "/PropertyTypes/AWS::Glue::Connection.ConnectionInput/Properties/ConnectionType/Value",
     "value": {
       "ValueType": "GlueConnectionInputType"
@@ -130,6 +165,13 @@
     "path": "/PropertyTypes/AWS::OpsWorks::Instance.EbsBlockDevice/Properties/VolumeType/Value",
     "value": {
       "ValueType": "EbsVolumeType"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/PropertyTypes/AWS::Route53::HealthCheck.HealthCheckConfig/Properties/InsufficientDataHealthStatus/Value",
+    "value": {
+      "ValueType": "Route53HealthCheckConfigHealthStatus"
     }
   },
   {
@@ -500,6 +542,13 @@
     "path": "/ResourceTypes/AWS::CodeBuild::Project/Properties/ServiceRole/Value",
     "value": {
       "ValueType": "IamRole.Arn"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/ResourceTypes/AWS::CodeDeploy::Application/Properties/ComputePlatform/Value",
+    "value": {
+      "ValueType": "CodeDeployApplicationPlatform"
     }
   },
   {

--- a/test/fixtures/templates/bad/resources/properties/allowed_values.yaml
+++ b/test/fixtures/templates/bad/resources/properties/allowed_values.yaml
@@ -152,6 +152,33 @@ Resources:
               PredefinedScalingMetricSpecification:
                 PredefinedScalingMetricType: "RequestCountPerTarget" # Invalid AllowedValue
               TargetValue: 10.5
+  CodeDeployApplication:
+    Type: AWS::CodeDeploy::Application
+    Properties:
+      ApplicationName: "CodeDeployApplication"
+      ComputePlatform: "EC2" # Invalid AllowedValue
+  CodeDeployDeploymentConfig:
+    Type: "AWS::CodeDeploy::DeploymentConfig"
+    Properties:
+      DeploymentConfigName: "CodeDeployDeploymentConfig"
+      MinimumHealthyHosts:
+        Type: "HOST_PERCENTAGE" # Invalid AllowedValue
+        Value: 1
+  CodeDeployDeploymentGroup:
+    Type: "AWS::CodeDeploy::DeploymentGroup"
+    Properties:
+      ApplicationName: "CodeDeployDeploymentGroup"
+      AutoRollbackConfiguration:
+        Events:
+          - "DEPLOYMENTFAILURE" # Invalid AllowedValue
+          - "DEPLOYMENT_STOP_ALARM" # Invalid AllowedValue
+      DeploymentStyle:
+        DeploymentOption: "TRAFFIC_CONTROL" # Invalid AllowedValue
+        DeploymentType: "IN PLACE" # Invalid AllowedValue
+      ServiceRoleArn: "ServiceRoleArn"
+      TriggerConfigurations:
+        - TriggerEvents:
+            - "DeploymentStart" # Invalid AllowedValue
   DmsEndpoint:
     Type: "AWS::DMS::Endpoint"
     Properties:
@@ -179,6 +206,7 @@ Resources:
     Type: "AWS::Route53::HealthCheck"
     Properties:
       HealthCheckConfig:
+        InsufficientDataHealthStatus: "" # Invalid AllowedValue
         Type: "HTTP_MATCH" # Invalid AllowedValue
   Route53RecordSet:
     Type: "AWS::Route53::RecordSet"

--- a/test/fixtures/templates/good/resources/properties/allowed_values.yaml
+++ b/test/fixtures/templates/good/resources/properties/allowed_values.yaml
@@ -152,6 +152,33 @@ Resources:
               PredefinedScalingMetricSpecification:
                 PredefinedScalingMetricType: "ALBRequestCountPerTarget" # Valid AllowedValue
               TargetValue: 10.5
+  CodeDeployApplication:
+    Type: "AWS::CodeDeploy::Application"
+    Properties:
+      ApplicationName: "CodeDeployApplication"
+      ComputePlatform: "Server" # Valid AllowedValue
+  CodeDeployDeploymentConfig:
+    Type: "AWS::CodeDeploy::DeploymentConfig"
+    Properties:
+      DeploymentConfigName: "CodeDeployDeploymentConfig"
+      MinimumHealthyHosts:
+        Type: "HOST_COUNT" # Valid AllowedValue
+        Value: 1
+  CodeDeployDeploymentGroup:
+    Type: "AWS::CodeDeploy::DeploymentGroup"
+    Properties:
+      ApplicationName: "CodeDeployDeploymentGroup"
+      AutoRollbackConfiguration:
+        Events:
+          - "DEPLOYMENT_FAILURE" # Valid AllowedValue
+          - "DEPLOYMENT_STOP_ON_ALARM" # Valid AllowedValue
+      DeploymentStyle:
+        DeploymentOption: "WITH_TRAFFIC_CONTROL" # Valid AllowedValue
+        DeploymentType: "IN_PLACE" # Valid AllowedValue
+      ServiceRoleArn: "ServiceRoleArn"
+      TriggerConfigurations:
+        - TriggerEvents:
+            - "DeploymentStart" # Valid AllowedValue
   DmsEndpoint:
     Type: "AWS::DMS::Endpoint"
     Properties:
@@ -179,6 +206,7 @@ Resources:
     Type: "AWS::Route53::HealthCheck"
     Properties:
       HealthCheckConfig:
+        InsufficientDataHealthStatus: "Healthy" # Valid AllowedValue
         Type: "CLOUDWATCH_METRIC"
   Route53RecordSet:
     Type: "AWS::Route53::RecordSet"

--- a/test/integration/test_patched_specs.py
+++ b/test/integration/test_patched_specs.py
@@ -57,7 +57,8 @@ class TestQuickStartTemplates(BaseTestCase):
                     # List Value if a singular value is set and the type is List
                     if p_values.get('Type') == 'List':
                         p_list_value_type = p_values.get('Value', {}).get('ListValueType')
-                        self.assertIn(p_list_value_type, self.spec.get('ValueTypes'), 'ResourceType: %s, Property: %s' % (r_name, p_name))
+                        if p_list_value_type:
+                            self.assertIn(p_list_value_type, self.spec.get('ValueTypes'), 'ResourceType: %s, Property: %s' % (r_name, p_name))
 
     def test_property_value_types(self):
         """Test Property Value Types"""

--- a/test/rules/resources/properties/test_allowed_value.py
+++ b/test/rules/resources/properties/test_allowed_value.py
@@ -34,4 +34,4 @@ class TestAllowedValue(BaseRuleTestCase):
 
     def test_file_negative(self):
         """Test failure"""
-        self.helper_file_negative('test/fixtures/templates/bad/resources/properties/allowed_values.yaml', 57)
+        self.helper_file_negative('test/fixtures/templates/bad/resources/properties/allowed_values.yaml', 64)


### PR DESCRIPTION
Add allowed_values for CodeDeploy resources.

Had to tweak the test on the ValueTypes a bit:  It is optional in the Rule itself ([Source](https://github.com/awslabs/cfn-python-lint/blob/master/src/cfnlint/rules/resources/properties/ValueRefGetAtt.py#L190)) and the AllowedValue also doesn't use it, I changed the test.

Triggered by the CodeDeployAutoRollbackConfigurationEvents

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
