### PR TITLE
Add CodePipeline Allowed Values

### DIFF
--- a/src/cfnlint/data/AdditionalSpecs/OnlyOne.json
+++ b/src/cfnlint/data/AdditionalSpecs/OnlyOne.json
@@ -46,6 +46,12 @@
         "MixedInstancesPolicy"
       ]
     ],
+    "AWS::CodePipeline::Pipeline": [
+      [
+        "ArtifactStore",
+        "ArtifactStores"
+      ]
+    ],
     "AWS::Route53::RecordSet": [
       [
         "HostedZoneId",

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
@@ -4164,7 +4164,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-customactiontype-configurationproperties.html#cfn-codepipeline-customactiontype-configurationproperties-type",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineActionTypeConfigurationType"
+          }
         }
       }
     },
@@ -4261,13 +4264,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-actions-actiontypeid.html#cfn-codepipeline-pipeline-stages-actions-actiontypeid-category",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineActionTypeCategory"
+          }
         },
         "Owner": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-actions-actiontypeid.html#cfn-codepipeline-pipeline-stages-actions-actiontypeid-owner",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineActionTypeOwner"
+          }
         },
         "Provider": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-actions-actiontypeid.html#cfn-codepipeline-pipeline-stages-actions-actiontypeid-provider",
@@ -4302,7 +4311,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-artifactstore.html#cfn-codepipeline-pipeline-artifactstore-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineArtifactStoreType"
+          }
         }
       }
     },
@@ -4336,7 +4348,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-blockers.html#cfn-codepipeline-pipeline-stages-blockers-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineBlockerType"
+          }
         }
       }
     },
@@ -19972,7 +19987,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-customactiontype.html#cfn-codepipeline-customactiontype-category",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CodePipelineActionType"
+          }
         },
         "ConfigurationProperties": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-customactiontype.html#cfn-codepipeline-customactiontype-configurationproperties",
@@ -20084,7 +20102,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-webhook.html#cfn-codepipeline-webhook-authentication",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineWehbookAuthentication"
+          }
         },
         "AuthenticationConfiguration": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-webhook.html#cfn-codepipeline-webhook-authenticationconfiguration",
@@ -31771,6 +31792,47 @@
         "InstanceReady",
         "InstanceStart",
         "InstanceSuccess"
+      ]
+    },
+    "CodePipelineActionTypeCategory": {
+      "AllowedValues": [
+        "Approval",
+        "Build",
+        "Deploy",
+        "Invoke",
+        "Source",
+        "Test"
+      ]
+    },
+    "CodePipelineActionTypeOwner": {
+      "AllowedValues": [
+        "AWS",
+        "Custom",
+        "ThirdParty"
+      ]
+    },
+    "CodePipelineArtifactStoreType": {
+      "AllowedValues": [
+        "S3"
+      ]
+    },
+    "CodePipelineBlockerType": {
+      "AllowedValues": [
+        "Schedule"
+      ]
+    },
+    "CodePipelineConfigurationPropertiesCategory": {
+      "AllowedValues": [
+        "Boolean",
+        "Number",
+        "String"
+      ]
+    },
+    "CodePipelineWehbookAuthentication": {
+      "AllowedValues": [
+        "GITHUB_HMAC",
+        "IP",
+        "UNAUTHENTICATED"
       ]
     },
     "DmsEndpointEngineName": {

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
@@ -3914,7 +3914,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-customactiontype-configurationproperties.html#cfn-codepipeline-customactiontype-configurationproperties-type",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineActionTypeConfigurationType"
+          }
         }
       }
     },
@@ -4011,13 +4014,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-actions-actiontypeid.html#cfn-codepipeline-pipeline-stages-actions-actiontypeid-category",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineActionTypeCategory"
+          }
         },
         "Owner": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-actions-actiontypeid.html#cfn-codepipeline-pipeline-stages-actions-actiontypeid-owner",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineActionTypeOwner"
+          }
         },
         "Provider": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-actions-actiontypeid.html#cfn-codepipeline-pipeline-stages-actions-actiontypeid-provider",
@@ -4052,7 +4061,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-artifactstore.html#cfn-codepipeline-pipeline-artifactstore-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineArtifactStoreType"
+          }
         }
       }
     },
@@ -4086,7 +4098,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-blockers.html#cfn-codepipeline-pipeline-stages-blockers-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineBlockerType"
+          }
         }
       }
     },
@@ -18308,7 +18323,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-customactiontype.html#cfn-codepipeline-customactiontype-category",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CodePipelineActionType"
+          }
         },
         "ConfigurationProperties": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-customactiontype.html#cfn-codepipeline-customactiontype-configurationproperties",
@@ -18420,7 +18438,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-webhook.html#cfn-codepipeline-webhook-authentication",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineWehbookAuthentication"
+          }
         },
         "AuthenticationConfiguration": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-webhook.html#cfn-codepipeline-webhook-authenticationconfiguration",
@@ -29290,6 +29311,47 @@
         "InstanceReady",
         "InstanceStart",
         "InstanceSuccess"
+      ]
+    },
+    "CodePipelineActionTypeCategory": {
+      "AllowedValues": [
+        "Approval",
+        "Build",
+        "Deploy",
+        "Invoke",
+        "Source",
+        "Test"
+      ]
+    },
+    "CodePipelineActionTypeOwner": {
+      "AllowedValues": [
+        "AWS",
+        "Custom",
+        "ThirdParty"
+      ]
+    },
+    "CodePipelineArtifactStoreType": {
+      "AllowedValues": [
+        "S3"
+      ]
+    },
+    "CodePipelineBlockerType": {
+      "AllowedValues": [
+        "Schedule"
+      ]
+    },
+    "CodePipelineConfigurationPropertiesCategory": {
+      "AllowedValues": [
+        "Boolean",
+        "Number",
+        "String"
+      ]
+    },
+    "CodePipelineWehbookAuthentication": {
+      "AllowedValues": [
+        "GITHUB_HMAC",
+        "IP",
+        "UNAUTHENTICATED"
       ]
     },
     "DmsEndpointEngineName": {

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
@@ -2003,7 +2003,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-customactiontype-configurationproperties.html#cfn-codepipeline-customactiontype-configurationproperties-type",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineActionTypeConfigurationType"
+          }
         }
       }
     },
@@ -2100,13 +2103,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-actions-actiontypeid.html#cfn-codepipeline-pipeline-stages-actions-actiontypeid-category",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineActionTypeCategory"
+          }
         },
         "Owner": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-actions-actiontypeid.html#cfn-codepipeline-pipeline-stages-actions-actiontypeid-owner",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineActionTypeOwner"
+          }
         },
         "Provider": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-actions-actiontypeid.html#cfn-codepipeline-pipeline-stages-actions-actiontypeid-provider",
@@ -2141,7 +2150,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-artifactstore.html#cfn-codepipeline-pipeline-artifactstore-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineArtifactStoreType"
+          }
         }
       }
     },
@@ -2175,7 +2187,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-blockers.html#cfn-codepipeline-pipeline-stages-blockers-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineBlockerType"
+          }
         }
       }
     },
@@ -13012,7 +13027,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-customactiontype.html#cfn-codepipeline-customactiontype-category",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CodePipelineActionType"
+          }
         },
         "ConfigurationProperties": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-customactiontype.html#cfn-codepipeline-customactiontype-configurationproperties",
@@ -21038,6 +21056,47 @@
         "InstanceReady",
         "InstanceStart",
         "InstanceSuccess"
+      ]
+    },
+    "CodePipelineActionTypeCategory": {
+      "AllowedValues": [
+        "Approval",
+        "Build",
+        "Deploy",
+        "Invoke",
+        "Source",
+        "Test"
+      ]
+    },
+    "CodePipelineActionTypeOwner": {
+      "AllowedValues": [
+        "AWS",
+        "Custom",
+        "ThirdParty"
+      ]
+    },
+    "CodePipelineArtifactStoreType": {
+      "AllowedValues": [
+        "S3"
+      ]
+    },
+    "CodePipelineBlockerType": {
+      "AllowedValues": [
+        "Schedule"
+      ]
+    },
+    "CodePipelineConfigurationPropertiesCategory": {
+      "AllowedValues": [
+        "Boolean",
+        "Number",
+        "String"
+      ]
+    },
+    "CodePipelineWehbookAuthentication": {
+      "AllowedValues": [
+        "GITHUB_HMAC",
+        "IP",
+        "UNAUTHENTICATED"
       ]
     },
     "DmsEndpointEngineName": {

--- a/src/cfnlint/data/CloudSpecs/ap-south-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-south-1.json
@@ -3776,7 +3776,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-customactiontype-configurationproperties.html#cfn-codepipeline-customactiontype-configurationproperties-type",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineActionTypeConfigurationType"
+          }
         }
       }
     },
@@ -3873,13 +3876,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-actions-actiontypeid.html#cfn-codepipeline-pipeline-stages-actions-actiontypeid-category",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineActionTypeCategory"
+          }
         },
         "Owner": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-actions-actiontypeid.html#cfn-codepipeline-pipeline-stages-actions-actiontypeid-owner",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineActionTypeOwner"
+          }
         },
         "Provider": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-actions-actiontypeid.html#cfn-codepipeline-pipeline-stages-actions-actiontypeid-provider",
@@ -3914,7 +3923,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-artifactstore.html#cfn-codepipeline-pipeline-artifactstore-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineArtifactStoreType"
+          }
         }
       }
     },
@@ -3948,7 +3960,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-blockers.html#cfn-codepipeline-pipeline-stages-blockers-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineBlockerType"
+          }
         }
       }
     },
@@ -17532,7 +17547,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-customactiontype.html#cfn-codepipeline-customactiontype-category",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CodePipelineActionType"
+          }
         },
         "ConfigurationProperties": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-customactiontype.html#cfn-codepipeline-customactiontype-configurationproperties",
@@ -17644,7 +17662,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-webhook.html#cfn-codepipeline-webhook-authentication",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineWehbookAuthentication"
+          }
         },
         "AuthenticationConfiguration": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-webhook.html#cfn-codepipeline-webhook-authenticationconfiguration",
@@ -28130,6 +28151,47 @@
         "InstanceReady",
         "InstanceStart",
         "InstanceSuccess"
+      ]
+    },
+    "CodePipelineActionTypeCategory": {
+      "AllowedValues": [
+        "Approval",
+        "Build",
+        "Deploy",
+        "Invoke",
+        "Source",
+        "Test"
+      ]
+    },
+    "CodePipelineActionTypeOwner": {
+      "AllowedValues": [
+        "AWS",
+        "Custom",
+        "ThirdParty"
+      ]
+    },
+    "CodePipelineArtifactStoreType": {
+      "AllowedValues": [
+        "S3"
+      ]
+    },
+    "CodePipelineBlockerType": {
+      "AllowedValues": [
+        "Schedule"
+      ]
+    },
+    "CodePipelineConfigurationPropertiesCategory": {
+      "AllowedValues": [
+        "Boolean",
+        "Number",
+        "String"
+      ]
+    },
+    "CodePipelineWehbookAuthentication": {
+      "AllowedValues": [
+        "GITHUB_HMAC",
+        "IP",
+        "UNAUTHENTICATED"
       ]
     },
     "DmsEndpointEngineName": {

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
@@ -4089,7 +4089,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-customactiontype-configurationproperties.html#cfn-codepipeline-customactiontype-configurationproperties-type",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineActionTypeConfigurationType"
+          }
         }
       }
     },
@@ -4186,13 +4189,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-actions-actiontypeid.html#cfn-codepipeline-pipeline-stages-actions-actiontypeid-category",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineActionTypeCategory"
+          }
         },
         "Owner": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-actions-actiontypeid.html#cfn-codepipeline-pipeline-stages-actions-actiontypeid-owner",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineActionTypeOwner"
+          }
         },
         "Provider": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-actions-actiontypeid.html#cfn-codepipeline-pipeline-stages-actions-actiontypeid-provider",
@@ -4227,7 +4236,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-artifactstore.html#cfn-codepipeline-pipeline-artifactstore-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineArtifactStoreType"
+          }
         }
       }
     },
@@ -4261,7 +4273,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-blockers.html#cfn-codepipeline-pipeline-stages-blockers-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineBlockerType"
+          }
         }
       }
     },
@@ -18555,7 +18570,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-customactiontype.html#cfn-codepipeline-customactiontype-category",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CodePipelineActionType"
+          }
         },
         "ConfigurationProperties": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-customactiontype.html#cfn-codepipeline-customactiontype-configurationproperties",
@@ -18667,7 +18685,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-webhook.html#cfn-codepipeline-webhook-authentication",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineWehbookAuthentication"
+          }
         },
         "AuthenticationConfiguration": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-webhook.html#cfn-codepipeline-webhook-authenticationconfiguration",
@@ -29288,6 +29309,47 @@
         "InstanceReady",
         "InstanceStart",
         "InstanceSuccess"
+      ]
+    },
+    "CodePipelineActionTypeCategory": {
+      "AllowedValues": [
+        "Approval",
+        "Build",
+        "Deploy",
+        "Invoke",
+        "Source",
+        "Test"
+      ]
+    },
+    "CodePipelineActionTypeOwner": {
+      "AllowedValues": [
+        "AWS",
+        "Custom",
+        "ThirdParty"
+      ]
+    },
+    "CodePipelineArtifactStoreType": {
+      "AllowedValues": [
+        "S3"
+      ]
+    },
+    "CodePipelineBlockerType": {
+      "AllowedValues": [
+        "Schedule"
+      ]
+    },
+    "CodePipelineConfigurationPropertiesCategory": {
+      "AllowedValues": [
+        "Boolean",
+        "Number",
+        "String"
+      ]
+    },
+    "CodePipelineWehbookAuthentication": {
+      "AllowedValues": [
+        "GITHUB_HMAC",
+        "IP",
+        "UNAUTHENTICATED"
       ]
     },
     "DmsEndpointEngineName": {

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
@@ -4164,7 +4164,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-customactiontype-configurationproperties.html#cfn-codepipeline-customactiontype-configurationproperties-type",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineActionTypeConfigurationType"
+          }
         }
       }
     },
@@ -4261,13 +4264,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-actions-actiontypeid.html#cfn-codepipeline-pipeline-stages-actions-actiontypeid-category",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineActionTypeCategory"
+          }
         },
         "Owner": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-actions-actiontypeid.html#cfn-codepipeline-pipeline-stages-actions-actiontypeid-owner",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineActionTypeOwner"
+          }
         },
         "Provider": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-actions-actiontypeid.html#cfn-codepipeline-pipeline-stages-actions-actiontypeid-provider",
@@ -4302,7 +4311,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-artifactstore.html#cfn-codepipeline-pipeline-artifactstore-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineArtifactStoreType"
+          }
         }
       }
     },
@@ -4336,7 +4348,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-blockers.html#cfn-codepipeline-pipeline-stages-blockers-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineBlockerType"
+          }
         }
       }
     },
@@ -19095,7 +19110,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-customactiontype.html#cfn-codepipeline-customactiontype-category",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CodePipelineActionType"
+          }
         },
         "ConfigurationProperties": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-customactiontype.html#cfn-codepipeline-customactiontype-configurationproperties",
@@ -19207,7 +19225,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-webhook.html#cfn-codepipeline-webhook-authentication",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineWehbookAuthentication"
+          }
         },
         "AuthenticationConfiguration": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-webhook.html#cfn-codepipeline-webhook-authenticationconfiguration",
@@ -30166,6 +30187,47 @@
         "InstanceReady",
         "InstanceStart",
         "InstanceSuccess"
+      ]
+    },
+    "CodePipelineActionTypeCategory": {
+      "AllowedValues": [
+        "Approval",
+        "Build",
+        "Deploy",
+        "Invoke",
+        "Source",
+        "Test"
+      ]
+    },
+    "CodePipelineActionTypeOwner": {
+      "AllowedValues": [
+        "AWS",
+        "Custom",
+        "ThirdParty"
+      ]
+    },
+    "CodePipelineArtifactStoreType": {
+      "AllowedValues": [
+        "S3"
+      ]
+    },
+    "CodePipelineBlockerType": {
+      "AllowedValues": [
+        "Schedule"
+      ]
+    },
+    "CodePipelineConfigurationPropertiesCategory": {
+      "AllowedValues": [
+        "Boolean",
+        "Number",
+        "String"
+      ]
+    },
+    "CodePipelineWehbookAuthentication": {
+      "AllowedValues": [
+        "GITHUB_HMAC",
+        "IP",
+        "UNAUTHENTICATED"
       ]
     },
     "DmsEndpointEngineName": {

--- a/src/cfnlint/data/CloudSpecs/ca-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/ca-central-1.json
@@ -3610,7 +3610,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-customactiontype-configurationproperties.html#cfn-codepipeline-customactiontype-configurationproperties-type",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineActionTypeConfigurationType"
+          }
         }
       }
     },
@@ -3707,13 +3710,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-actions-actiontypeid.html#cfn-codepipeline-pipeline-stages-actions-actiontypeid-category",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineActionTypeCategory"
+          }
         },
         "Owner": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-actions-actiontypeid.html#cfn-codepipeline-pipeline-stages-actions-actiontypeid-owner",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineActionTypeOwner"
+          }
         },
         "Provider": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-actions-actiontypeid.html#cfn-codepipeline-pipeline-stages-actions-actiontypeid-provider",
@@ -3748,7 +3757,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-artifactstore.html#cfn-codepipeline-pipeline-artifactstore-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineArtifactStoreType"
+          }
         }
       }
     },
@@ -3782,7 +3794,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-blockers.html#cfn-codepipeline-pipeline-stages-blockers-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineBlockerType"
+          }
         }
       }
     },
@@ -16358,7 +16373,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-customactiontype.html#cfn-codepipeline-customactiontype-category",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CodePipelineActionType"
+          }
         },
         "ConfigurationProperties": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-customactiontype.html#cfn-codepipeline-customactiontype-configurationproperties",
@@ -16470,7 +16488,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-webhook.html#cfn-codepipeline-webhook-authentication",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineWehbookAuthentication"
+          }
         },
         "AuthenticationConfiguration": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-webhook.html#cfn-codepipeline-webhook-authenticationconfiguration",
@@ -26490,6 +26511,47 @@
         "InstanceReady",
         "InstanceStart",
         "InstanceSuccess"
+      ]
+    },
+    "CodePipelineActionTypeCategory": {
+      "AllowedValues": [
+        "Approval",
+        "Build",
+        "Deploy",
+        "Invoke",
+        "Source",
+        "Test"
+      ]
+    },
+    "CodePipelineActionTypeOwner": {
+      "AllowedValues": [
+        "AWS",
+        "Custom",
+        "ThirdParty"
+      ]
+    },
+    "CodePipelineArtifactStoreType": {
+      "AllowedValues": [
+        "S3"
+      ]
+    },
+    "CodePipelineBlockerType": {
+      "AllowedValues": [
+        "Schedule"
+      ]
+    },
+    "CodePipelineConfigurationPropertiesCategory": {
+      "AllowedValues": [
+        "Boolean",
+        "Number",
+        "String"
+      ]
+    },
+    "CodePipelineWehbookAuthentication": {
+      "AllowedValues": [
+        "GITHUB_HMAC",
+        "IP",
+        "UNAUTHENTICATED"
       ]
     },
     "DmsEndpointEngineName": {

--- a/src/cfnlint/data/CloudSpecs/eu-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-central-1.json
@@ -4089,7 +4089,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-customactiontype-configurationproperties.html#cfn-codepipeline-customactiontype-configurationproperties-type",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineActionTypeConfigurationType"
+          }
         }
       }
     },
@@ -4186,13 +4189,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-actions-actiontypeid.html#cfn-codepipeline-pipeline-stages-actions-actiontypeid-category",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineActionTypeCategory"
+          }
         },
         "Owner": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-actions-actiontypeid.html#cfn-codepipeline-pipeline-stages-actions-actiontypeid-owner",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineActionTypeOwner"
+          }
         },
         "Provider": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-actions-actiontypeid.html#cfn-codepipeline-pipeline-stages-actions-actiontypeid-provider",
@@ -4227,7 +4236,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-artifactstore.html#cfn-codepipeline-pipeline-artifactstore-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineArtifactStoreType"
+          }
         }
       }
     },
@@ -4261,7 +4273,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-blockers.html#cfn-codepipeline-pipeline-stages-blockers-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineBlockerType"
+          }
         }
       }
     },
@@ -19517,7 +19532,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-customactiontype.html#cfn-codepipeline-customactiontype-category",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CodePipelineActionType"
+          }
         },
         "ConfigurationProperties": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-customactiontype.html#cfn-codepipeline-customactiontype-configurationproperties",
@@ -19629,7 +19647,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-webhook.html#cfn-codepipeline-webhook-authentication",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineWehbookAuthentication"
+          }
         },
         "AuthenticationConfiguration": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-webhook.html#cfn-codepipeline-webhook-authenticationconfiguration",
@@ -30971,6 +30992,47 @@
         "InstanceReady",
         "InstanceStart",
         "InstanceSuccess"
+      ]
+    },
+    "CodePipelineActionTypeCategory": {
+      "AllowedValues": [
+        "Approval",
+        "Build",
+        "Deploy",
+        "Invoke",
+        "Source",
+        "Test"
+      ]
+    },
+    "CodePipelineActionTypeOwner": {
+      "AllowedValues": [
+        "AWS",
+        "Custom",
+        "ThirdParty"
+      ]
+    },
+    "CodePipelineArtifactStoreType": {
+      "AllowedValues": [
+        "S3"
+      ]
+    },
+    "CodePipelineBlockerType": {
+      "AllowedValues": [
+        "Schedule"
+      ]
+    },
+    "CodePipelineConfigurationPropertiesCategory": {
+      "AllowedValues": [
+        "Boolean",
+        "Number",
+        "String"
+      ]
+    },
+    "CodePipelineWehbookAuthentication": {
+      "AllowedValues": [
+        "GITHUB_HMAC",
+        "IP",
+        "UNAUTHENTICATED"
       ]
     },
     "DmsEndpointEngineName": {

--- a/src/cfnlint/data/CloudSpecs/eu-north-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-north-1.json
@@ -2003,7 +2003,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-customactiontype-configurationproperties.html#cfn-codepipeline-customactiontype-configurationproperties-type",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineActionTypeConfigurationType"
+          }
         }
       }
     },
@@ -2100,13 +2103,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-actions-actiontypeid.html#cfn-codepipeline-pipeline-stages-actions-actiontypeid-category",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineActionTypeCategory"
+          }
         },
         "Owner": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-actions-actiontypeid.html#cfn-codepipeline-pipeline-stages-actions-actiontypeid-owner",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineActionTypeOwner"
+          }
         },
         "Provider": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-actions-actiontypeid.html#cfn-codepipeline-pipeline-stages-actions-actiontypeid-provider",
@@ -2141,7 +2150,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-artifactstore.html#cfn-codepipeline-pipeline-artifactstore-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineArtifactStoreType"
+          }
         }
       }
     },
@@ -2175,7 +2187,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-blockers.html#cfn-codepipeline-pipeline-stages-blockers-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineBlockerType"
+          }
         }
       }
     },
@@ -13030,7 +13045,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-customactiontype.html#cfn-codepipeline-customactiontype-category",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CodePipelineActionType"
+          }
         },
         "ConfigurationProperties": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-customactiontype.html#cfn-codepipeline-customactiontype-configurationproperties",
@@ -21470,6 +21488,47 @@
         "InstanceReady",
         "InstanceStart",
         "InstanceSuccess"
+      ]
+    },
+    "CodePipelineActionTypeCategory": {
+      "AllowedValues": [
+        "Approval",
+        "Build",
+        "Deploy",
+        "Invoke",
+        "Source",
+        "Test"
+      ]
+    },
+    "CodePipelineActionTypeOwner": {
+      "AllowedValues": [
+        "AWS",
+        "Custom",
+        "ThirdParty"
+      ]
+    },
+    "CodePipelineArtifactStoreType": {
+      "AllowedValues": [
+        "S3"
+      ]
+    },
+    "CodePipelineBlockerType": {
+      "AllowedValues": [
+        "Schedule"
+      ]
+    },
+    "CodePipelineConfigurationPropertiesCategory": {
+      "AllowedValues": [
+        "Boolean",
+        "Number",
+        "String"
+      ]
+    },
+    "CodePipelineWehbookAuthentication": {
+      "AllowedValues": [
+        "GITHUB_HMAC",
+        "IP",
+        "UNAUTHENTICATED"
       ]
     },
     "DmsEndpointEngineName": {

--- a/src/cfnlint/data/CloudSpecs/eu-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-1.json
@@ -4525,7 +4525,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-customactiontype-configurationproperties.html#cfn-codepipeline-customactiontype-configurationproperties-type",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineActionTypeConfigurationType"
+          }
         }
       }
     },
@@ -4622,13 +4625,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-actions-actiontypeid.html#cfn-codepipeline-pipeline-stages-actions-actiontypeid-category",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineActionTypeCategory"
+          }
         },
         "Owner": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-actions-actiontypeid.html#cfn-codepipeline-pipeline-stages-actions-actiontypeid-owner",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineActionTypeOwner"
+          }
         },
         "Provider": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-actions-actiontypeid.html#cfn-codepipeline-pipeline-stages-actions-actiontypeid-provider",
@@ -4663,7 +4672,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-artifactstore.html#cfn-codepipeline-pipeline-artifactstore-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineArtifactStoreType"
+          }
         }
       }
     },
@@ -4697,7 +4709,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-blockers.html#cfn-codepipeline-pipeline-stages-blockers-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineBlockerType"
+          }
         }
       }
     },
@@ -21506,7 +21521,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-customactiontype.html#cfn-codepipeline-customactiontype-category",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CodePipelineActionType"
+          }
         },
         "ConfigurationProperties": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-customactiontype.html#cfn-codepipeline-customactiontype-configurationproperties",
@@ -21618,7 +21636,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-webhook.html#cfn-codepipeline-webhook-authentication",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineWehbookAuthentication"
+          }
         },
         "AuthenticationConfiguration": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-webhook.html#cfn-codepipeline-webhook-authenticationconfiguration",
@@ -34073,6 +34094,47 @@
         "InstanceReady",
         "InstanceStart",
         "InstanceSuccess"
+      ]
+    },
+    "CodePipelineActionTypeCategory": {
+      "AllowedValues": [
+        "Approval",
+        "Build",
+        "Deploy",
+        "Invoke",
+        "Source",
+        "Test"
+      ]
+    },
+    "CodePipelineActionTypeOwner": {
+      "AllowedValues": [
+        "AWS",
+        "Custom",
+        "ThirdParty"
+      ]
+    },
+    "CodePipelineArtifactStoreType": {
+      "AllowedValues": [
+        "S3"
+      ]
+    },
+    "CodePipelineBlockerType": {
+      "AllowedValues": [
+        "Schedule"
+      ]
+    },
+    "CodePipelineConfigurationPropertiesCategory": {
+      "AllowedValues": [
+        "Boolean",
+        "Number",
+        "String"
+      ]
+    },
+    "CodePipelineWehbookAuthentication": {
+      "AllowedValues": [
+        "GITHUB_HMAC",
+        "IP",
+        "UNAUTHENTICATED"
       ]
     },
     "DmsEndpointEngineName": {

--- a/src/cfnlint/data/CloudSpecs/eu-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-2.json
@@ -3627,7 +3627,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-customactiontype-configurationproperties.html#cfn-codepipeline-customactiontype-configurationproperties-type",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineActionTypeConfigurationType"
+          }
         }
       }
     },
@@ -3724,13 +3727,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-actions-actiontypeid.html#cfn-codepipeline-pipeline-stages-actions-actiontypeid-category",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineActionTypeCategory"
+          }
         },
         "Owner": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-actions-actiontypeid.html#cfn-codepipeline-pipeline-stages-actions-actiontypeid-owner",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineActionTypeOwner"
+          }
         },
         "Provider": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-actions-actiontypeid.html#cfn-codepipeline-pipeline-stages-actions-actiontypeid-provider",
@@ -3765,7 +3774,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-artifactstore.html#cfn-codepipeline-pipeline-artifactstore-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineArtifactStoreType"
+          }
         }
       }
     },
@@ -3799,7 +3811,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-blockers.html#cfn-codepipeline-pipeline-stages-blockers-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineBlockerType"
+          }
         }
       }
     },
@@ -16890,7 +16905,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-customactiontype.html#cfn-codepipeline-customactiontype-category",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CodePipelineActionType"
+          }
         },
         "ConfigurationProperties": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-customactiontype.html#cfn-codepipeline-customactiontype-configurationproperties",
@@ -17002,7 +17020,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-webhook.html#cfn-codepipeline-webhook-authentication",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineWehbookAuthentication"
+          }
         },
         "AuthenticationConfiguration": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-webhook.html#cfn-codepipeline-webhook-authenticationconfiguration",
@@ -27791,6 +27812,47 @@
         "InstanceReady",
         "InstanceStart",
         "InstanceSuccess"
+      ]
+    },
+    "CodePipelineActionTypeCategory": {
+      "AllowedValues": [
+        "Approval",
+        "Build",
+        "Deploy",
+        "Invoke",
+        "Source",
+        "Test"
+      ]
+    },
+    "CodePipelineActionTypeOwner": {
+      "AllowedValues": [
+        "AWS",
+        "Custom",
+        "ThirdParty"
+      ]
+    },
+    "CodePipelineArtifactStoreType": {
+      "AllowedValues": [
+        "S3"
+      ]
+    },
+    "CodePipelineBlockerType": {
+      "AllowedValues": [
+        "Schedule"
+      ]
+    },
+    "CodePipelineConfigurationPropertiesCategory": {
+      "AllowedValues": [
+        "Boolean",
+        "Number",
+        "String"
+      ]
+    },
+    "CodePipelineWehbookAuthentication": {
+      "AllowedValues": [
+        "GITHUB_HMAC",
+        "IP",
+        "UNAUTHENTICATED"
       ]
     },
     "DmsEndpointEngineName": {

--- a/src/cfnlint/data/CloudSpecs/eu-west-3.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-3.json
@@ -3079,7 +3079,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-customactiontype-configurationproperties.html#cfn-codepipeline-customactiontype-configurationproperties-type",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineActionTypeConfigurationType"
+          }
         }
       }
     },
@@ -3176,13 +3179,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-actions-actiontypeid.html#cfn-codepipeline-pipeline-stages-actions-actiontypeid-category",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineActionTypeCategory"
+          }
         },
         "Owner": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-actions-actiontypeid.html#cfn-codepipeline-pipeline-stages-actions-actiontypeid-owner",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineActionTypeOwner"
+          }
         },
         "Provider": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-actions-actiontypeid.html#cfn-codepipeline-pipeline-stages-actions-actiontypeid-provider",
@@ -3217,7 +3226,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-artifactstore.html#cfn-codepipeline-pipeline-artifactstore-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineArtifactStoreType"
+          }
         }
       }
     },
@@ -3251,7 +3263,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-blockers.html#cfn-codepipeline-pipeline-stages-blockers-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineBlockerType"
+          }
         }
       }
     },
@@ -15297,7 +15312,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-customactiontype.html#cfn-codepipeline-customactiontype-category",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CodePipelineActionType"
+          }
         },
         "ConfigurationProperties": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-customactiontype.html#cfn-codepipeline-customactiontype-configurationproperties",
@@ -15409,7 +15427,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-webhook.html#cfn-codepipeline-webhook-authentication",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineWehbookAuthentication"
+          }
         },
         "AuthenticationConfiguration": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-webhook.html#cfn-codepipeline-webhook-authenticationconfiguration",
@@ -24673,6 +24694,47 @@
         "InstanceReady",
         "InstanceStart",
         "InstanceSuccess"
+      ]
+    },
+    "CodePipelineActionTypeCategory": {
+      "AllowedValues": [
+        "Approval",
+        "Build",
+        "Deploy",
+        "Invoke",
+        "Source",
+        "Test"
+      ]
+    },
+    "CodePipelineActionTypeOwner": {
+      "AllowedValues": [
+        "AWS",
+        "Custom",
+        "ThirdParty"
+      ]
+    },
+    "CodePipelineArtifactStoreType": {
+      "AllowedValues": [
+        "S3"
+      ]
+    },
+    "CodePipelineBlockerType": {
+      "AllowedValues": [
+        "Schedule"
+      ]
+    },
+    "CodePipelineConfigurationPropertiesCategory": {
+      "AllowedValues": [
+        "Boolean",
+        "Number",
+        "String"
+      ]
+    },
+    "CodePipelineWehbookAuthentication": {
+      "AllowedValues": [
+        "GITHUB_HMAC",
+        "IP",
+        "UNAUTHENTICATED"
       ]
     },
     "DmsEndpointEngineName": {

--- a/src/cfnlint/data/CloudSpecs/sa-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/sa-east-1.json
@@ -3296,7 +3296,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-customactiontype-configurationproperties.html#cfn-codepipeline-customactiontype-configurationproperties-type",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineActionTypeConfigurationType"
+          }
         }
       }
     },
@@ -3393,13 +3396,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-actions-actiontypeid.html#cfn-codepipeline-pipeline-stages-actions-actiontypeid-category",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineActionTypeCategory"
+          }
         },
         "Owner": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-actions-actiontypeid.html#cfn-codepipeline-pipeline-stages-actions-actiontypeid-owner",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineActionTypeOwner"
+          }
         },
         "Provider": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-actions-actiontypeid.html#cfn-codepipeline-pipeline-stages-actions-actiontypeid-provider",
@@ -3434,7 +3443,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-artifactstore.html#cfn-codepipeline-pipeline-artifactstore-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineArtifactStoreType"
+          }
         }
       }
     },
@@ -3468,7 +3480,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-blockers.html#cfn-codepipeline-pipeline-stages-blockers-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineBlockerType"
+          }
         }
       }
     },
@@ -15895,7 +15910,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-customactiontype.html#cfn-codepipeline-customactiontype-category",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CodePipelineActionType"
+          }
         },
         "ConfigurationProperties": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-customactiontype.html#cfn-codepipeline-customactiontype-configurationproperties",
@@ -16007,7 +16025,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-webhook.html#cfn-codepipeline-webhook-authentication",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineWehbookAuthentication"
+          }
         },
         "AuthenticationConfiguration": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-webhook.html#cfn-codepipeline-webhook-authenticationconfiguration",
@@ -25664,6 +25685,47 @@
         "InstanceReady",
         "InstanceStart",
         "InstanceSuccess"
+      ]
+    },
+    "CodePipelineActionTypeCategory": {
+      "AllowedValues": [
+        "Approval",
+        "Build",
+        "Deploy",
+        "Invoke",
+        "Source",
+        "Test"
+      ]
+    },
+    "CodePipelineActionTypeOwner": {
+      "AllowedValues": [
+        "AWS",
+        "Custom",
+        "ThirdParty"
+      ]
+    },
+    "CodePipelineArtifactStoreType": {
+      "AllowedValues": [
+        "S3"
+      ]
+    },
+    "CodePipelineBlockerType": {
+      "AllowedValues": [
+        "Schedule"
+      ]
+    },
+    "CodePipelineConfigurationPropertiesCategory": {
+      "AllowedValues": [
+        "Boolean",
+        "Number",
+        "String"
+      ]
+    },
+    "CodePipelineWehbookAuthentication": {
+      "AllowedValues": [
+        "GITHUB_HMAC",
+        "IP",
+        "UNAUTHENTICATED"
       ]
     },
     "DmsEndpointEngineName": {

--- a/src/cfnlint/data/CloudSpecs/us-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-1.json
@@ -4525,7 +4525,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-customactiontype-configurationproperties.html#cfn-codepipeline-customactiontype-configurationproperties-type",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineActionTypeConfigurationType"
+          }
         }
       }
     },
@@ -4622,13 +4625,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-actions-actiontypeid.html#cfn-codepipeline-pipeline-stages-actions-actiontypeid-category",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineActionTypeCategory"
+          }
         },
         "Owner": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-actions-actiontypeid.html#cfn-codepipeline-pipeline-stages-actions-actiontypeid-owner",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineActionTypeOwner"
+          }
         },
         "Provider": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-actions-actiontypeid.html#cfn-codepipeline-pipeline-stages-actions-actiontypeid-provider",
@@ -4663,7 +4672,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-artifactstore.html#cfn-codepipeline-pipeline-artifactstore-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineArtifactStoreType"
+          }
         }
       }
     },
@@ -4697,7 +4709,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-blockers.html#cfn-codepipeline-pipeline-stages-blockers-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineBlockerType"
+          }
         }
       }
     },
@@ -21507,7 +21522,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-customactiontype.html#cfn-codepipeline-customactiontype-category",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CodePipelineActionType"
+          }
         },
         "ConfigurationProperties": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-customactiontype.html#cfn-codepipeline-customactiontype-configurationproperties",
@@ -21619,7 +21637,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-webhook.html#cfn-codepipeline-webhook-authentication",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineWehbookAuthentication"
+          }
         },
         "AuthenticationConfiguration": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-webhook.html#cfn-codepipeline-webhook-authenticationconfiguration",
@@ -34102,6 +34123,47 @@
         "InstanceReady",
         "InstanceStart",
         "InstanceSuccess"
+      ]
+    },
+    "CodePipelineActionTypeCategory": {
+      "AllowedValues": [
+        "Approval",
+        "Build",
+        "Deploy",
+        "Invoke",
+        "Source",
+        "Test"
+      ]
+    },
+    "CodePipelineActionTypeOwner": {
+      "AllowedValues": [
+        "AWS",
+        "Custom",
+        "ThirdParty"
+      ]
+    },
+    "CodePipelineArtifactStoreType": {
+      "AllowedValues": [
+        "S3"
+      ]
+    },
+    "CodePipelineBlockerType": {
+      "AllowedValues": [
+        "Schedule"
+      ]
+    },
+    "CodePipelineConfigurationPropertiesCategory": {
+      "AllowedValues": [
+        "Boolean",
+        "Number",
+        "String"
+      ]
+    },
+    "CodePipelineWehbookAuthentication": {
+      "AllowedValues": [
+        "GITHUB_HMAC",
+        "IP",
+        "UNAUTHENTICATED"
       ]
     },
     "DmsEndpointEngineName": {

--- a/src/cfnlint/data/CloudSpecs/us-east-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-2.json
@@ -4060,7 +4060,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-customactiontype-configurationproperties.html#cfn-codepipeline-customactiontype-configurationproperties-type",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineActionTypeConfigurationType"
+          }
         }
       }
     },
@@ -4157,13 +4160,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-actions-actiontypeid.html#cfn-codepipeline-pipeline-stages-actions-actiontypeid-category",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineActionTypeCategory"
+          }
         },
         "Owner": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-actions-actiontypeid.html#cfn-codepipeline-pipeline-stages-actions-actiontypeid-owner",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineActionTypeOwner"
+          }
         },
         "Provider": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-actions-actiontypeid.html#cfn-codepipeline-pipeline-stages-actions-actiontypeid-provider",
@@ -4198,7 +4207,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-artifactstore.html#cfn-codepipeline-pipeline-artifactstore-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineArtifactStoreType"
+          }
         }
       }
     },
@@ -4232,7 +4244,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-blockers.html#cfn-codepipeline-pipeline-stages-blockers-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineBlockerType"
+          }
         }
       }
     },
@@ -19944,7 +19959,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-customactiontype.html#cfn-codepipeline-customactiontype-category",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CodePipelineActionType"
+          }
         },
         "ConfigurationProperties": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-customactiontype.html#cfn-codepipeline-customactiontype-configurationproperties",
@@ -20056,7 +20074,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-webhook.html#cfn-codepipeline-webhook-authentication",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineWehbookAuthentication"
+          }
         },
         "AuthenticationConfiguration": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-webhook.html#cfn-codepipeline-webhook-authenticationconfiguration",
@@ -32115,6 +32136,47 @@
         "InstanceReady",
         "InstanceStart",
         "InstanceSuccess"
+      ]
+    },
+    "CodePipelineActionTypeCategory": {
+      "AllowedValues": [
+        "Approval",
+        "Build",
+        "Deploy",
+        "Invoke",
+        "Source",
+        "Test"
+      ]
+    },
+    "CodePipelineActionTypeOwner": {
+      "AllowedValues": [
+        "AWS",
+        "Custom",
+        "ThirdParty"
+      ]
+    },
+    "CodePipelineArtifactStoreType": {
+      "AllowedValues": [
+        "S3"
+      ]
+    },
+    "CodePipelineBlockerType": {
+      "AllowedValues": [
+        "Schedule"
+      ]
+    },
+    "CodePipelineConfigurationPropertiesCategory": {
+      "AllowedValues": [
+        "Boolean",
+        "Number",
+        "String"
+      ]
+    },
+    "CodePipelineWehbookAuthentication": {
+      "AllowedValues": [
+        "GITHUB_HMAC",
+        "IP",
+        "UNAUTHENTICATED"
       ]
     },
     "DmsEndpointEngineName": {

--- a/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
@@ -2003,7 +2003,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-customactiontype-configurationproperties.html#cfn-codepipeline-customactiontype-configurationproperties-type",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineActionTypeConfigurationType"
+          }
         }
       }
     },
@@ -2100,13 +2103,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-actions-actiontypeid.html#cfn-codepipeline-pipeline-stages-actions-actiontypeid-category",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineActionTypeCategory"
+          }
         },
         "Owner": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-actions-actiontypeid.html#cfn-codepipeline-pipeline-stages-actions-actiontypeid-owner",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineActionTypeOwner"
+          }
         },
         "Provider": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-actions-actiontypeid.html#cfn-codepipeline-pipeline-stages-actions-actiontypeid-provider",
@@ -2141,7 +2150,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-artifactstore.html#cfn-codepipeline-pipeline-artifactstore-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineArtifactStoreType"
+          }
         }
       }
     },
@@ -2175,7 +2187,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-blockers.html#cfn-codepipeline-pipeline-stages-blockers-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineBlockerType"
+          }
         }
       }
     },
@@ -12832,7 +12847,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-customactiontype.html#cfn-codepipeline-customactiontype-category",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CodePipelineActionType"
+          }
         },
         "ConfigurationProperties": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-customactiontype.html#cfn-codepipeline-customactiontype-configurationproperties",
@@ -20842,6 +20860,47 @@
         "InstanceReady",
         "InstanceStart",
         "InstanceSuccess"
+      ]
+    },
+    "CodePipelineActionTypeCategory": {
+      "AllowedValues": [
+        "Approval",
+        "Build",
+        "Deploy",
+        "Invoke",
+        "Source",
+        "Test"
+      ]
+    },
+    "CodePipelineActionTypeOwner": {
+      "AllowedValues": [
+        "AWS",
+        "Custom",
+        "ThirdParty"
+      ]
+    },
+    "CodePipelineArtifactStoreType": {
+      "AllowedValues": [
+        "S3"
+      ]
+    },
+    "CodePipelineBlockerType": {
+      "AllowedValues": [
+        "Schedule"
+      ]
+    },
+    "CodePipelineConfigurationPropertiesCategory": {
+      "AllowedValues": [
+        "Boolean",
+        "Number",
+        "String"
+      ]
+    },
+    "CodePipelineWehbookAuthentication": {
+      "AllowedValues": [
+        "GITHUB_HMAC",
+        "IP",
+        "UNAUTHENTICATED"
       ]
     },
     "DmsEndpointEngineName": {

--- a/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
@@ -2003,7 +2003,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-customactiontype-configurationproperties.html#cfn-codepipeline-customactiontype-configurationproperties-type",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineActionTypeConfigurationType"
+          }
         }
       }
     },
@@ -2100,13 +2103,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-actions-actiontypeid.html#cfn-codepipeline-pipeline-stages-actions-actiontypeid-category",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineActionTypeCategory"
+          }
         },
         "Owner": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-actions-actiontypeid.html#cfn-codepipeline-pipeline-stages-actions-actiontypeid-owner",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineActionTypeOwner"
+          }
         },
         "Provider": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-actions-actiontypeid.html#cfn-codepipeline-pipeline-stages-actions-actiontypeid-provider",
@@ -2141,7 +2150,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-artifactstore.html#cfn-codepipeline-pipeline-artifactstore-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineArtifactStoreType"
+          }
         }
       }
     },
@@ -2175,7 +2187,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-blockers.html#cfn-codepipeline-pipeline-stages-blockers-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineBlockerType"
+          }
         }
       }
     },
@@ -12902,7 +12917,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-customactiontype.html#cfn-codepipeline-customactiontype-category",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CodePipelineActionType"
+          }
         },
         "ConfigurationProperties": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-customactiontype.html#cfn-codepipeline-customactiontype-configurationproperties",
@@ -21059,6 +21077,47 @@
         "InstanceReady",
         "InstanceStart",
         "InstanceSuccess"
+      ]
+    },
+    "CodePipelineActionTypeCategory": {
+      "AllowedValues": [
+        "Approval",
+        "Build",
+        "Deploy",
+        "Invoke",
+        "Source",
+        "Test"
+      ]
+    },
+    "CodePipelineActionTypeOwner": {
+      "AllowedValues": [
+        "AWS",
+        "Custom",
+        "ThirdParty"
+      ]
+    },
+    "CodePipelineArtifactStoreType": {
+      "AllowedValues": [
+        "S3"
+      ]
+    },
+    "CodePipelineBlockerType": {
+      "AllowedValues": [
+        "Schedule"
+      ]
+    },
+    "CodePipelineConfigurationPropertiesCategory": {
+      "AllowedValues": [
+        "Boolean",
+        "Number",
+        "String"
+      ]
+    },
+    "CodePipelineWehbookAuthentication": {
+      "AllowedValues": [
+        "GITHUB_HMAC",
+        "IP",
+        "UNAUTHENTICATED"
       ]
     },
     "DmsEndpointEngineName": {

--- a/src/cfnlint/data/CloudSpecs/us-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-1.json
@@ -3748,7 +3748,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-customactiontype-configurationproperties.html#cfn-codepipeline-customactiontype-configurationproperties-type",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineActionTypeConfigurationType"
+          }
         }
       }
     },
@@ -3845,13 +3848,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-actions-actiontypeid.html#cfn-codepipeline-pipeline-stages-actions-actiontypeid-category",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineActionTypeCategory"
+          }
         },
         "Owner": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-actions-actiontypeid.html#cfn-codepipeline-pipeline-stages-actions-actiontypeid-owner",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineActionTypeOwner"
+          }
         },
         "Provider": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-actions-actiontypeid.html#cfn-codepipeline-pipeline-stages-actions-actiontypeid-provider",
@@ -3886,7 +3895,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-artifactstore.html#cfn-codepipeline-pipeline-artifactstore-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineArtifactStoreType"
+          }
         }
       }
     },
@@ -3920,7 +3932,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-blockers.html#cfn-codepipeline-pipeline-stages-blockers-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineBlockerType"
+          }
         }
       }
     },
@@ -16724,7 +16739,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-customactiontype.html#cfn-codepipeline-customactiontype-category",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CodePipelineActionType"
+          }
         },
         "ConfigurationProperties": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-customactiontype.html#cfn-codepipeline-customactiontype-configurationproperties",
@@ -16836,7 +16854,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-webhook.html#cfn-codepipeline-webhook-authentication",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineWehbookAuthentication"
+          }
         },
         "AuthenticationConfiguration": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-webhook.html#cfn-codepipeline-webhook-authenticationconfiguration",
@@ -27124,6 +27145,47 @@
         "InstanceReady",
         "InstanceStart",
         "InstanceSuccess"
+      ]
+    },
+    "CodePipelineActionTypeCategory": {
+      "AllowedValues": [
+        "Approval",
+        "Build",
+        "Deploy",
+        "Invoke",
+        "Source",
+        "Test"
+      ]
+    },
+    "CodePipelineActionTypeOwner": {
+      "AllowedValues": [
+        "AWS",
+        "Custom",
+        "ThirdParty"
+      ]
+    },
+    "CodePipelineArtifactStoreType": {
+      "AllowedValues": [
+        "S3"
+      ]
+    },
+    "CodePipelineBlockerType": {
+      "AllowedValues": [
+        "Schedule"
+      ]
+    },
+    "CodePipelineConfigurationPropertiesCategory": {
+      "AllowedValues": [
+        "Boolean",
+        "Number",
+        "String"
+      ]
+    },
+    "CodePipelineWehbookAuthentication": {
+      "AllowedValues": [
+        "GITHUB_HMAC",
+        "IP",
+        "UNAUTHENTICATED"
       ]
     },
     "DmsEndpointEngineName": {

--- a/src/cfnlint/data/CloudSpecs/us-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-2.json
@@ -4525,7 +4525,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-customactiontype-configurationproperties.html#cfn-codepipeline-customactiontype-configurationproperties-type",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineActionTypeConfigurationType"
+          }
         }
       }
     },
@@ -4622,13 +4625,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-actions-actiontypeid.html#cfn-codepipeline-pipeline-stages-actions-actiontypeid-category",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineActionTypeCategory"
+          }
         },
         "Owner": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-actions-actiontypeid.html#cfn-codepipeline-pipeline-stages-actions-actiontypeid-owner",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineActionTypeOwner"
+          }
         },
         "Provider": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-actions-actiontypeid.html#cfn-codepipeline-pipeline-stages-actions-actiontypeid-provider",
@@ -4663,7 +4672,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-artifactstore.html#cfn-codepipeline-pipeline-artifactstore-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineArtifactStoreType"
+          }
         }
       }
     },
@@ -4697,7 +4709,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-blockers.html#cfn-codepipeline-pipeline-stages-blockers-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineBlockerType"
+          }
         }
       }
     },
@@ -21525,7 +21540,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-customactiontype.html#cfn-codepipeline-customactiontype-category",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CodePipelineActionType"
+          }
         },
         "ConfigurationProperties": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-customactiontype.html#cfn-codepipeline-customactiontype-configurationproperties",
@@ -21637,7 +21655,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-webhook.html#cfn-codepipeline-webhook-authentication",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CodePipelineWehbookAuthentication"
+          }
         },
         "AuthenticationConfiguration": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-webhook.html#cfn-codepipeline-webhook-authenticationconfiguration",
@@ -34132,6 +34153,47 @@
         "InstanceReady",
         "InstanceStart",
         "InstanceSuccess"
+      ]
+    },
+    "CodePipelineActionTypeCategory": {
+      "AllowedValues": [
+        "Approval",
+        "Build",
+        "Deploy",
+        "Invoke",
+        "Source",
+        "Test"
+      ]
+    },
+    "CodePipelineActionTypeOwner": {
+      "AllowedValues": [
+        "AWS",
+        "Custom",
+        "ThirdParty"
+      ]
+    },
+    "CodePipelineArtifactStoreType": {
+      "AllowedValues": [
+        "S3"
+      ]
+    },
+    "CodePipelineBlockerType": {
+      "AllowedValues": [
+        "Schedule"
+      ]
+    },
+    "CodePipelineConfigurationPropertiesCategory": {
+      "AllowedValues": [
+        "Boolean",
+        "Number",
+        "String"
+      ]
+    },
+    "CodePipelineWehbookAuthentication": {
+      "AllowedValues": [
+        "GITHUB_HMAC",
+        "IP",
+        "UNAUTHENTICATED"
       ]
     },
     "DmsEndpointEngineName": {

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
@@ -282,6 +282,47 @@
           "InstanceSuccess"
         ]
       },
+      "CodePipelineActionTypeCategory": {
+        "AllowedValues": [
+          "Approval",
+          "Build",
+          "Deploy",
+          "Invoke",
+          "Source",
+          "Test"
+        ]
+      },
+      "CodePipelineConfigurationPropertiesCategory": {
+        "AllowedValues": [
+          "Boolean",
+          "Number",
+          "String"
+        ]
+      },
+      "CodePipelineActionTypeOwner": {
+        "AllowedValues": [
+          "AWS",
+          "Custom",
+          "ThirdParty"
+        ]
+      },
+      "CodePipelineArtifactStoreType": {
+        "AllowedValues": [
+          "S3"
+        ]
+      },
+      "CodePipelineBlockerType": {
+        "AllowedValues": [
+          "Schedule"
+        ]
+      },
+      "CodePipelineWehbookAuthentication": {
+        "AllowedValues": [
+          "GITHUB_HMAC",
+          "IP",
+          "UNAUTHENTICATED"
+        ]
+      },
       "DmsEndpointEngineName": {
         "AllowedValues": [
           "aurora-postgresql",

--- a/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
@@ -141,6 +141,41 @@
   },
   {
     "op": "add",
+    "path": "/PropertyTypes/AWS::CodePipeline::CustomActionType.ConfigurationProperties/Properties/Type/Value",
+    "value": {
+      "ValueType": "CodePipelineActionTypeConfigurationType"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/PropertyTypes/AWS::CodePipeline::Pipeline.ArtifactStore/Properties/Type/Value",
+    "value": {
+      "ValueType": "CodePipelineArtifactStoreType"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/PropertyTypes/AWS::CodePipeline::Pipeline.ActionTypeId/Properties/Category/Value",
+    "value": {
+      "ValueType": "CodePipelineActionTypeCategory"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/PropertyTypes/AWS::CodePipeline::Pipeline.ActionTypeId/Properties/Owner/Value",
+    "value": {
+      "ValueType": "CodePipelineActionTypeOwner"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/PropertyTypes/AWS::CodePipeline::Pipeline.BlockerDeclaration/Properties/Type/Value",
+    "value": {
+      "ValueType": "CodePipelineBlockerType"
+    }
+  },
+  {
+    "op": "add",
     "path": "/PropertyTypes/AWS::EC2::SpotFleet.EbsBlockDevice/Properties/VolumeType/Value",
     "value": {
       "ValueType": "EbsVolumeType"
@@ -616,6 +651,13 @@
   },
   {
     "op": "add",
+    "path": "/ResourceTypes/AWS::CodePipeline::CustomActionType/Properties/Category/Value",
+    "value": {
+      "ValueType": "CodePipelineActionType"
+    }
+  },
+  {
+    "op": "add",
     "path": "/ResourceTypes/AWS::DMS::Endpoint/Properties/EngineName/Value",
     "value": {
       "ValueType": "DmsEndpointEngineName"
@@ -1004,6 +1046,13 @@
     "path": "/ResourceTypes/AWS::AutoScaling::ScalingPolicy/Properties/PolicyType/Value",
     "value": {
       "ValueType": "AutoScalingPolicyType"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/ResourceTypes/AWS::CodePipeline::Webhook/Properties/Authentication/Value",
+    "value": {
+      "ValueType": "CodePipelineWehbookAuthentication"
     }
   },
   {

--- a/src/cfnlint/rules/resources/codepipeline/CodepipelineStageActions.py
+++ b/src/cfnlint/rules/resources/codepipeline/CodepipelineStageActions.py
@@ -26,8 +26,6 @@ class CodepipelineStageActions(CloudFormationLintRule):
     source_url = 'https://docs.aws.amazon.com/codepipeline/latest/userguide/reference-pipeline-structure.html#pipeline-requirements'
     tags = ['resources', 'codepipeline']
 
-    VALID_OWNER_STRINGS = {'AWS', 'ThirdParty', 'Custom'}
-
     CONSTRAINTS = {
         'AWS': {
             'Source': {
@@ -150,25 +148,6 @@ class CodepipelineStageActions(CloudFormationLintRule):
 
         return matches
 
-    def check_owner(self, action, path):
-        """Check that action type owner is valid."""
-        matches = []
-
-        owner = action.get('ActionTypeId').get('Owner')
-        if owner not in self.VALID_OWNER_STRINGS and owner is not None:
-            message = (
-                'For all currently supported action types, the only valid owner '
-                'strings are {owners}'
-            ).format(
-                owners=', '.join(list(self.VALID_OWNER_STRINGS))
-            )
-            matches.append(RuleMatch(
-                path + ['ActionTypeId', 'Owner'],
-                message
-            ))
-
-        return matches
-
     def check_version(self, action, path):
         """Check that action type version is valid."""
         matches = []
@@ -222,11 +201,11 @@ class CodepipelineStageActions(CloudFormationLintRule):
 
                         for l_i_a_action, l_i_a_path in s_action_v.items_safe(s_action_p):
                             try:
-                                matches.extend(self.check_names_unique(l_i_a_action, l_i_a_path, action_names))
-                                matches.extend(self.check_version(l_i_a_action, l_i_a_path))
-                                matches.extend(self.check_owner(l_i_a_action, l_i_a_path))
-                                matches.extend(self.check_artifact_counts(l_i_a_action, 'InputArtifacts', l_i_a_path))
-                                matches.extend(self.check_artifact_counts(l_i_a_action, 'OutputArtifacts', l_i_a_path))
+                                full_path = path + l_i_a_path
+                                matches.extend(self.check_names_unique(l_i_a_action, full_path, action_names))
+                                matches.extend(self.check_version(l_i_a_action, full_path))
+                                matches.extend(self.check_artifact_counts(l_i_a_action, 'InputArtifacts', full_path))
+                                matches.extend(self.check_artifact_counts(l_i_a_action, 'OutputArtifacts', full_path))
                             except AttributeError as err:
                                 self.logger.debug('Got AttributeError. Should have been caught by generic linting. '
                                                   'Ignoring the error here: %s', str(err))

--- a/src/cfnlint/rules/resources/codepipeline/CodepipelineStages.py
+++ b/src/cfnlint/rules/resources/codepipeline/CodepipelineStages.py
@@ -113,17 +113,18 @@ class CodepipelineStages(CloudFormationLintRule):
                     return matches
 
                 try:
+                    stage_path = path + s_stage_p
                     matches.extend(
-                        self.check_stage_count(s_stage_v, s_stage_p)
+                        self.check_stage_count(s_stage_v, stage_path)
                     )
                     matches.extend(
-                        self.check_first_stage(s_stage_v, s_stage_p)
+                        self.check_first_stage(s_stage_v, stage_path)
                     )
                     matches.extend(
-                        self.check_source_actions(s_stage_v, s_stage_p)
+                        self.check_source_actions(s_stage_v, stage_path)
                     )
                     matches.extend(
-                        self.check_names_unique(s_stage_v, s_stage_p)
+                        self.check_names_unique(s_stage_v, stage_path)
                     )
                 except AttributeError as err:
                     self.logger.debug('Got AttributeError. Should have been caught by generic linting. '

--- a/test/fixtures/templates/bad/resources/properties/allowed_values.yaml
+++ b/test/fixtures/templates/bad/resources/properties/allowed_values.yaml
@@ -199,6 +199,54 @@ Resources:
       TriggerConfigurations:
         - TriggerEvents:
             - "DeploymentStart" # Invalid AllowedValue
+
+  CodePipelineCustomActionType:
+    Type: "AWS::CodePipeline::CustomActionType"
+    Properties:
+      Category: "Custom" # Invalid AllowedValue
+      ConfigurationProperties:
+        - Key: True
+          Name: "My-Name"
+          Required: True
+          Secret: False
+          Type: "string" # Invalid AllowedValue
+      InputArtifactDetails:
+        MaximumCount: 1
+        MinimumCount: 1
+      OutputArtifactDetails:
+        MaximumCount: 1
+        MinimumCount: 1
+      Provider: "My-Build-Provider-Name"
+  CodePipeline:
+    Type: "AWS::CodePipeline::Pipeline"
+    Properties:
+      ArtifactStore:
+        Location: "S3Bucket"
+        Type: "ec2" # Invalid AllowedValue
+      RoleArn: "my-role-arn"
+      Stages:
+        - Name: "stage1"
+          Actions:
+            - Name: "action1"
+              ActionTypeId:
+                Category: "Testing" # Invalid AllowedValue
+                Owner: "me" # Invalid AllowedValue
+                Provider: "provider"
+                Version: "latest"
+          Blockers:
+            - Name: "blocker1"
+              Type: "blocker" # Invalid AllowedValue
+  CodePipelineWebhook:
+    Type: "AWS::CodePipeline::Webhook"
+    Properties:
+      Authentication: "GITHUB" # InValid AllowedValue
+      AuthenticationConfiguration:
+        SecretToken: "githubtoken"
+      Filters:
+        - JsonPath: ""
+      TargetAction: "action1"
+      TargetPipeline: ""
+      TargetPipelineVersion: 1
   DmsEndpoint:
     Type: "AWS::DMS::Endpoint"
     Properties:

--- a/test/fixtures/templates/good/resources/properties/allowed_values.yaml
+++ b/test/fixtures/templates/good/resources/properties/allowed_values.yaml
@@ -205,11 +205,6 @@ Resources:
       ArtifactStore:
         Location: "S3Bucket"
         Type: "S3" # Valid AllowedValue
-      ArtifactStores:
-        - ArtifactStore:
-            Location: "S3Bucket"
-            Type: "S3" # Valid AllowedValue
-          Region: "eu-west-1"
       RoleArn: "my-role-arn"
       Stages:
         - Name: "stage1"

--- a/test/fixtures/templates/good/resources/properties/allowed_values.yaml
+++ b/test/fixtures/templates/good/resources/properties/allowed_values.yaml
@@ -199,6 +199,53 @@ Resources:
       TriggerConfigurations:
         - TriggerEvents:
             - "DeploymentStart" # Valid AllowedValue
+  CodePipeline:
+    Type: "AWS::CodePipeline::Pipeline"
+    Properties:
+      ArtifactStore:
+        Location: "S3Bucket"
+        Type: "S3" # Valid AllowedValue
+      RoleArn: "my-role-arn"
+      Stages:
+        - Name: "stage1"
+          Actions:
+            - Name: "action1"
+              ActionTypeId:
+                Category: "Test" # Valid AllowedValue
+                Owner: "AWS" # Valid AllowedValue
+                Provider: "provider"
+                Version: "latest"
+          Blockers:
+            - Name: "blocker1"
+              Type: "Schedule" # Valid AllowedValue
+  CodePipelineCustomActionType:
+    Type: AWS::CodePipeline::CustomActionType
+    Properties:
+      Category: "Test" # Valid AllowedValue
+      ConfigurationProperties:
+        - Key: True
+          Name: "My-Name"
+          Required: True
+          Secret: False
+          Type: "String" # Valid AllowedValue
+      InputArtifactDetails:
+        MaximumCount: 1
+        MinimumCount: 1
+      OutputArtifactDetails:
+        MaximumCount: 1
+        MinimumCount: 1
+      Provider: "My-Build-Provider-Name"
+  CodePipelineWebhook:
+    Type: "AWS::CodePipeline::Webhook"
+    Properties:
+      Authentication: "GITHUB_HMAC" # Valid AllowedValue
+      AuthenticationConfiguration:
+        SecretToken: "githubtoken"
+      Filters:
+        - JsonPath: ""
+      TargetAction: "action1"
+      TargetPipeline: ""
+      TargetPipelineVersion: 1
   DmsEndpoint:
     Type: "AWS::DMS::Endpoint"
     Properties:

--- a/test/fixtures/templates/good/resources/properties/allowed_values.yaml
+++ b/test/fixtures/templates/good/resources/properties/allowed_values.yaml
@@ -205,19 +205,32 @@ Resources:
       ArtifactStore:
         Location: "S3Bucket"
         Type: "S3" # Valid AllowedValue
+      ArtifactStores:
+        - ArtifactStore:
+            Location: "S3Bucket"
+            Type: "S3" # Valid AllowedValue
+          Region: "eu-west-1"
       RoleArn: "my-role-arn"
       Stages:
         - Name: "stage1"
           Actions:
             - Name: "action1"
               ActionTypeId:
-                Category: "Test" # Valid AllowedValue
+                Category: "Source" # Valid AllowedValue
                 Owner: "AWS" # Valid AllowedValue
                 Provider: "provider"
-                Version: "latest"
+                Version: "1"
           Blockers:
             - Name: "blocker1"
               Type: "Schedule" # Valid AllowedValue
+        - Name: "stage2"
+          Actions:
+            - Name: "action2"
+              ActionTypeId:
+                Category: "Test" # Valid AllowedValue
+                Owner: "AWS" # Valid AllowedValue
+                Provider: "provider"
+                Version: "1"
   CodePipelineCustomActionType:
     Type: AWS::CodePipeline::CustomActionType
     Properties:

--- a/test/rules/resources/properties/test_allowed_value.py
+++ b/test/rules/resources/properties/test_allowed_value.py
@@ -34,4 +34,4 @@ class TestAllowedValue(BaseRuleTestCase):
 
     def test_file_negative(self):
         """Test failure"""
-        self.helper_file_negative('test/fixtures/templates/bad/resources/properties/allowed_values.yaml', 73)
+        self.helper_file_negative('test/fixtures/templates/bad/resources/properties/allowed_values.yaml', 80)


### PR DESCRIPTION
*Issue https://github.com/awslabs/cfn-python-lint/issues/50, if available:*

Added the allowed values of all the [`AWS::CodePipeline`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-reference-codepipeline.html) resources.

Along the way:
Based on the [documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-pipeline.html#cfn-codepipeline-pipeline-artifactstores), added `ArtifactStore`/`ArtificatStores` of CodePipeline to the `OnlyOne` check.

Tweaked the existing CodePipeline rules:

- Correct paths (all the error were thrown at Line `1:1`
- Remove the Owners check since that's covered by the Allowed_values rule

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
