### PR TITLE
Improve Vpc Cidrblock check

### DIFF
--- a/src/cfnlint/rules/resources/ectwo/Vpc.py
+++ b/src/cfnlint/rules/resources/ectwo/Vpc.py
@@ -36,6 +36,14 @@ class Vpc(CloudFormationLintRule):
         if not re.match(cfnlint.helpers.REGEX_CIDR, value):
             message = 'CidrBlock needs to be of x.x.x.x/y at {0}'
             matches.append(RuleMatch(path, message.format(('/'.join(['Parameters', value])))))
+        else:
+            # CHeck the netmask block, has to be between /16 and /28
+            netmask = int(value.split('/')[1])
+
+            if netmask < 16 or netmask > 28:
+                message = 'VPC Cidrblock netmask ({}) must be between /16 and /28'
+                matches.append(RuleMatch(path, message.format(value)))
+
         return matches
 
     def check_cidr_ref(self, value, path, parameters, resources):

--- a/test/fixtures/templates/bad/properties_ec2_network.yaml
+++ b/test/fixtures/templates/bad/properties_ec2_network.yaml
@@ -34,6 +34,11 @@ Resources:
     Properties:
       InstanceTenancy: !Ref vpcTenancy
       CidrBlock: !Ref cidrBlockAllowedValues
+  myVpc4:
+    Type: AWS::EC2::VPC
+    Properties:
+      InstanceTenancy: !Ref vpcTenancy
+      CidrBlock: "10.0.0.8/8"
   mySubnet2-1:
     Type: AWS::EC2::Subnet
     Properties:

--- a/test/fixtures/templates/good/resources/properties/allowed_values.yaml
+++ b/test/fixtures/templates/good/resources/properties/allowed_values.yaml
@@ -360,7 +360,7 @@ Resources:
   Vpc:
     Type: "AWS::EC2::VPC"
     Properties:
-      CidrBlock: "10.0.0.0/8"
+      CidrBlock: "10.0.0.0/16"
       InstanceTenancy: "default" # Valid AllowedValue
   WAFRule:
     Type: "AWS::WAFRegional::Rule"

--- a/test/rules/resources/ec2/test_ec2_vpc.py
+++ b/test/rules/resources/ec2/test_ec2_vpc.py
@@ -34,4 +34,4 @@ class TestPropertyEc2Vpc(BaseRuleTestCase):
 
     def test_file_negative(self):
         """Test failure"""
-        self.helper_file_negative('test/fixtures/templates/bad/properties_ec2_network.yaml', 2)
+        self.helper_file_negative('test/fixtures/templates/bad/properties_ec2_network.yaml', 3)


### PR DESCRIPTION
I've been deploying a/the [Completely valid AllowedValues](https://github.com/awslabs/cfn-python-lint/blob/master/test/fixtures/templates/good/resources/properties/allowed_values.yaml) template to hunt for missing features/quickwins in the linter.

This is the first PR: Add a netmask check on the VPC's CidrBlock. See the documentation: https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Subnets.html#vpc-sizing-ipv4



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
