### PR TITLE
Add Certificate Manager Allowed Values

### DIFF
--- a/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
@@ -19385,7 +19385,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-certificatemanager-certificate.html#cfn-certificatemanager-certificate-validationmethod",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CertificateValidationMethod"
+          }
         }
       }
     },
@@ -31716,6 +31719,12 @@
       "AllowedValues": [
         "EMAIL",
         "SNS"
+      ]
+    },
+    "CertificateValidationMethod": {
+      "AllowedValues": [
+        "DNS",
+        "EMAIL"
       ]
     },
     "CodeDeployApplicationPlatform": {

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
@@ -17721,7 +17721,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-certificatemanager-certificate.html#cfn-certificatemanager-certificate-validationmethod",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CertificateValidationMethod"
+          }
         }
       }
     },
@@ -29235,6 +29238,12 @@
       "AllowedValues": [
         "EMAIL",
         "SNS"
+      ]
+    },
+    "CertificateValidationMethod": {
+      "AllowedValues": [
+        "DNS",
+        "EMAIL"
       ]
     },
     "CodeDeployApplicationPlatform": {

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
@@ -12504,7 +12504,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-certificatemanager-certificate.html#cfn-certificatemanager-certificate-validationmethod",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CertificateValidationMethod"
+          }
         }
       }
     },
@@ -21012,6 +21015,12 @@
       "AllowedValues": [
         "EMAIL",
         "SNS"
+      ]
+    },
+    "CertificateValidationMethod": {
+      "AllowedValues": [
+        "DNS",
+        "EMAIL"
       ]
     },
     "CodeDeployApplicationPlatform": {

--- a/src/cfnlint/data/CloudSpecs/ap-south-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-south-1.json
@@ -16945,7 +16945,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-certificatemanager-certificate.html#cfn-certificatemanager-certificate-validationmethod",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CertificateValidationMethod"
+          }
         }
       }
     },
@@ -28075,6 +28078,12 @@
       "AllowedValues": [
         "EMAIL",
         "SNS"
+      ]
+    },
+    "CertificateValidationMethod": {
+      "AllowedValues": [
+        "DNS",
+        "EMAIL"
       ]
     },
     "CodeDeployApplicationPlatform": {

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
@@ -17912,7 +17912,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-certificatemanager-certificate.html#cfn-certificatemanager-certificate-validationmethod",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CertificateValidationMethod"
+          }
         }
       }
     },
@@ -29233,6 +29236,12 @@
       "AllowedValues": [
         "EMAIL",
         "SNS"
+      ]
+    },
+    "CertificateValidationMethod": {
+      "AllowedValues": [
+        "DNS",
+        "EMAIL"
       ]
     },
     "CodeDeployApplicationPlatform": {

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
@@ -18508,7 +18508,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-certificatemanager-certificate.html#cfn-certificatemanager-certificate-validationmethod",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CertificateValidationMethod"
+          }
         }
       }
     },
@@ -30111,6 +30114,12 @@
       "AllowedValues": [
         "EMAIL",
         "SNS"
+      ]
+    },
+    "CertificateValidationMethod": {
+      "AllowedValues": [
+        "DNS",
+        "EMAIL"
       ]
     },
     "CodeDeployApplicationPlatform": {

--- a/src/cfnlint/data/CloudSpecs/ca-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/ca-central-1.json
@@ -15771,7 +15771,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-certificatemanager-certificate.html#cfn-certificatemanager-certificate-validationmethod",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CertificateValidationMethod"
+          }
         }
       }
     },
@@ -26435,6 +26438,12 @@
       "AllowedValues": [
         "EMAIL",
         "SNS"
+      ]
+    },
+    "CertificateValidationMethod": {
+      "AllowedValues": [
+        "DNS",
+        "EMAIL"
       ]
     },
     "CodeDeployApplicationPlatform": {

--- a/src/cfnlint/data/CloudSpecs/eu-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-central-1.json
@@ -18930,7 +18930,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-certificatemanager-certificate.html#cfn-certificatemanager-certificate-validationmethod",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CertificateValidationMethod"
+          }
         }
       }
     },
@@ -30916,6 +30919,12 @@
       "AllowedValues": [
         "EMAIL",
         "SNS"
+      ]
+    },
+    "CertificateValidationMethod": {
+      "AllowedValues": [
+        "DNS",
+        "EMAIL"
       ]
     },
     "CodeDeployApplicationPlatform": {

--- a/src/cfnlint/data/CloudSpecs/eu-north-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-north-1.json
@@ -12505,7 +12505,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-certificatemanager-certificate.html#cfn-certificatemanager-certificate-validationmethod",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CertificateValidationMethod"
+          }
         }
       }
     },
@@ -21428,6 +21431,12 @@
       "AllowedValues": [
         "EMAIL",
         "SNS"
+      ]
+    },
+    "CertificateValidationMethod": {
+      "AllowedValues": [
+        "DNS",
+        "EMAIL"
       ]
     },
     "CodeDeployApplicationPlatform": {

--- a/src/cfnlint/data/CloudSpecs/eu-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-1.json
@@ -20707,7 +20707,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-certificatemanager-certificate.html#cfn-certificatemanager-certificate-validationmethod",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CertificateValidationMethod"
+          }
         }
       }
     },
@@ -34018,6 +34021,12 @@
       "AllowedValues": [
         "EMAIL",
         "SNS"
+      ]
+    },
+    "CertificateValidationMethod": {
+      "AllowedValues": [
+        "DNS",
+        "EMAIL"
       ]
     },
     "CodeDeployApplicationPlatform": {

--- a/src/cfnlint/data/CloudSpecs/eu-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-2.json
@@ -16303,7 +16303,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-certificatemanager-certificate.html#cfn-certificatemanager-certificate-validationmethod",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CertificateValidationMethod"
+          }
         }
       }
     },
@@ -27736,6 +27739,12 @@
       "AllowedValues": [
         "EMAIL",
         "SNS"
+      ]
+    },
+    "CertificateValidationMethod": {
+      "AllowedValues": [
+        "DNS",
+        "EMAIL"
       ]
     },
     "CodeDeployApplicationPlatform": {

--- a/src/cfnlint/data/CloudSpecs/eu-west-3.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-3.json
@@ -14727,7 +14727,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-certificatemanager-certificate.html#cfn-certificatemanager-certificate-validationmethod",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CertificateValidationMethod"
+          }
         }
       }
     },
@@ -24618,6 +24621,12 @@
       "AllowedValues": [
         "EMAIL",
         "SNS"
+      ]
+    },
+    "CertificateValidationMethod": {
+      "AllowedValues": [
+        "DNS",
+        "EMAIL"
       ]
     },
     "CodeDeployApplicationPlatform": {

--- a/src/cfnlint/data/CloudSpecs/sa-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/sa-east-1.json
@@ -15308,7 +15308,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-certificatemanager-certificate.html#cfn-certificatemanager-certificate-validationmethod",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CertificateValidationMethod"
+          }
         }
       }
     },
@@ -25609,6 +25612,12 @@
       "AllowedValues": [
         "EMAIL",
         "SNS"
+      ]
+    },
+    "CertificateValidationMethod": {
+      "AllowedValues": [
+        "DNS",
+        "EMAIL"
       ]
     },
     "CodeDeployApplicationPlatform": {

--- a/src/cfnlint/data/CloudSpecs/us-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-1.json
@@ -20708,7 +20708,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-certificatemanager-certificate.html#cfn-certificatemanager-certificate-validationmethod",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CertificateValidationMethod"
+          }
         }
       }
     },
@@ -34047,6 +34050,12 @@
       "AllowedValues": [
         "EMAIL",
         "SNS"
+      ]
+    },
+    "CertificateValidationMethod": {
+      "AllowedValues": [
+        "DNS",
+        "EMAIL"
       ]
     },
     "CodeDeployApplicationPlatform": {

--- a/src/cfnlint/data/CloudSpecs/us-east-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-2.json
@@ -19263,7 +19263,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-certificatemanager-certificate.html#cfn-certificatemanager-certificate-validationmethod",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CertificateValidationMethod"
+          }
         }
       }
     },
@@ -32060,6 +32063,12 @@
       "AllowedValues": [
         "EMAIL",
         "SNS"
+      ]
+    },
+    "CertificateValidationMethod": {
+      "AllowedValues": [
+        "DNS",
+        "EMAIL"
       ]
     },
     "CodeDeployApplicationPlatform": {

--- a/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
@@ -12324,7 +12324,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-certificatemanager-certificate.html#cfn-certificatemanager-certificate-validationmethod",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CertificateValidationMethod"
+          }
         }
       }
     },
@@ -20787,6 +20790,12 @@
       "AllowedValues": [
         "EMAIL",
         "SNS"
+      ]
+    },
+    "CertificateValidationMethod": {
+      "AllowedValues": [
+        "DNS",
+        "EMAIL"
       ]
     },
     "CodeDeployApplicationPlatform": {

--- a/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
@@ -12394,7 +12394,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-certificatemanager-certificate.html#cfn-certificatemanager-certificate-validationmethod",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CertificateValidationMethod"
+          }
         }
       }
     },
@@ -21004,6 +21007,12 @@
       "AllowedValues": [
         "EMAIL",
         "SNS"
+      ]
+    },
+    "CertificateValidationMethod": {
+      "AllowedValues": [
+        "DNS",
+        "EMAIL"
       ]
     },
     "CodeDeployApplicationPlatform": {

--- a/src/cfnlint/data/CloudSpecs/us-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-1.json
@@ -16137,7 +16137,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-certificatemanager-certificate.html#cfn-certificatemanager-certificate-validationmethod",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CertificateValidationMethod"
+          }
         }
       }
     },
@@ -27069,6 +27072,12 @@
       "AllowedValues": [
         "EMAIL",
         "SNS"
+      ]
+    },
+    "CertificateValidationMethod": {
+      "AllowedValues": [
+        "DNS",
+        "EMAIL"
       ]
     },
     "CodeDeployApplicationPlatform": {

--- a/src/cfnlint/data/CloudSpecs/us-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-2.json
@@ -20726,7 +20726,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-certificatemanager-certificate.html#cfn-certificatemanager-certificate-validationmethod",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CertificateValidationMethod"
+          }
         }
       }
     },
@@ -34077,6 +34080,12 @@
       "AllowedValues": [
         "EMAIL",
         "SNS"
+      ]
+    },
+    "CertificateValidationMethod": {
+      "AllowedValues": [
+        "DNS",
+        "EMAIL"
       ]
     },
     "CodeDeployApplicationPlatform": {

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
@@ -230,6 +230,12 @@
           "SNS"
         ]
       },
+      "CertificateValidationMethod": {
+        "AllowedValues": [
+          "DNS",
+          "EMAIL"
+        ]
+      },
       "CodeDeployApplicationPlatform": {
         "AllowedValues": [
           "ECS",

--- a/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
@@ -595,6 +595,13 @@
   },
   {
     "op": "add",
+    "path": "/ResourceTypes/AWS::CertificateManager::Certificate/Properties/ValidationMethod/Value",
+    "value": {
+      "ValueType": "CertificateValidationMethod"
+    }
+  },
+  {
+    "op": "add",
     "path": "/ResourceTypes/AWS::CodeBuild::Project/Properties/ServiceRole/Value",
     "value": {
       "ValueType": "IamRole.Arn"

--- a/test/fixtures/templates/bad/resources/properties/allowed_values.yaml
+++ b/test/fixtures/templates/bad/resources/properties/allowed_values.yaml
@@ -167,6 +167,11 @@ Resources:
             Threshold: 80
             NotificationType: "FORECAST" # Invalid AllowedValue
             ComparisonOperator: "GREATER" # Invalid AllowedValue
+  Certificate:
+    Type: "AWS::CertificateManager::Certificate"
+    Properties:
+      DomainName: "example.com"
+      ValidationMethod: "Dns" # Invalid AllowedValue
   CodeDeployApplication:
     Type: AWS::CodeDeploy::Application
     Properties:

--- a/test/fixtures/templates/good/resources/properties/allowed_values.yaml
+++ b/test/fixtures/templates/good/resources/properties/allowed_values.yaml
@@ -167,6 +167,11 @@ Resources:
             Threshold: 80
             NotificationType: "ACTUAL" # Valid AllowedValue
             ComparisonOperator: "GREATER_THAN" # Valid AllowedValue
+  Certificate:
+    Type: AWS::CertificateManager::Certificate
+    Properties:
+      DomainName: "example.com"
+      ValidationMethod: "DNS" # Valid AllowedValue
   CodeDeployApplication:
     Type: "AWS::CodeDeploy::Application"
     Properties:

--- a/test/rules/resources/properties/test_allowed_value.py
+++ b/test/rules/resources/properties/test_allowed_value.py
@@ -34,4 +34,4 @@ class TestAllowedValue(BaseRuleTestCase):
 
     def test_file_negative(self):
         """Test failure"""
-        self.helper_file_negative('test/fixtures/templates/bad/resources/properties/allowed_values.yaml', 72)
+        self.helper_file_negative('test/fixtures/templates/bad/resources/properties/allowed_values.yaml', 73)


### PR DESCRIPTION
*Issue https://github.com/awslabs/cfn-python-lint/issues/50, if available:*

Added the Allowed Values of all the [`AWS::CertificateManager`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-reference-certificatemanager.html) resources

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
