### PR TITLE
Handle equals that use empty string

### DIFF
--- a/src/cfnlint/conditions.py
+++ b/src/cfnlint/conditions.py
@@ -133,14 +133,14 @@ class Condition(object):
                 self.Influenced_Equals[equal.Left.Function] = set()
             if equal.Right.Function:
                 self.Influenced_Equals[equal.Left.Function].add(equal.Right.Function)
-            elif equal.Right.String:
+            elif equal.Right.String is not None:
                 self.Influenced_Equals[equal.Left.Function].add(equal.Right.String)
         if equal.Right.Function:
             if not self.Influenced_Equals.get(equal.Right.Function):
                 self.Influenced_Equals[equal.Right.Function] = set()
             if equal.Left.Function:
                 self.Influenced_Equals[equal.Right.Function].add(equal.Left.Function)
-            elif equal.Left.String:
+            elif equal.Left.String is not None:
                 self.Influenced_Equals[equal.Right.Function].add(equal.Left.String)
 
     def process_condition(self, template, value):

--- a/test/module/conditions/test_condition.py
+++ b/test/module/conditions/test_condition.py
@@ -124,6 +124,21 @@ class TestCondition(BaseTestCase):
         self.assertFalse(result.test({'36305712594f5e76fbcbbe2f82cd3f850f6018e9': 'us-east-1'}))
         self.assertTrue(result.test({'36305712594f5e76fbcbbe2f82cd3f850f6018e9': '36cf15035d5be0f36e03d67b66cddb6081f5855d'}))
 
+    def test_empty_string_in_equals(self):
+        """ Empty String in Condition """
+        template = {
+            'Conditions': {
+                'isSet': {'Fn::Equals': [{'Ref': 'myEnvironment'}, '']}
+            },
+            'Resources': {}
+        }
+        result = conditions.Condition(template, 'isSet')
+        self.assertEqual(result.And, [])  # No And
+        self.assertEqual(result.Or, [])  # No Or
+        self.assertEqual(result.Not, [])  # No Not
+        self.assertIsNotNone(result.Equals)
+        self.assertEqual(result.Influenced_Equals, {'d60d12101638186a2c742b772ec8e69b3e2382b9': {''}})
+
 
 class TestBadConditions(BaseTestCase):
     """Test Badly Formmated Condition """


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Have Conditions better handle Equals to an empty string

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
