### PR TITLE
Add condition logic to OnlyOne check

### DIFF
--- a/test/fixtures/templates/bad/properties_onlyone.yaml
+++ b/test/fixtures/templates/bad/properties_onlyone.yaml
@@ -2,14 +2,29 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Description: >
   At Least One Property types
+Parameters:
+  myAmiId:
+    Type: String
+    Default: ''
+  LaunchConfiguration:
+    Type: String
+Conditions:
+  useAmiId: !Not [!Equals [!Ref myAmiId, '']]
 Resources:
   myInstance:
     Type: AWS::EC2::Instance
     Properties:
-      ImageId: ami-1234567
+      ImageId: ami-132456
       BlockDeviceMappings:
       -
         DeviceName: myDevice
+  AutoScalingGroup:
+    Type: AWS::AutoScaling::AutoScalingGroup
+    Properties:
+      InstanceId: !If ['useAmiId', {'Ref': 'myAmiId'}, {'Ref': 'AWS::NoValue'}]
+      LaunchConfigurationName: !If ['useAmiId', {'Ref': 'LaunchConfiguration'}, {'Ref': 'AWS::NoValue'}]
+      MaxSize: '3'
+      MinSize: '1'
   S3Bucket:
     Type: AWS::S3::Bucket
     Properties:

--- a/test/module/test_rules_collections.py
+++ b/test/module/test_rules_collections.py
@@ -72,7 +72,7 @@ class TestTemplate(BaseTestCase):
 
         matches = []
         matches.extend(self.rules.run(filename, cfn))
-        assert len(matches) == 3, 'Expected {} failures, got {}'.format(2, len(matches))
+        assert len(matches) == 5, 'Expected {} failures, got {}'.format(5, len(matches))
 
     def test_success_filtering_of_rules_default(self):
         """Test extend function"""

--- a/test/rules/resources/properties/test_onlyone.py
+++ b/test/rules/resources/properties/test_onlyone.py
@@ -31,4 +31,4 @@ class TestPropertyOnlyOne(BaseRuleTestCase):
 
     def test_file_negative(self):
         """Test failure"""
-        self.helper_file_negative('test/fixtures/templates/bad/properties_onlyone.yaml', 2)
+        self.helper_file_negative('test/fixtures/templates/bad/properties_onlyone.yaml', 4)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Fix rule E2523 to detect when only one attribute is used with conditions and AWS NoValue

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
