### PR TITLE
Fix Cloudwatch alarm DataQuery spec patch

### DIFF
--- a/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
@@ -19730,7 +19730,7 @@
         },
         "Metrics": {
           "Documentation": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-metrics",
-          "ItemType": "DataQuery",
+          "ItemType": "MetricDataQuery",
           "Required": false,
           "Type": "List",
           "UpdateType": "Mutable"

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
@@ -18066,7 +18066,7 @@
         },
         "Metrics": {
           "Documentation": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-metrics",
-          "ItemType": "DataQuery",
+          "ItemType": "MetricDataQuery",
           "Required": false,
           "Type": "List",
           "UpdateType": "Mutable"

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
@@ -12805,7 +12805,7 @@
         },
         "Metrics": {
           "Documentation": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-metrics",
-          "ItemType": "DataQuery",
+          "ItemType": "MetricDataQuery",
           "Required": false,
           "Type": "List",
           "UpdateType": "Mutable"

--- a/src/cfnlint/data/CloudSpecs/ap-south-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-south-1.json
@@ -17290,7 +17290,7 @@
         },
         "Metrics": {
           "Documentation": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-metrics",
-          "ItemType": "DataQuery",
+          "ItemType": "MetricDataQuery",
           "Required": false,
           "Type": "List",
           "UpdateType": "Mutable"

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
@@ -18313,7 +18313,7 @@
         },
         "Metrics": {
           "Documentation": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-metrics",
-          "ItemType": "DataQuery",
+          "ItemType": "MetricDataQuery",
           "Required": false,
           "Type": "List",
           "UpdateType": "Mutable"

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
@@ -18853,7 +18853,7 @@
         },
         "Metrics": {
           "Documentation": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-metrics",
-          "ItemType": "DataQuery",
+          "ItemType": "MetricDataQuery",
           "Required": false,
           "Type": "List",
           "UpdateType": "Mutable"

--- a/src/cfnlint/data/CloudSpecs/ca-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/ca-central-1.json
@@ -16116,7 +16116,7 @@
         },
         "Metrics": {
           "Documentation": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-metrics",
-          "ItemType": "DataQuery",
+          "ItemType": "MetricDataQuery",
           "Required": false,
           "Type": "List",
           "UpdateType": "Mutable"

--- a/src/cfnlint/data/CloudSpecs/eu-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-central-1.json
@@ -19275,7 +19275,7 @@
         },
         "Metrics": {
           "Documentation": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-metrics",
-          "ItemType": "DataQuery",
+          "ItemType": "MetricDataQuery",
           "Required": false,
           "Type": "List",
           "UpdateType": "Mutable"

--- a/src/cfnlint/data/CloudSpecs/eu-north-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-north-1.json
@@ -12806,7 +12806,7 @@
         },
         "Metrics": {
           "Documentation": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-metrics",
-          "ItemType": "DataQuery",
+          "ItemType": "MetricDataQuery",
           "Required": false,
           "Type": "List",
           "UpdateType": "Mutable"

--- a/src/cfnlint/data/CloudSpecs/eu-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-1.json
@@ -21108,7 +21108,7 @@
         },
         "Metrics": {
           "Documentation": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-metrics",
-          "ItemType": "DataQuery",
+          "ItemType": "MetricDataQuery",
           "Required": false,
           "Type": "List",
           "UpdateType": "Mutable"

--- a/src/cfnlint/data/CloudSpecs/eu-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-2.json
@@ -16648,7 +16648,7 @@
         },
         "Metrics": {
           "Documentation": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-metrics",
-          "ItemType": "DataQuery",
+          "ItemType": "MetricDataQuery",
           "Required": false,
           "Type": "List",
           "UpdateType": "Mutable"

--- a/src/cfnlint/data/CloudSpecs/eu-west-3.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-3.json
@@ -15090,7 +15090,7 @@
         },
         "Metrics": {
           "Documentation": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-metrics",
-          "ItemType": "DataQuery",
+          "ItemType": "MetricDataQuery",
           "Required": false,
           "Type": "List",
           "UpdateType": "Mutable"

--- a/src/cfnlint/data/CloudSpecs/sa-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/sa-east-1.json
@@ -15653,7 +15653,7 @@
         },
         "Metrics": {
           "Documentation": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-metrics",
-          "ItemType": "DataQuery",
+          "ItemType": "MetricDataQuery",
           "Required": false,
           "Type": "List",
           "UpdateType": "Mutable"

--- a/src/cfnlint/data/CloudSpecs/us-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-1.json
@@ -21109,7 +21109,7 @@
         },
         "Metrics": {
           "Documentation": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-metrics",
-          "ItemType": "DataQuery",
+          "ItemType": "MetricDataQuery",
           "Required": false,
           "Type": "List",
           "UpdateType": "Mutable"

--- a/src/cfnlint/data/CloudSpecs/us-east-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-2.json
@@ -19664,7 +19664,7 @@
         },
         "Metrics": {
           "Documentation": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-metrics",
-          "ItemType": "DataQuery",
+          "ItemType": "MetricDataQuery",
           "Required": false,
           "Type": "List",
           "UpdateType": "Mutable"

--- a/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
@@ -12625,7 +12625,7 @@
         },
         "Metrics": {
           "Documentation": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-metrics",
-          "ItemType": "DataQuery",
+          "ItemType": "MetricDataQuery",
           "Required": false,
           "Type": "List",
           "UpdateType": "Mutable"

--- a/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
@@ -12695,7 +12695,7 @@
         },
         "Metrics": {
           "Documentation": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-metrics",
-          "ItemType": "DataQuery",
+          "ItemType": "MetricDataQuery",
           "Required": false,
           "Type": "List",
           "UpdateType": "Mutable"

--- a/src/cfnlint/data/CloudSpecs/us-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-1.json
@@ -16482,7 +16482,7 @@
         },
         "Metrics": {
           "Documentation": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-metrics",
-          "ItemType": "DataQuery",
+          "ItemType": "MetricDataQuery",
           "Required": false,
           "Type": "List",
           "UpdateType": "Mutable"

--- a/src/cfnlint/data/CloudSpecs/us-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-2.json
@@ -21127,7 +21127,7 @@
         },
         "Metrics": {
           "Documentation": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-metrics",
-          "ItemType": "DataQuery",
+          "ItemType": "MetricDataQuery",
           "Required": false,
           "Type": "List",
           "UpdateType": "Mutable"

--- a/src/cfnlint/data/ExtendedSpecs/all/01_spec_patch.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/01_spec_patch.json
@@ -158,7 +158,7 @@
     "path": "/ResourceTypes/AWS::CloudWatch::Alarm/Properties/Metrics",
     "value": {
       "Documentation": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-metrics",
-      "ItemType": "DataQuery",
+      "ItemType": "MetricDataQuery",
       "Required": false,
       "Type": "List",
       "UpdateType": "Mutable"

--- a/test/integration/test_patched_specs.py
+++ b/test/integration/test_patched_specs.py
@@ -20,8 +20,8 @@ import pkg_resources
 from testlib.testcase import BaseTestCase
 
 
-class TestQuickStartTemplates(BaseTestCase):
-    """Test QuickStart Templates Parsing """
+class TestPatchedSpecs(BaseTestCase):
+    """Test Patched spec files """
     def setUp(self):
         """ SetUp template object"""
 
@@ -59,6 +59,41 @@ class TestQuickStartTemplates(BaseTestCase):
                         p_list_value_type = p_values.get('Value', {}).get('ListValueType')
                         if p_list_value_type:
                             self.assertIn(p_list_value_type, self.spec.get('ValueTypes'), 'ResourceType: %s, Property: %s' % (r_name, p_name))
+
+    def _test_sub_properties(self, resource_name, properties):
+        property_types = self.spec.get('PropertyTypes').keys()
+        for v_propertyname, v_propertyvalues in properties:
+            if 'PrimitiveType' not in v_propertyvalues and 'PrimitiveItemType' not in v_propertyvalues:
+                v_propertytype = ''
+                if 'ItemType' in v_propertyvalues:
+                    v_propertytype = v_propertyvalues['ItemType']
+                elif 'Type' in v_propertyvalues:
+                    v_propertytype = v_propertyvalues['Type']
+
+                v_subproperty_type = str.format('{0}.{1}', resource_name, v_propertytype)
+
+                property_exists = False
+                if v_subproperty_type in property_types:
+                    property_exists = True
+                elif v_propertytype in property_types:
+                    # Special: There is a "Tag" Property type that's used as a "CatchAll" mechanism for Tags,
+                    # If the subproperty is not found, check if it exists with the resource in the property
+                    property_exists = True
+
+                self.assertEqual(property_exists, True, 'Specified property type {} not found for property {}'.format(v_subproperty_type, v_propertyname))
+
+    def test_sub_properties(self):
+        """Test Resource sub-Property definitions"""
+        # Test properties from resources
+        for v_name, v_values in self.spec.get('ResourceTypes').items():
+            self._test_sub_properties(v_name, v_values.get('Properties').items())
+
+        # Test properties from subproperties
+        for v_name, v_values in self.spec.get('PropertyTypes').items():
+            # Grab the resource part from the subproperty
+            resource_name = v_name.split('.', 1)[0]
+            if resource_name:
+                self._test_sub_properties(resource_name, v_values.get('Properties').items())
 
     def test_property_value_types(self):
         """Test Property Value Types"""


### PR DESCRIPTION
*Issue https://github.com/awslabs/cfn-python-lint/issues/539, if available:*

Fixed patch error introduced in PR https://github.com/awslabs/cfn-python-lint/pull/541

Working on a test to cover this scenario (Extending the `test_patched_specs` tests) to prevent this in the future, but for now this fixes the current issue.

Error raised:

```2019-01-16 12:20:37,588 - cfnlint - DEBUG - Completed linting of file: test.yaml
E0002 Unknown exception while processing rule E3002: Traceback (most recent call last):
  File "/Users/frankvanboven/Documents/dev/cfn-python-lint/src/cfnlint/__init__.py", line 180, in run_check
    return check(*args)
  File "/Users/frankvanboven/Documents/dev/cfn-python-lint/src/cfnlint/__init__.py", line 71, in wrapper
    results = match_function(self, filename, cfn, *args, **kwargs)
  File "/Users/frankvanboven/Documents/dev/cfn-python-lint/src/cfnlint/__init__.py", line 100, in matchall
    return self.match(cfn)  # pylint: disable=E1102
  File "/Users/frankvanboven/Documents/dev/cfn-python-lint/src/cfnlint/rules/resources/properties/Properties.py", line 301, in match
    resourcetype, resourcename, path, True))
  File "/Users/frankvanboven/Documents/dev/cfn-python-lint/src/cfnlint/rules/resources/properties/Properties.py", line 227, in propertycheck
    parenttype, resourcename, arrproppath, False))
  File "/Users/frankvanboven/Documents/dev/cfn-python-lint/src/cfnlint/rules/resources/properties/Properties.py", line 186, in propertycheck
    resourcespec = specs[resourcetype].get('Properties', {})
KeyError: 'AWS::CloudWatch::Alarm.DataQuery'
```

The rule expects that the property types actually exist. 

Also added in a unit test to prevent this mistakes in the future

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
