### PR TITLE
Add Budget Allowed Values

### DIFF
--- a/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
@@ -2665,7 +2665,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-budgetdata.html#cfn-budgets-budget-budgetdata-budgettype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetDataBudgetType"
+          }
         },
         "CostFilters": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-budgetdata.html#cfn-budgets-budget-budgetdata-costfilters",
@@ -2689,7 +2692,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-budgetdata.html#cfn-budgets-budget-budgetdata-timeunit",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetDataTimeUnit"
+          }
         }
       }
     },
@@ -2771,13 +2777,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-comparisonoperator",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetNotificationComparisonOperator"
+          }
         },
         "NotificationType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-notificationtype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetNotificationNotificationType"
+          }
         },
         "Threshold": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-threshold",
@@ -2789,7 +2801,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-thresholdtype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetNotificationThresholdType"
+          }
         }
       }
     },
@@ -2841,7 +2856,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-subscriber.html#cfn-budgets-budget-subscriber-subscriptiontype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetSubscriptionType"
+          }
         }
       }
     },
@@ -31658,6 +31676,47 @@
           "AvailabilityZones"
         ]
       }
+    },
+    "BudgetDataBudgetType": {
+      "AllowedValues": [
+        "COST",
+        "RI_COVERAGE",
+        "RI_UTILIZATION",
+        "USAGE"
+      ]
+    },
+    "BudgetDataTimeUnit": {
+      "AllowedValues": [
+        "ANNUALLY",
+        "DAILY",
+        "MONTHLY",
+        "QUARTERLY"
+      ]
+    },
+    "BudgetNotificationComparisonOperator": {
+      "AllowedValues": [
+        "EQUAL_TO",
+        "GREATER_THAN",
+        "LESS_THAN"
+      ]
+    },
+    "BudgetNotificationNotificationType": {
+      "AllowedValues": [
+        "ACTUAL",
+        "FORECASTED"
+      ]
+    },
+    "BudgetNotificationThresholdType": {
+      "AllowedValues": [
+        "ABSOLUTE_VALUE",
+        "PERCENTAGE"
+      ]
+    },
+    "BudgetSubscriptionType": {
+      "AllowedValues": [
+        "EMAIL",
+        "SNS"
+      ]
     },
     "CodeDeployApplicationPlatform": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
@@ -2415,7 +2415,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-budgetdata.html#cfn-budgets-budget-budgetdata-budgettype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetDataBudgetType"
+          }
         },
         "CostFilters": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-budgetdata.html#cfn-budgets-budget-budgetdata-costfilters",
@@ -2439,7 +2442,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-budgetdata.html#cfn-budgets-budget-budgetdata-timeunit",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetDataTimeUnit"
+          }
         }
       }
     },
@@ -2521,13 +2527,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-comparisonoperator",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetNotificationComparisonOperator"
+          }
         },
         "NotificationType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-notificationtype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetNotificationNotificationType"
+          }
         },
         "Threshold": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-threshold",
@@ -2539,7 +2551,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-thresholdtype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetNotificationThresholdType"
+          }
         }
       }
     },
@@ -2591,7 +2606,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-subscriber.html#cfn-budgets-budget-subscriber-subscriptiontype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetSubscriptionType"
+          }
         }
       }
     },
@@ -29177,6 +29195,47 @@
           "AvailabilityZones"
         ]
       }
+    },
+    "BudgetDataBudgetType": {
+      "AllowedValues": [
+        "COST",
+        "RI_COVERAGE",
+        "RI_UTILIZATION",
+        "USAGE"
+      ]
+    },
+    "BudgetDataTimeUnit": {
+      "AllowedValues": [
+        "ANNUALLY",
+        "DAILY",
+        "MONTHLY",
+        "QUARTERLY"
+      ]
+    },
+    "BudgetNotificationComparisonOperator": {
+      "AllowedValues": [
+        "EQUAL_TO",
+        "GREATER_THAN",
+        "LESS_THAN"
+      ]
+    },
+    "BudgetNotificationNotificationType": {
+      "AllowedValues": [
+        "ACTUAL",
+        "FORECASTED"
+      ]
+    },
+    "BudgetNotificationThresholdType": {
+      "AllowedValues": [
+        "ABSOLUTE_VALUE",
+        "PERCENTAGE"
+      ]
+    },
+    "BudgetSubscriptionType": {
+      "AllowedValues": [
+        "EMAIL",
+        "SNS"
+      ]
     },
     "CodeDeployApplicationPlatform": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
@@ -20973,6 +20973,47 @@
         ]
       }
     },
+    "BudgetDataBudgetType": {
+      "AllowedValues": [
+        "COST",
+        "RI_COVERAGE",
+        "RI_UTILIZATION",
+        "USAGE"
+      ]
+    },
+    "BudgetDataTimeUnit": {
+      "AllowedValues": [
+        "ANNUALLY",
+        "DAILY",
+        "MONTHLY",
+        "QUARTERLY"
+      ]
+    },
+    "BudgetNotificationComparisonOperator": {
+      "AllowedValues": [
+        "EQUAL_TO",
+        "GREATER_THAN",
+        "LESS_THAN"
+      ]
+    },
+    "BudgetNotificationNotificationType": {
+      "AllowedValues": [
+        "ACTUAL",
+        "FORECASTED"
+      ]
+    },
+    "BudgetNotificationThresholdType": {
+      "AllowedValues": [
+        "ABSOLUTE_VALUE",
+        "PERCENTAGE"
+      ]
+    },
+    "BudgetSubscriptionType": {
+      "AllowedValues": [
+        "EMAIL",
+        "SNS"
+      ]
+    },
     "CodeDeployApplicationPlatform": {
       "AllowedValues": [
         "ECS",

--- a/src/cfnlint/data/CloudSpecs/ap-south-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-south-1.json
@@ -2277,7 +2277,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-budgetdata.html#cfn-budgets-budget-budgetdata-budgettype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetDataBudgetType"
+          }
         },
         "CostFilters": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-budgetdata.html#cfn-budgets-budget-budgetdata-costfilters",
@@ -2301,7 +2304,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-budgetdata.html#cfn-budgets-budget-budgetdata-timeunit",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetDataTimeUnit"
+          }
         }
       }
     },
@@ -2383,13 +2389,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-comparisonoperator",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetNotificationComparisonOperator"
+          }
         },
         "NotificationType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-notificationtype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetNotificationNotificationType"
+          }
         },
         "Threshold": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-threshold",
@@ -2401,7 +2413,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-thresholdtype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetNotificationThresholdType"
+          }
         }
       }
     },
@@ -2453,7 +2468,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-subscriber.html#cfn-budgets-budget-subscriber-subscriptiontype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetSubscriptionType"
+          }
         }
       }
     },
@@ -28017,6 +28035,47 @@
           "AvailabilityZones"
         ]
       }
+    },
+    "BudgetDataBudgetType": {
+      "AllowedValues": [
+        "COST",
+        "RI_COVERAGE",
+        "RI_UTILIZATION",
+        "USAGE"
+      ]
+    },
+    "BudgetDataTimeUnit": {
+      "AllowedValues": [
+        "ANNUALLY",
+        "DAILY",
+        "MONTHLY",
+        "QUARTERLY"
+      ]
+    },
+    "BudgetNotificationComparisonOperator": {
+      "AllowedValues": [
+        "EQUAL_TO",
+        "GREATER_THAN",
+        "LESS_THAN"
+      ]
+    },
+    "BudgetNotificationNotificationType": {
+      "AllowedValues": [
+        "ACTUAL",
+        "FORECASTED"
+      ]
+    },
+    "BudgetNotificationThresholdType": {
+      "AllowedValues": [
+        "ABSOLUTE_VALUE",
+        "PERCENTAGE"
+      ]
+    },
+    "BudgetSubscriptionType": {
+      "AllowedValues": [
+        "EMAIL",
+        "SNS"
+      ]
     },
     "CodeDeployApplicationPlatform": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
@@ -2573,7 +2573,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-budgetdata.html#cfn-budgets-budget-budgetdata-budgettype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetDataBudgetType"
+          }
         },
         "CostFilters": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-budgetdata.html#cfn-budgets-budget-budgetdata-costfilters",
@@ -2597,7 +2600,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-budgetdata.html#cfn-budgets-budget-budgetdata-timeunit",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetDataTimeUnit"
+          }
         }
       }
     },
@@ -2679,13 +2685,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-comparisonoperator",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetNotificationComparisonOperator"
+          }
         },
         "NotificationType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-notificationtype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetNotificationNotificationType"
+          }
         },
         "Threshold": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-threshold",
@@ -2697,7 +2709,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-thresholdtype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetNotificationThresholdType"
+          }
         }
       }
     },
@@ -2749,7 +2764,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-subscriber.html#cfn-budgets-budget-subscriber-subscriptiontype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetSubscriptionType"
+          }
         }
       }
     },
@@ -29175,6 +29193,47 @@
           "AvailabilityZones"
         ]
       }
+    },
+    "BudgetDataBudgetType": {
+      "AllowedValues": [
+        "COST",
+        "RI_COVERAGE",
+        "RI_UTILIZATION",
+        "USAGE"
+      ]
+    },
+    "BudgetDataTimeUnit": {
+      "AllowedValues": [
+        "ANNUALLY",
+        "DAILY",
+        "MONTHLY",
+        "QUARTERLY"
+      ]
+    },
+    "BudgetNotificationComparisonOperator": {
+      "AllowedValues": [
+        "EQUAL_TO",
+        "GREATER_THAN",
+        "LESS_THAN"
+      ]
+    },
+    "BudgetNotificationNotificationType": {
+      "AllowedValues": [
+        "ACTUAL",
+        "FORECASTED"
+      ]
+    },
+    "BudgetNotificationThresholdType": {
+      "AllowedValues": [
+        "ABSOLUTE_VALUE",
+        "PERCENTAGE"
+      ]
+    },
+    "BudgetSubscriptionType": {
+      "AllowedValues": [
+        "EMAIL",
+        "SNS"
+      ]
     },
     "CodeDeployApplicationPlatform": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
@@ -2665,7 +2665,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-budgetdata.html#cfn-budgets-budget-budgetdata-budgettype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetDataBudgetType"
+          }
         },
         "CostFilters": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-budgetdata.html#cfn-budgets-budget-budgetdata-costfilters",
@@ -2689,7 +2692,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-budgetdata.html#cfn-budgets-budget-budgetdata-timeunit",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetDataTimeUnit"
+          }
         }
       }
     },
@@ -2771,13 +2777,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-comparisonoperator",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetNotificationComparisonOperator"
+          }
         },
         "NotificationType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-notificationtype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetNotificationNotificationType"
+          }
         },
         "Threshold": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-threshold",
@@ -2789,7 +2801,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-thresholdtype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetNotificationThresholdType"
+          }
         }
       }
     },
@@ -2841,7 +2856,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-subscriber.html#cfn-budgets-budget-subscriber-subscriptiontype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetSubscriptionType"
+          }
         }
       }
     },
@@ -30053,6 +30071,47 @@
           "AvailabilityZones"
         ]
       }
+    },
+    "BudgetDataBudgetType": {
+      "AllowedValues": [
+        "COST",
+        "RI_COVERAGE",
+        "RI_UTILIZATION",
+        "USAGE"
+      ]
+    },
+    "BudgetDataTimeUnit": {
+      "AllowedValues": [
+        "ANNUALLY",
+        "DAILY",
+        "MONTHLY",
+        "QUARTERLY"
+      ]
+    },
+    "BudgetNotificationComparisonOperator": {
+      "AllowedValues": [
+        "EQUAL_TO",
+        "GREATER_THAN",
+        "LESS_THAN"
+      ]
+    },
+    "BudgetNotificationNotificationType": {
+      "AllowedValues": [
+        "ACTUAL",
+        "FORECASTED"
+      ]
+    },
+    "BudgetNotificationThresholdType": {
+      "AllowedValues": [
+        "ABSOLUTE_VALUE",
+        "PERCENTAGE"
+      ]
+    },
+    "BudgetSubscriptionType": {
+      "AllowedValues": [
+        "EMAIL",
+        "SNS"
+      ]
     },
     "CodeDeployApplicationPlatform": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ca-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/ca-central-1.json
@@ -2111,7 +2111,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-budgetdata.html#cfn-budgets-budget-budgetdata-budgettype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetDataBudgetType"
+          }
         },
         "CostFilters": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-budgetdata.html#cfn-budgets-budget-budgetdata-costfilters",
@@ -2135,7 +2138,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-budgetdata.html#cfn-budgets-budget-budgetdata-timeunit",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetDataTimeUnit"
+          }
         }
       }
     },
@@ -2217,13 +2223,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-comparisonoperator",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetNotificationComparisonOperator"
+          }
         },
         "NotificationType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-notificationtype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetNotificationNotificationType"
+          }
         },
         "Threshold": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-threshold",
@@ -2235,7 +2247,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-thresholdtype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetNotificationThresholdType"
+          }
         }
       }
     },
@@ -2287,7 +2302,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-subscriber.html#cfn-budgets-budget-subscriber-subscriptiontype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetSubscriptionType"
+          }
         }
       }
     },
@@ -26377,6 +26395,47 @@
           "AvailabilityZones"
         ]
       }
+    },
+    "BudgetDataBudgetType": {
+      "AllowedValues": [
+        "COST",
+        "RI_COVERAGE",
+        "RI_UTILIZATION",
+        "USAGE"
+      ]
+    },
+    "BudgetDataTimeUnit": {
+      "AllowedValues": [
+        "ANNUALLY",
+        "DAILY",
+        "MONTHLY",
+        "QUARTERLY"
+      ]
+    },
+    "BudgetNotificationComparisonOperator": {
+      "AllowedValues": [
+        "EQUAL_TO",
+        "GREATER_THAN",
+        "LESS_THAN"
+      ]
+    },
+    "BudgetNotificationNotificationType": {
+      "AllowedValues": [
+        "ACTUAL",
+        "FORECASTED"
+      ]
+    },
+    "BudgetNotificationThresholdType": {
+      "AllowedValues": [
+        "ABSOLUTE_VALUE",
+        "PERCENTAGE"
+      ]
+    },
+    "BudgetSubscriptionType": {
+      "AllowedValues": [
+        "EMAIL",
+        "SNS"
+      ]
     },
     "CodeDeployApplicationPlatform": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/eu-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-central-1.json
@@ -2590,7 +2590,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-budgetdata.html#cfn-budgets-budget-budgetdata-budgettype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetDataBudgetType"
+          }
         },
         "CostFilters": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-budgetdata.html#cfn-budgets-budget-budgetdata-costfilters",
@@ -2614,7 +2617,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-budgetdata.html#cfn-budgets-budget-budgetdata-timeunit",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetDataTimeUnit"
+          }
         }
       }
     },
@@ -2696,13 +2702,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-comparisonoperator",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetNotificationComparisonOperator"
+          }
         },
         "NotificationType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-notificationtype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetNotificationNotificationType"
+          }
         },
         "Threshold": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-threshold",
@@ -2714,7 +2726,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-thresholdtype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetNotificationThresholdType"
+          }
         }
       }
     },
@@ -2766,7 +2781,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-subscriber.html#cfn-budgets-budget-subscriber-subscriptiontype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetSubscriptionType"
+          }
         }
       }
     },
@@ -30858,6 +30876,47 @@
           "AvailabilityZones"
         ]
       }
+    },
+    "BudgetDataBudgetType": {
+      "AllowedValues": [
+        "COST",
+        "RI_COVERAGE",
+        "RI_UTILIZATION",
+        "USAGE"
+      ]
+    },
+    "BudgetDataTimeUnit": {
+      "AllowedValues": [
+        "ANNUALLY",
+        "DAILY",
+        "MONTHLY",
+        "QUARTERLY"
+      ]
+    },
+    "BudgetNotificationComparisonOperator": {
+      "AllowedValues": [
+        "EQUAL_TO",
+        "GREATER_THAN",
+        "LESS_THAN"
+      ]
+    },
+    "BudgetNotificationNotificationType": {
+      "AllowedValues": [
+        "ACTUAL",
+        "FORECASTED"
+      ]
+    },
+    "BudgetNotificationThresholdType": {
+      "AllowedValues": [
+        "ABSOLUTE_VALUE",
+        "PERCENTAGE"
+      ]
+    },
+    "BudgetSubscriptionType": {
+      "AllowedValues": [
+        "EMAIL",
+        "SNS"
+      ]
     },
     "CodeDeployApplicationPlatform": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/eu-north-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-north-1.json
@@ -21389,6 +21389,47 @@
         ]
       }
     },
+    "BudgetDataBudgetType": {
+      "AllowedValues": [
+        "COST",
+        "RI_COVERAGE",
+        "RI_UTILIZATION",
+        "USAGE"
+      ]
+    },
+    "BudgetDataTimeUnit": {
+      "AllowedValues": [
+        "ANNUALLY",
+        "DAILY",
+        "MONTHLY",
+        "QUARTERLY"
+      ]
+    },
+    "BudgetNotificationComparisonOperator": {
+      "AllowedValues": [
+        "EQUAL_TO",
+        "GREATER_THAN",
+        "LESS_THAN"
+      ]
+    },
+    "BudgetNotificationNotificationType": {
+      "AllowedValues": [
+        "ACTUAL",
+        "FORECASTED"
+      ]
+    },
+    "BudgetNotificationThresholdType": {
+      "AllowedValues": [
+        "ABSOLUTE_VALUE",
+        "PERCENTAGE"
+      ]
+    },
+    "BudgetSubscriptionType": {
+      "AllowedValues": [
+        "EMAIL",
+        "SNS"
+      ]
+    },
     "CodeDeployApplicationPlatform": {
       "AllowedValues": [
         "ECS",

--- a/src/cfnlint/data/CloudSpecs/eu-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-1.json
@@ -2665,7 +2665,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-budgetdata.html#cfn-budgets-budget-budgetdata-budgettype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetDataBudgetType"
+          }
         },
         "CostFilters": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-budgetdata.html#cfn-budgets-budget-budgetdata-costfilters",
@@ -2689,7 +2692,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-budgetdata.html#cfn-budgets-budget-budgetdata-timeunit",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetDataTimeUnit"
+          }
         }
       }
     },
@@ -2771,13 +2777,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-comparisonoperator",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetNotificationComparisonOperator"
+          }
         },
         "NotificationType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-notificationtype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetNotificationNotificationType"
+          }
         },
         "Threshold": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-threshold",
@@ -2789,7 +2801,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-thresholdtype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetNotificationThresholdType"
+          }
         }
       }
     },
@@ -2841,7 +2856,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-subscriber.html#cfn-budgets-budget-subscriber-subscriptiontype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetSubscriptionType"
+          }
         }
       }
     },
@@ -33960,6 +33978,47 @@
           "AvailabilityZones"
         ]
       }
+    },
+    "BudgetDataBudgetType": {
+      "AllowedValues": [
+        "COST",
+        "RI_COVERAGE",
+        "RI_UTILIZATION",
+        "USAGE"
+      ]
+    },
+    "BudgetDataTimeUnit": {
+      "AllowedValues": [
+        "ANNUALLY",
+        "DAILY",
+        "MONTHLY",
+        "QUARTERLY"
+      ]
+    },
+    "BudgetNotificationComparisonOperator": {
+      "AllowedValues": [
+        "EQUAL_TO",
+        "GREATER_THAN",
+        "LESS_THAN"
+      ]
+    },
+    "BudgetNotificationNotificationType": {
+      "AllowedValues": [
+        "ACTUAL",
+        "FORECASTED"
+      ]
+    },
+    "BudgetNotificationThresholdType": {
+      "AllowedValues": [
+        "ABSOLUTE_VALUE",
+        "PERCENTAGE"
+      ]
+    },
+    "BudgetSubscriptionType": {
+      "AllowedValues": [
+        "EMAIL",
+        "SNS"
+      ]
     },
     "CodeDeployApplicationPlatform": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/eu-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-2.json
@@ -2128,7 +2128,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-budgetdata.html#cfn-budgets-budget-budgetdata-budgettype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetDataBudgetType"
+          }
         },
         "CostFilters": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-budgetdata.html#cfn-budgets-budget-budgetdata-costfilters",
@@ -2152,7 +2155,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-budgetdata.html#cfn-budgets-budget-budgetdata-timeunit",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetDataTimeUnit"
+          }
         }
       }
     },
@@ -2234,13 +2240,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-comparisonoperator",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetNotificationComparisonOperator"
+          }
         },
         "NotificationType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-notificationtype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetNotificationNotificationType"
+          }
         },
         "Threshold": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-threshold",
@@ -2252,7 +2264,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-thresholdtype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetNotificationThresholdType"
+          }
         }
       }
     },
@@ -2304,7 +2319,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-subscriber.html#cfn-budgets-budget-subscriber-subscriptiontype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetSubscriptionType"
+          }
         }
       }
     },
@@ -27678,6 +27696,47 @@
           "AvailabilityZones"
         ]
       }
+    },
+    "BudgetDataBudgetType": {
+      "AllowedValues": [
+        "COST",
+        "RI_COVERAGE",
+        "RI_UTILIZATION",
+        "USAGE"
+      ]
+    },
+    "BudgetDataTimeUnit": {
+      "AllowedValues": [
+        "ANNUALLY",
+        "DAILY",
+        "MONTHLY",
+        "QUARTERLY"
+      ]
+    },
+    "BudgetNotificationComparisonOperator": {
+      "AllowedValues": [
+        "EQUAL_TO",
+        "GREATER_THAN",
+        "LESS_THAN"
+      ]
+    },
+    "BudgetNotificationNotificationType": {
+      "AllowedValues": [
+        "ACTUAL",
+        "FORECASTED"
+      ]
+    },
+    "BudgetNotificationThresholdType": {
+      "AllowedValues": [
+        "ABSOLUTE_VALUE",
+        "PERCENTAGE"
+      ]
+    },
+    "BudgetSubscriptionType": {
+      "AllowedValues": [
+        "EMAIL",
+        "SNS"
+      ]
     },
     "CodeDeployApplicationPlatform": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/eu-west-3.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-3.json
@@ -24579,6 +24579,47 @@
         ]
       }
     },
+    "BudgetDataBudgetType": {
+      "AllowedValues": [
+        "COST",
+        "RI_COVERAGE",
+        "RI_UTILIZATION",
+        "USAGE"
+      ]
+    },
+    "BudgetDataTimeUnit": {
+      "AllowedValues": [
+        "ANNUALLY",
+        "DAILY",
+        "MONTHLY",
+        "QUARTERLY"
+      ]
+    },
+    "BudgetNotificationComparisonOperator": {
+      "AllowedValues": [
+        "EQUAL_TO",
+        "GREATER_THAN",
+        "LESS_THAN"
+      ]
+    },
+    "BudgetNotificationNotificationType": {
+      "AllowedValues": [
+        "ACTUAL",
+        "FORECASTED"
+      ]
+    },
+    "BudgetNotificationThresholdType": {
+      "AllowedValues": [
+        "ABSOLUTE_VALUE",
+        "PERCENTAGE"
+      ]
+    },
+    "BudgetSubscriptionType": {
+      "AllowedValues": [
+        "EMAIL",
+        "SNS"
+      ]
+    },
     "CodeDeployApplicationPlatform": {
       "AllowedValues": [
         "ECS",

--- a/src/cfnlint/data/CloudSpecs/sa-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/sa-east-1.json
@@ -1797,7 +1797,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-budgetdata.html#cfn-budgets-budget-budgetdata-budgettype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetDataBudgetType"
+          }
         },
         "CostFilters": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-budgetdata.html#cfn-budgets-budget-budgetdata-costfilters",
@@ -1821,7 +1824,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-budgetdata.html#cfn-budgets-budget-budgetdata-timeunit",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetDataTimeUnit"
+          }
         }
       }
     },
@@ -1903,13 +1909,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-comparisonoperator",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetNotificationComparisonOperator"
+          }
         },
         "NotificationType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-notificationtype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetNotificationNotificationType"
+          }
         },
         "Threshold": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-threshold",
@@ -1921,7 +1933,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-thresholdtype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetNotificationThresholdType"
+          }
         }
       }
     },
@@ -1973,7 +1988,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-subscriber.html#cfn-budgets-budget-subscriber-subscriptiontype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetSubscriptionType"
+          }
         }
       }
     },
@@ -25551,6 +25569,47 @@
           "AvailabilityZones"
         ]
       }
+    },
+    "BudgetDataBudgetType": {
+      "AllowedValues": [
+        "COST",
+        "RI_COVERAGE",
+        "RI_UTILIZATION",
+        "USAGE"
+      ]
+    },
+    "BudgetDataTimeUnit": {
+      "AllowedValues": [
+        "ANNUALLY",
+        "DAILY",
+        "MONTHLY",
+        "QUARTERLY"
+      ]
+    },
+    "BudgetNotificationComparisonOperator": {
+      "AllowedValues": [
+        "EQUAL_TO",
+        "GREATER_THAN",
+        "LESS_THAN"
+      ]
+    },
+    "BudgetNotificationNotificationType": {
+      "AllowedValues": [
+        "ACTUAL",
+        "FORECASTED"
+      ]
+    },
+    "BudgetNotificationThresholdType": {
+      "AllowedValues": [
+        "ABSOLUTE_VALUE",
+        "PERCENTAGE"
+      ]
+    },
+    "BudgetSubscriptionType": {
+      "AllowedValues": [
+        "EMAIL",
+        "SNS"
+      ]
     },
     "CodeDeployApplicationPlatform": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/us-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-1.json
@@ -2665,7 +2665,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-budgetdata.html#cfn-budgets-budget-budgetdata-budgettype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetDataBudgetType"
+          }
         },
         "CostFilters": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-budgetdata.html#cfn-budgets-budget-budgetdata-costfilters",
@@ -2689,7 +2692,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-budgetdata.html#cfn-budgets-budget-budgetdata-timeunit",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetDataTimeUnit"
+          }
         }
       }
     },
@@ -2771,13 +2777,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-comparisonoperator",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetNotificationComparisonOperator"
+          }
         },
         "NotificationType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-notificationtype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetNotificationNotificationType"
+          }
         },
         "Threshold": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-threshold",
@@ -2789,7 +2801,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-thresholdtype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetNotificationThresholdType"
+          }
         }
       }
     },
@@ -2841,7 +2856,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-subscriber.html#cfn-budgets-budget-subscriber-subscriptiontype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetSubscriptionType"
+          }
         }
       }
     },
@@ -33989,6 +34007,47 @@
           "AvailabilityZones"
         ]
       }
+    },
+    "BudgetDataBudgetType": {
+      "AllowedValues": [
+        "COST",
+        "RI_COVERAGE",
+        "RI_UTILIZATION",
+        "USAGE"
+      ]
+    },
+    "BudgetDataTimeUnit": {
+      "AllowedValues": [
+        "ANNUALLY",
+        "DAILY",
+        "MONTHLY",
+        "QUARTERLY"
+      ]
+    },
+    "BudgetNotificationComparisonOperator": {
+      "AllowedValues": [
+        "EQUAL_TO",
+        "GREATER_THAN",
+        "LESS_THAN"
+      ]
+    },
+    "BudgetNotificationNotificationType": {
+      "AllowedValues": [
+        "ACTUAL",
+        "FORECASTED"
+      ]
+    },
+    "BudgetNotificationThresholdType": {
+      "AllowedValues": [
+        "ABSOLUTE_VALUE",
+        "PERCENTAGE"
+      ]
+    },
+    "BudgetSubscriptionType": {
+      "AllowedValues": [
+        "EMAIL",
+        "SNS"
+      ]
     },
     "CodeDeployApplicationPlatform": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/us-east-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-2.json
@@ -2507,7 +2507,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-budgetdata.html#cfn-budgets-budget-budgetdata-budgettype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetDataBudgetType"
+          }
         },
         "CostFilters": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-budgetdata.html#cfn-budgets-budget-budgetdata-costfilters",
@@ -2531,7 +2534,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-budgetdata.html#cfn-budgets-budget-budgetdata-timeunit",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetDataTimeUnit"
+          }
         }
       }
     },
@@ -2613,13 +2619,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-comparisonoperator",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetNotificationComparisonOperator"
+          }
         },
         "NotificationType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-notificationtype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetNotificationNotificationType"
+          }
         },
         "Threshold": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-threshold",
@@ -2631,7 +2643,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-thresholdtype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetNotificationThresholdType"
+          }
         }
       }
     },
@@ -2683,7 +2698,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-subscriber.html#cfn-budgets-budget-subscriber-subscriptiontype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetSubscriptionType"
+          }
         }
       }
     },
@@ -32002,6 +32020,47 @@
           "AvailabilityZones"
         ]
       }
+    },
+    "BudgetDataBudgetType": {
+      "AllowedValues": [
+        "COST",
+        "RI_COVERAGE",
+        "RI_UTILIZATION",
+        "USAGE"
+      ]
+    },
+    "BudgetDataTimeUnit": {
+      "AllowedValues": [
+        "ANNUALLY",
+        "DAILY",
+        "MONTHLY",
+        "QUARTERLY"
+      ]
+    },
+    "BudgetNotificationComparisonOperator": {
+      "AllowedValues": [
+        "EQUAL_TO",
+        "GREATER_THAN",
+        "LESS_THAN"
+      ]
+    },
+    "BudgetNotificationNotificationType": {
+      "AllowedValues": [
+        "ACTUAL",
+        "FORECASTED"
+      ]
+    },
+    "BudgetNotificationThresholdType": {
+      "AllowedValues": [
+        "ABSOLUTE_VALUE",
+        "PERCENTAGE"
+      ]
+    },
+    "BudgetSubscriptionType": {
+      "AllowedValues": [
+        "EMAIL",
+        "SNS"
+      ]
     },
     "CodeDeployApplicationPlatform": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
@@ -20748,6 +20748,47 @@
         ]
       }
     },
+    "BudgetDataBudgetType": {
+      "AllowedValues": [
+        "COST",
+        "RI_COVERAGE",
+        "RI_UTILIZATION",
+        "USAGE"
+      ]
+    },
+    "BudgetDataTimeUnit": {
+      "AllowedValues": [
+        "ANNUALLY",
+        "DAILY",
+        "MONTHLY",
+        "QUARTERLY"
+      ]
+    },
+    "BudgetNotificationComparisonOperator": {
+      "AllowedValues": [
+        "EQUAL_TO",
+        "GREATER_THAN",
+        "LESS_THAN"
+      ]
+    },
+    "BudgetNotificationNotificationType": {
+      "AllowedValues": [
+        "ACTUAL",
+        "FORECASTED"
+      ]
+    },
+    "BudgetNotificationThresholdType": {
+      "AllowedValues": [
+        "ABSOLUTE_VALUE",
+        "PERCENTAGE"
+      ]
+    },
+    "BudgetSubscriptionType": {
+      "AllowedValues": [
+        "EMAIL",
+        "SNS"
+      ]
+    },
     "CodeDeployApplicationPlatform": {
       "AllowedValues": [
         "ECS",

--- a/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
@@ -20965,6 +20965,47 @@
         ]
       }
     },
+    "BudgetDataBudgetType": {
+      "AllowedValues": [
+        "COST",
+        "RI_COVERAGE",
+        "RI_UTILIZATION",
+        "USAGE"
+      ]
+    },
+    "BudgetDataTimeUnit": {
+      "AllowedValues": [
+        "ANNUALLY",
+        "DAILY",
+        "MONTHLY",
+        "QUARTERLY"
+      ]
+    },
+    "BudgetNotificationComparisonOperator": {
+      "AllowedValues": [
+        "EQUAL_TO",
+        "GREATER_THAN",
+        "LESS_THAN"
+      ]
+    },
+    "BudgetNotificationNotificationType": {
+      "AllowedValues": [
+        "ACTUAL",
+        "FORECASTED"
+      ]
+    },
+    "BudgetNotificationThresholdType": {
+      "AllowedValues": [
+        "ABSOLUTE_VALUE",
+        "PERCENTAGE"
+      ]
+    },
+    "BudgetSubscriptionType": {
+      "AllowedValues": [
+        "EMAIL",
+        "SNS"
+      ]
+    },
     "CodeDeployApplicationPlatform": {
       "AllowedValues": [
         "ECS",

--- a/src/cfnlint/data/CloudSpecs/us-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-1.json
@@ -2249,7 +2249,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-budgetdata.html#cfn-budgets-budget-budgetdata-budgettype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetDataBudgetType"
+          }
         },
         "CostFilters": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-budgetdata.html#cfn-budgets-budget-budgetdata-costfilters",
@@ -2273,7 +2276,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-budgetdata.html#cfn-budgets-budget-budgetdata-timeunit",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetDataTimeUnit"
+          }
         }
       }
     },
@@ -2355,13 +2361,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-comparisonoperator",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetNotificationComparisonOperator"
+          }
         },
         "NotificationType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-notificationtype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetNotificationNotificationType"
+          }
         },
         "Threshold": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-threshold",
@@ -2373,7 +2385,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-thresholdtype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetNotificationThresholdType"
+          }
         }
       }
     },
@@ -2425,7 +2440,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-subscriber.html#cfn-budgets-budget-subscriber-subscriptiontype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetSubscriptionType"
+          }
         }
       }
     },
@@ -27011,6 +27029,47 @@
           "AvailabilityZones"
         ]
       }
+    },
+    "BudgetDataBudgetType": {
+      "AllowedValues": [
+        "COST",
+        "RI_COVERAGE",
+        "RI_UTILIZATION",
+        "USAGE"
+      ]
+    },
+    "BudgetDataTimeUnit": {
+      "AllowedValues": [
+        "ANNUALLY",
+        "DAILY",
+        "MONTHLY",
+        "QUARTERLY"
+      ]
+    },
+    "BudgetNotificationComparisonOperator": {
+      "AllowedValues": [
+        "EQUAL_TO",
+        "GREATER_THAN",
+        "LESS_THAN"
+      ]
+    },
+    "BudgetNotificationNotificationType": {
+      "AllowedValues": [
+        "ACTUAL",
+        "FORECASTED"
+      ]
+    },
+    "BudgetNotificationThresholdType": {
+      "AllowedValues": [
+        "ABSOLUTE_VALUE",
+        "PERCENTAGE"
+      ]
+    },
+    "BudgetSubscriptionType": {
+      "AllowedValues": [
+        "EMAIL",
+        "SNS"
+      ]
     },
     "CodeDeployApplicationPlatform": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/us-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-2.json
@@ -2665,7 +2665,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-budgetdata.html#cfn-budgets-budget-budgetdata-budgettype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetDataBudgetType"
+          }
         },
         "CostFilters": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-budgetdata.html#cfn-budgets-budget-budgetdata-costfilters",
@@ -2689,7 +2692,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-budgetdata.html#cfn-budgets-budget-budgetdata-timeunit",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetDataTimeUnit"
+          }
         }
       }
     },
@@ -2771,13 +2777,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-comparisonoperator",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetNotificationComparisonOperator"
+          }
         },
         "NotificationType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-notificationtype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetNotificationNotificationType"
+          }
         },
         "Threshold": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-threshold",
@@ -2789,7 +2801,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-thresholdtype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetNotificationThresholdType"
+          }
         }
       }
     },
@@ -2841,7 +2856,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-subscriber.html#cfn-budgets-budget-subscriber-subscriptiontype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetSubscriptionType"
+          }
         }
       }
     },
@@ -34019,6 +34037,47 @@
           "AvailabilityZones"
         ]
       }
+    },
+    "BudgetDataBudgetType": {
+      "AllowedValues": [
+        "COST",
+        "RI_COVERAGE",
+        "RI_UTILIZATION",
+        "USAGE"
+      ]
+    },
+    "BudgetDataTimeUnit": {
+      "AllowedValues": [
+        "ANNUALLY",
+        "DAILY",
+        "MONTHLY",
+        "QUARTERLY"
+      ]
+    },
+    "BudgetNotificationComparisonOperator": {
+      "AllowedValues": [
+        "EQUAL_TO",
+        "GREATER_THAN",
+        "LESS_THAN"
+      ]
+    },
+    "BudgetNotificationNotificationType": {
+      "AllowedValues": [
+        "ACTUAL",
+        "FORECASTED"
+      ]
+    },
+    "BudgetNotificationThresholdType": {
+      "AllowedValues": [
+        "ABSOLUTE_VALUE",
+        "PERCENTAGE"
+      ]
+    },
+    "BudgetSubscriptionType": {
+      "AllowedValues": [
+        "EMAIL",
+        "SNS"
+      ]
     },
     "CodeDeployApplicationPlatform": {
       "AllowedValues": [

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
@@ -189,6 +189,47 @@
           "TargetTrackingScaling"
         ]
       },
+      "BudgetDataBudgetType": {
+        "AllowedValues": [
+          "COST",
+          "RI_COVERAGE",
+          "RI_UTILIZATION",
+          "USAGE"
+        ]
+      },
+      "BudgetDataTimeUnit": {
+        "AllowedValues": [
+          "ANNUALLY",
+          "DAILY",
+          "MONTHLY",
+          "QUARTERLY"
+        ]
+      },
+      "BudgetNotificationComparisonOperator": {
+        "AllowedValues": [
+          "EQUAL_TO",
+          "GREATER_THAN",
+          "LESS_THAN"
+        ]
+      },
+      "BudgetNotificationNotificationType": {
+        "AllowedValues": [
+          "ACTUAL",
+          "FORECASTED"
+        ]
+      },
+      "BudgetNotificationThresholdType": {
+        "AllowedValues": [
+          "ABSOLUTE_VALUE",
+          "PERCENTAGE"
+        ]
+      },
+      "BudgetSubscriptionType": {
+        "AllowedValues": [
+          "EMAIL",
+          "SNS"
+        ]
+      },
       "CodeDeployApplicationPlatform": {
         "AllowedValues": [
           "ECS",

--- a/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
@@ -99,6 +99,48 @@
   },
   {
     "op": "add",
+    "path": "/PropertyTypes/AWS::Budgets::Budget.BudgetData/Properties/BudgetType/Value",
+    "value": {
+      "ValueType": "BudgetDataBudgetType"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/PropertyTypes/AWS::Budgets::Budget.BudgetData/Properties/TimeUnit/Value",
+    "value": {
+      "ValueType": "BudgetDataTimeUnit"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/PropertyTypes/AWS::Budgets::Budget.Notification/Properties/ComparisonOperator/Value",
+    "value": {
+      "ValueType": "BudgetNotificationComparisonOperator"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/PropertyTypes/AWS::Budgets::Budget.Notification/Properties/NotificationType/Value",
+    "value": {
+      "ValueType": "BudgetNotificationNotificationType"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/PropertyTypes/AWS::Budgets::Budget.Notification/Properties/ThresholdType/Value",
+    "value": {
+      "ValueType": "BudgetNotificationThresholdType"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/PropertyTypes/AWS::Budgets::Budget.Subscriber/Properties/SubscriptionType/Value",
+    "value": {
+      "ValueType": "BudgetSubscriptionType"
+    }
+  },
+  {
+    "op": "add",
     "path": "/PropertyTypes/AWS::EC2::SpotFleet.EbsBlockDevice/Properties/VolumeType/Value",
     "value": {
       "ValueType": "EbsVolumeType"

--- a/test/fixtures/templates/bad/resources/properties/allowed_values.yaml
+++ b/test/fixtures/templates/bad/resources/properties/allowed_values.yaml
@@ -152,6 +152,21 @@ Resources:
               PredefinedScalingMetricSpecification:
                 PredefinedScalingMetricType: "RequestCountPerTarget" # Invalid AllowedValue
               TargetValue: 10.5
+  Budget:
+    Type: "AWS::Budgets::Budget"
+    Properties:
+      Budget:
+        BudgetType: "UTILIZATION" # Invalid AllowedValue
+        TimeUnit: "month" # Invalid AllowedValue
+      NotificationsWithSubscribers:
+        - Subscribers:
+          - SubscriptionType: "e-mail" # Invalid AllowedValue
+            Address: "test@test.com"
+          Notification:
+            ThresholdType: "ACTUAL" # Invalid AllowedValue
+            Threshold: 80
+            NotificationType: "FORECAST" # Invalid AllowedValue
+            ComparisonOperator: "GREATER" # Invalid AllowedValue
   CodeDeployApplication:
     Type: AWS::CodeDeploy::Application
     Properties:

--- a/test/fixtures/templates/good/resources/properties/allowed_values.yaml
+++ b/test/fixtures/templates/good/resources/properties/allowed_values.yaml
@@ -152,6 +152,21 @@ Resources:
               PredefinedScalingMetricSpecification:
                 PredefinedScalingMetricType: "ALBRequestCountPerTarget" # Valid AllowedValue
               TargetValue: 10.5
+  Budget:
+    Type: "AWS::Budgets::Budget"
+    Properties:
+      Budget:
+        BudgetType: "RI_UTILIZATION" # Valid AllowedValue
+        TimeUnit: "MONTHLY" # Valid AllowedValue
+      NotificationsWithSubscribers:
+        - Subscribers:
+          - SubscriptionType: "EMAIL" #Valid AllowedValue
+            Address: "test@test.com"
+          Notification:
+            ThresholdType: "PERCENTAGE" # Valid AllowedValue
+            Threshold: 80
+            NotificationType: "ACTUAL" # Valid AllowedValue
+            ComparisonOperator: "GREATER_THAN" # Valid AllowedValue
   CodeDeployApplication:
     Type: "AWS::CodeDeploy::Application"
     Properties:

--- a/test/rules/resources/properties/test_allowed_value.py
+++ b/test/rules/resources/properties/test_allowed_value.py
@@ -34,4 +34,4 @@ class TestAllowedValue(BaseRuleTestCase):
 
     def test_file_negative(self):
         """Test failure"""
-        self.helper_file_negative('test/fixtures/templates/bad/resources/properties/allowed_values.yaml', 66)
+        self.helper_file_negative('test/fixtures/templates/bad/resources/properties/allowed_values.yaml', 72)


### PR DESCRIPTION
*Issue https://github.com/awslabs/cfn-python-lint/issues/50, if available:*

Add the allowed values of the [`AWS::Budgets` resources](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-reference-budgets.html)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
