### PR TITLE
fix indentation in .pre-commit-config.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ repos:
     rev: v0.12.1  # The version of cfn-lint to use
     hooks:
     -   id: cfn-python-lint
-    files: path/to/cfn/dir/.*\.(json|yml|yaml)$
+        files: path/to/cfn/dir/.*\.(json|yml|yaml)$
 ```
 
 * If you exclude the `files:` line above, every json/yml/yaml file will be checked.


### PR DESCRIPTION

*Description of changes:*
The provided `.pre-commit-config.yaml` in the README has incorrect indentation for `files` key. 

Before:
```
$git commit -m  'commit message'
AWSLabs CloudFormation Linter............................................Failed
hookid: cfn-python-lint

E1001 Top level item repos isn't valid
.pre-commit-config.yaml:1:1

E1001 Missing top level item Resources to file module
.pre-commit-config.yaml:1:1
```

After:
```
git commit -m 'intermediate commit'
AWSLabs CloudFormation Linter............................................Passed
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
