### PR TITLE
Reorder template loading so legacy is used first

### DIFF
--- a/src/cfnlint/config.py
+++ b/src/cfnlint/config.py
@@ -421,10 +421,10 @@ class ConfigMixIn(TemplateArgs, CliArgs, ConfigFileArgs, object):
         """ templates """
         templates_args = self._get_argument_value('templates', False, True)
         template_alt_args = self._get_argument_value('template_alt', False, False)
-        if templates_args:
-            filenames = templates_args
-        elif template_alt_args:
+        if template_alt_args:
             filenames = template_alt_args
+        elif templates_args:
+            filenames = templates_args
         else:
             return None
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Related to https://github.com/awslabs/aws-cfn-lint-visual-studio-code/issues/37
- When using `--template` in a folder with a `.cfnlintrc` file the `.cfnlintrc` file will win.  This change will use `--template` first.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
