### PR TITLE
Allow multiple inputs/outputs to CodeBuild jobs in CodePipeline

### DIFF
--- a/src/cfnlint/rules/resources/codepipeline/CodepipelineStageActions.py
+++ b/src/cfnlint/rules/resources/codepipeline/CodepipelineStageActions.py
@@ -40,12 +40,6 @@ class CodepipelineStageActions(CloudFormationLintRule):
                     'OutputArtifactRange': 1,
                 }
             },
-            'Build': {
-                'CodeBuild': {
-                    'InputArtifactRange': 1,
-                    'OutputArtifactRange': (0, 1),
-                },
-            },
             'Test': {
                 'CodeBuild': {
                     'InputArtifactRange': 1,

--- a/test/fixtures/templates/bad/resources_codepipeline_action_artifact_counts.yaml
+++ b/test/fixtures/templates/bad/resources_codepipeline_action_artifact_counts.yaml
@@ -37,4 +37,23 @@ Resources:
                 ProjectName: cfn-python-lint
               InputArtifacts:
               - Name: MyApp
-              - Name: MyApp2
+              - Name: MyApp2  # No Longer an error
+              OutputArtifacts:
+              - Name: MyOutput1
+              - Name: MyOutput2  # No Longer an error
+        - Name: MyApprovalStage
+          Actions:
+            - Name: MyApprovalAction
+              ActionTypeId:
+                Category: Approval
+                Owner: AWS
+                Version: "1"
+                Provider: Manual
+              InputArtifacts:
+              - Name: MyApp # Error
+              OutputArtifacts:
+              - Name: MyOutput1 # Error
+              Configuration:
+                NotificationArn: arn:aws:sns:us-east-2:80398EXAMPLE:MyApprovalTopic
+                ExternalEntityLink: http://example.com
+                CustomData: The latest changes include feedback from Bob.

--- a/test/rules/resources/codepipeline/test_stageactions.py
+++ b/test/rules/resources/codepipeline/test_stageactions.py
@@ -31,7 +31,7 @@ class TestCodePipelineStageActions(BaseRuleTestCase):
 
     def test_file_artifact_counts(self):
         """Test failure"""
-        self.helper_file_negative('test/fixtures/templates/bad/resources_codepipeline_action_artifact_counts.yaml', 1)
+        self.helper_file_negative('test/fixtures/templates/bad/resources_codepipeline_action_artifact_counts.yaml', 2)
 
     def test_file_invalid_owner(self):
         """Test failure"""


### PR DESCRIPTION
*Issue #, if available:*
Fix #594 
*Description of changes:*
- Fix rule E2541 to not check input/output artifact counts on CodeBuild Actions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
