### PR TITLE
Add CloudWatch Allowed Values

### DIFF
--- a/src/cfnlint/data/AdditionalSpecs/AtLeastOne.json
+++ b/src/cfnlint/data/AdditionalSpecs/AtLeastOne.json
@@ -28,6 +28,12 @@
         "Ipv6CidrBlock",
         "CidrBlock"
       ]
+    ],
+    "AWS::Events::Rule": [
+      [
+        "EventPattern",
+        "ScheduleExpression"
+      ]
     ]
   }
 }

--- a/src/cfnlint/data/AdditionalSpecs/OnlyOne.json
+++ b/src/cfnlint/data/AdditionalSpecs/OnlyOne.json
@@ -46,6 +46,12 @@
         "MixedInstancesPolicy"
       ]
     ],
+    "AWS::CloudWatch::Alarm": [
+      [
+        "ExtendedStatistic",
+        "Statistic"
+      ]
+    ],
     "AWS::CodePipeline::Pipeline": [
       [
         "ArtifactStore",

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
@@ -10636,13 +10636,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-events-eventbuspolicy-condition.html#cfn-events-eventbuspolicy-condition-key",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchEventBusPolicyConditionKey"
+          }
         },
         "Type": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-events-eventbuspolicy-condition.html#cfn-events-eventbuspolicy-condition-type",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchEventBusPolicyConditionType"
+          }
         },
         "Value": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-events-eventbuspolicy-condition.html#cfn-events-eventbuspolicy-condition-value",
@@ -19742,7 +19748,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-comparisonoperator",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchAlarmComparisonOperator"
+          }
         },
         "DatapointsToAlarm": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-datapointstoalarm",
@@ -19821,7 +19830,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-statistic",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchAlarmStatistic"
+          }
         },
         "Threshold": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-threshold",
@@ -19833,13 +19845,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-treatmissingdata",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchAlarmTreatMissingData"
+          }
         },
         "Unit": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-unit",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchAlarmUnit"
+          }
         }
       }
     },
@@ -25307,7 +25325,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbuspolicy.html#cfn-events-eventbuspolicy-action",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchEventBusPolicyAction"
+          }
         },
         "Condition": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbuspolicy.html#cfn-events-eventbuspolicy-condition",
@@ -25371,7 +25392,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-rule.html#cfn-events-rule-state",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchEventRuleState"
+          }
         },
         "Targets": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-rule.html#cfn-events-rule-targets",
@@ -31929,6 +31953,83 @@
       "AllowedValues": [
         "DNS",
         "EMAIL"
+      ]
+    },
+    "CloudWatchAlarmComparisonOperator": {
+      "AllowedValues": [
+        "GreaterThanOrEqualToThreshold",
+        "GreaterThanThreshold",
+        "LessThanOrEqualToThreshold.",
+        "LessThanThreshold"
+      ]
+    },
+    "CloudWatchAlarmStatistic": {
+      "AllowedValues": [
+        "Average",
+        "Maximum",
+        "Minimum",
+        "SampleCount",
+        "Sum"
+      ]
+    },
+    "CloudWatchAlarmTreatMissingData": {
+      "AllowedValues": [
+        "breaching",
+        "ignore",
+        "missing",
+        "notBreaching"
+      ]
+    },
+    "CloudWatchAlarmUnit": {
+      "AllowedValues": [
+        "Bits",
+        "Bits/Second",
+        "Bytes",
+        "Bytes/Second",
+        "Count",
+        "Count/Second",
+        "Gigabits",
+        "Gigabits/Second",
+        "Gigabytes",
+        "Gigabytes/Second",
+        "Kilobits",
+        "Kilobits/Second",
+        "Kilobytes",
+        "Kilobytes/Second",
+        "Megabits",
+        "Megabits/Second",
+        "Megabytes",
+        "Megabytes/Second",
+        "Microseconds",
+        "Milliseconds",
+        "None",
+        "Percent",
+        "Seconds",
+        "Terabits",
+        "Terabits/Second",
+        "Terabytes",
+        "Terabytes/Second"
+      ]
+    },
+    "CloudWatchEventBusPolicyAction": {
+      "AllowedValues": [
+        "events:PutEvents"
+      ]
+    },
+    "CloudWatchEventBusPolicyConditionKey": {
+      "AllowedValues": [
+        "aws:PrincipalOrgID"
+      ]
+    },
+    "CloudWatchEventBusPolicyConditionType": {
+      "AllowedValues": [
+        "StringEquals"
+      ]
+    },
+    "CloudWatchEventRuleState": {
+      "AllowedValues": [
+        "DISABLED",
+        "ENABLED"
       ]
     },
     "CodeBuildArtifactPackaging": {

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
@@ -10326,13 +10326,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-events-eventbuspolicy-condition.html#cfn-events-eventbuspolicy-condition-key",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchEventBusPolicyConditionKey"
+          }
         },
         "Type": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-events-eventbuspolicy-condition.html#cfn-events-eventbuspolicy-condition-type",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchEventBusPolicyConditionType"
+          }
         },
         "Value": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-events-eventbuspolicy-condition.html#cfn-events-eventbuspolicy-condition-value",
@@ -18061,7 +18067,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-comparisonoperator",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchAlarmComparisonOperator"
+          }
         },
         "DatapointsToAlarm": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-datapointstoalarm",
@@ -18140,7 +18149,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-statistic",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchAlarmStatistic"
+          }
         },
         "Threshold": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-threshold",
@@ -18152,13 +18164,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-treatmissingdata",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchAlarmTreatMissingData"
+          }
         },
         "Unit": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-unit",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchAlarmUnit"
+          }
         }
       }
     },
@@ -23445,7 +23463,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbuspolicy.html#cfn-events-eventbuspolicy-action",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchEventBusPolicyAction"
+          }
         },
         "Condition": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbuspolicy.html#cfn-events-eventbuspolicy-condition",
@@ -23509,7 +23530,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-rule.html#cfn-events-rule-state",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchEventRuleState"
+          }
         },
         "Targets": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-rule.html#cfn-events-rule-targets",
@@ -29277,6 +29301,83 @@
       "AllowedValues": [
         "DNS",
         "EMAIL"
+      ]
+    },
+    "CloudWatchAlarmComparisonOperator": {
+      "AllowedValues": [
+        "GreaterThanOrEqualToThreshold",
+        "GreaterThanThreshold",
+        "LessThanOrEqualToThreshold.",
+        "LessThanThreshold"
+      ]
+    },
+    "CloudWatchAlarmStatistic": {
+      "AllowedValues": [
+        "Average",
+        "Maximum",
+        "Minimum",
+        "SampleCount",
+        "Sum"
+      ]
+    },
+    "CloudWatchAlarmTreatMissingData": {
+      "AllowedValues": [
+        "breaching",
+        "ignore",
+        "missing",
+        "notBreaching"
+      ]
+    },
+    "CloudWatchAlarmUnit": {
+      "AllowedValues": [
+        "Bits",
+        "Bits/Second",
+        "Bytes",
+        "Bytes/Second",
+        "Count",
+        "Count/Second",
+        "Gigabits",
+        "Gigabits/Second",
+        "Gigabytes",
+        "Gigabytes/Second",
+        "Kilobits",
+        "Kilobits/Second",
+        "Kilobytes",
+        "Kilobytes/Second",
+        "Megabits",
+        "Megabits/Second",
+        "Megabytes",
+        "Megabytes/Second",
+        "Microseconds",
+        "Milliseconds",
+        "None",
+        "Percent",
+        "Seconds",
+        "Terabits",
+        "Terabits/Second",
+        "Terabytes",
+        "Terabytes/Second"
+      ]
+    },
+    "CloudWatchEventBusPolicyAction": {
+      "AllowedValues": [
+        "events:PutEvents"
+      ]
+    },
+    "CloudWatchEventBusPolicyConditionKey": {
+      "AllowedValues": [
+        "aws:PrincipalOrgID"
+      ]
+    },
+    "CloudWatchEventBusPolicyConditionType": {
+      "AllowedValues": [
+        "StringEquals"
+      ]
+    },
+    "CloudWatchEventRuleState": {
+      "AllowedValues": [
+        "DISABLED",
+        "ENABLED"
       ]
     },
     "CodeBuildArtifactPackaging": {

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
@@ -12782,7 +12782,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-comparisonoperator",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchAlarmComparisonOperator"
+          }
         },
         "DatapointsToAlarm": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-datapointstoalarm",
@@ -12861,7 +12864,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-statistic",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchAlarmStatistic"
+          }
         },
         "Threshold": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-threshold",
@@ -12873,13 +12879,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-treatmissingdata",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchAlarmTreatMissingData"
+          }
         },
         "Unit": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-unit",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchAlarmUnit"
+          }
         }
       }
     },
@@ -17099,7 +17111,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-rule.html#cfn-events-rule-state",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchEventRuleState"
+          }
         },
         "Targets": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-rule.html#cfn-events-rule-targets",
@@ -21056,6 +21071,83 @@
       "AllowedValues": [
         "DNS",
         "EMAIL"
+      ]
+    },
+    "CloudWatchAlarmComparisonOperator": {
+      "AllowedValues": [
+        "GreaterThanOrEqualToThreshold",
+        "GreaterThanThreshold",
+        "LessThanOrEqualToThreshold.",
+        "LessThanThreshold"
+      ]
+    },
+    "CloudWatchAlarmStatistic": {
+      "AllowedValues": [
+        "Average",
+        "Maximum",
+        "Minimum",
+        "SampleCount",
+        "Sum"
+      ]
+    },
+    "CloudWatchAlarmTreatMissingData": {
+      "AllowedValues": [
+        "breaching",
+        "ignore",
+        "missing",
+        "notBreaching"
+      ]
+    },
+    "CloudWatchAlarmUnit": {
+      "AllowedValues": [
+        "Bits",
+        "Bits/Second",
+        "Bytes",
+        "Bytes/Second",
+        "Count",
+        "Count/Second",
+        "Gigabits",
+        "Gigabits/Second",
+        "Gigabytes",
+        "Gigabytes/Second",
+        "Kilobits",
+        "Kilobits/Second",
+        "Kilobytes",
+        "Kilobytes/Second",
+        "Megabits",
+        "Megabits/Second",
+        "Megabytes",
+        "Megabytes/Second",
+        "Microseconds",
+        "Milliseconds",
+        "None",
+        "Percent",
+        "Seconds",
+        "Terabits",
+        "Terabits/Second",
+        "Terabytes",
+        "Terabytes/Second"
+      ]
+    },
+    "CloudWatchEventBusPolicyAction": {
+      "AllowedValues": [
+        "events:PutEvents"
+      ]
+    },
+    "CloudWatchEventBusPolicyConditionKey": {
+      "AllowedValues": [
+        "aws:PrincipalOrgID"
+      ]
+    },
+    "CloudWatchEventBusPolicyConditionType": {
+      "AllowedValues": [
+        "StringEquals"
+      ]
+    },
+    "CloudWatchEventRuleState": {
+      "AllowedValues": [
+        "DISABLED",
+        "ENABLED"
       ]
     },
     "CodeBuildArtifactPackaging": {

--- a/src/cfnlint/data/CloudSpecs/ap-south-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-south-1.json
@@ -9766,13 +9766,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-events-eventbuspolicy-condition.html#cfn-events-eventbuspolicy-condition-key",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchEventBusPolicyConditionKey"
+          }
         },
         "Type": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-events-eventbuspolicy-condition.html#cfn-events-eventbuspolicy-condition-type",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchEventBusPolicyConditionType"
+          }
         },
         "Value": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-events-eventbuspolicy-condition.html#cfn-events-eventbuspolicy-condition-value",
@@ -17285,7 +17291,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-comparisonoperator",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchAlarmComparisonOperator"
+          }
         },
         "DatapointsToAlarm": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-datapointstoalarm",
@@ -17364,7 +17373,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-statistic",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchAlarmStatistic"
+          }
         },
         "Threshold": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-threshold",
@@ -17376,13 +17388,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-treatmissingdata",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchAlarmTreatMissingData"
+          }
         },
         "Unit": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-unit",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchAlarmUnit"
+          }
         }
       }
     },
@@ -22285,7 +22303,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbuspolicy.html#cfn-events-eventbuspolicy-action",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchEventBusPolicyAction"
+          }
         },
         "Condition": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbuspolicy.html#cfn-events-eventbuspolicy-condition",
@@ -22349,7 +22370,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-rule.html#cfn-events-rule-state",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchEventRuleState"
+          }
         },
         "Targets": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-rule.html#cfn-events-rule-targets",
@@ -28109,6 +28133,83 @@
       "AllowedValues": [
         "DNS",
         "EMAIL"
+      ]
+    },
+    "CloudWatchAlarmComparisonOperator": {
+      "AllowedValues": [
+        "GreaterThanOrEqualToThreshold",
+        "GreaterThanThreshold",
+        "LessThanOrEqualToThreshold.",
+        "LessThanThreshold"
+      ]
+    },
+    "CloudWatchAlarmStatistic": {
+      "AllowedValues": [
+        "Average",
+        "Maximum",
+        "Minimum",
+        "SampleCount",
+        "Sum"
+      ]
+    },
+    "CloudWatchAlarmTreatMissingData": {
+      "AllowedValues": [
+        "breaching",
+        "ignore",
+        "missing",
+        "notBreaching"
+      ]
+    },
+    "CloudWatchAlarmUnit": {
+      "AllowedValues": [
+        "Bits",
+        "Bits/Second",
+        "Bytes",
+        "Bytes/Second",
+        "Count",
+        "Count/Second",
+        "Gigabits",
+        "Gigabits/Second",
+        "Gigabytes",
+        "Gigabytes/Second",
+        "Kilobits",
+        "Kilobits/Second",
+        "Kilobytes",
+        "Kilobytes/Second",
+        "Megabits",
+        "Megabits/Second",
+        "Megabytes",
+        "Megabytes/Second",
+        "Microseconds",
+        "Milliseconds",
+        "None",
+        "Percent",
+        "Seconds",
+        "Terabits",
+        "Terabits/Second",
+        "Terabytes",
+        "Terabytes/Second"
+      ]
+    },
+    "CloudWatchEventBusPolicyAction": {
+      "AllowedValues": [
+        "events:PutEvents"
+      ]
+    },
+    "CloudWatchEventBusPolicyConditionKey": {
+      "AllowedValues": [
+        "aws:PrincipalOrgID"
+      ]
+    },
+    "CloudWatchEventBusPolicyConditionType": {
+      "AllowedValues": [
+        "StringEquals"
+      ]
+    },
+    "CloudWatchEventRuleState": {
+      "AllowedValues": [
+        "DISABLED",
+        "ENABLED"
       ]
     },
     "CodeBuildArtifactPackaging": {

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
@@ -10128,13 +10128,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-events-eventbuspolicy-condition.html#cfn-events-eventbuspolicy-condition-key",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchEventBusPolicyConditionKey"
+          }
         },
         "Type": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-events-eventbuspolicy-condition.html#cfn-events-eventbuspolicy-condition-type",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchEventBusPolicyConditionType"
+          }
         },
         "Value": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-events-eventbuspolicy-condition.html#cfn-events-eventbuspolicy-condition-value",
@@ -18325,7 +18331,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-comparisonoperator",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchAlarmComparisonOperator"
+          }
         },
         "DatapointsToAlarm": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-datapointstoalarm",
@@ -18404,7 +18413,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-statistic",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchAlarmStatistic"
+          }
         },
         "Threshold": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-threshold",
@@ -18416,13 +18428,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-treatmissingdata",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchAlarmTreatMissingData"
+          }
         },
         "Unit": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-unit",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchAlarmUnit"
+          }
         }
       }
     },
@@ -23366,7 +23384,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbuspolicy.html#cfn-events-eventbuspolicy-action",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchEventBusPolicyAction"
+          }
         },
         "Condition": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbuspolicy.html#cfn-events-eventbuspolicy-condition",
@@ -23430,7 +23451,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-rule.html#cfn-events-rule-state",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchEventRuleState"
+          }
         },
         "Targets": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-rule.html#cfn-events-rule-targets",
@@ -29404,6 +29428,83 @@
       "AllowedValues": [
         "DNS",
         "EMAIL"
+      ]
+    },
+    "CloudWatchAlarmComparisonOperator": {
+      "AllowedValues": [
+        "GreaterThanOrEqualToThreshold",
+        "GreaterThanThreshold",
+        "LessThanOrEqualToThreshold.",
+        "LessThanThreshold"
+      ]
+    },
+    "CloudWatchAlarmStatistic": {
+      "AllowedValues": [
+        "Average",
+        "Maximum",
+        "Minimum",
+        "SampleCount",
+        "Sum"
+      ]
+    },
+    "CloudWatchAlarmTreatMissingData": {
+      "AllowedValues": [
+        "breaching",
+        "ignore",
+        "missing",
+        "notBreaching"
+      ]
+    },
+    "CloudWatchAlarmUnit": {
+      "AllowedValues": [
+        "Bits",
+        "Bits/Second",
+        "Bytes",
+        "Bytes/Second",
+        "Count",
+        "Count/Second",
+        "Gigabits",
+        "Gigabits/Second",
+        "Gigabytes",
+        "Gigabytes/Second",
+        "Kilobits",
+        "Kilobits/Second",
+        "Kilobytes",
+        "Kilobytes/Second",
+        "Megabits",
+        "Megabits/Second",
+        "Megabytes",
+        "Megabytes/Second",
+        "Microseconds",
+        "Milliseconds",
+        "None",
+        "Percent",
+        "Seconds",
+        "Terabits",
+        "Terabits/Second",
+        "Terabytes",
+        "Terabytes/Second"
+      ]
+    },
+    "CloudWatchEventBusPolicyAction": {
+      "AllowedValues": [
+        "events:PutEvents"
+      ]
+    },
+    "CloudWatchEventBusPolicyConditionKey": {
+      "AllowedValues": [
+        "aws:PrincipalOrgID"
+      ]
+    },
+    "CloudWatchEventBusPolicyConditionType": {
+      "AllowedValues": [
+        "StringEquals"
+      ]
+    },
+    "CloudWatchEventRuleState": {
+      "AllowedValues": [
+        "DISABLED",
+        "ENABLED"
       ]
     },
     "CodeBuildArtifactPackaging": {

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
@@ -10625,13 +10625,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-events-eventbuspolicy-condition.html#cfn-events-eventbuspolicy-condition-key",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchEventBusPolicyConditionKey"
+          }
         },
         "Type": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-events-eventbuspolicy-condition.html#cfn-events-eventbuspolicy-condition-type",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchEventBusPolicyConditionType"
+          }
         },
         "Value": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-events-eventbuspolicy-condition.html#cfn-events-eventbuspolicy-condition-value",
@@ -18865,7 +18871,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-comparisonoperator",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchAlarmComparisonOperator"
+          }
         },
         "DatapointsToAlarm": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-datapointstoalarm",
@@ -18944,7 +18953,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-statistic",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchAlarmStatistic"
+          }
         },
         "Threshold": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-threshold",
@@ -18956,13 +18968,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-treatmissingdata",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchAlarmTreatMissingData"
+          }
         },
         "Unit": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-unit",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchAlarmUnit"
+          }
         }
       }
     },
@@ -24290,7 +24308,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbuspolicy.html#cfn-events-eventbuspolicy-action",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchEventBusPolicyAction"
+          }
         },
         "Condition": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbuspolicy.html#cfn-events-eventbuspolicy-condition",
@@ -24354,7 +24375,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-rule.html#cfn-events-rule-state",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchEventRuleState"
+          }
         },
         "Targets": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-rule.html#cfn-events-rule-targets",
@@ -30282,6 +30306,83 @@
       "AllowedValues": [
         "DNS",
         "EMAIL"
+      ]
+    },
+    "CloudWatchAlarmComparisonOperator": {
+      "AllowedValues": [
+        "GreaterThanOrEqualToThreshold",
+        "GreaterThanThreshold",
+        "LessThanOrEqualToThreshold.",
+        "LessThanThreshold"
+      ]
+    },
+    "CloudWatchAlarmStatistic": {
+      "AllowedValues": [
+        "Average",
+        "Maximum",
+        "Minimum",
+        "SampleCount",
+        "Sum"
+      ]
+    },
+    "CloudWatchAlarmTreatMissingData": {
+      "AllowedValues": [
+        "breaching",
+        "ignore",
+        "missing",
+        "notBreaching"
+      ]
+    },
+    "CloudWatchAlarmUnit": {
+      "AllowedValues": [
+        "Bits",
+        "Bits/Second",
+        "Bytes",
+        "Bytes/Second",
+        "Count",
+        "Count/Second",
+        "Gigabits",
+        "Gigabits/Second",
+        "Gigabytes",
+        "Gigabytes/Second",
+        "Kilobits",
+        "Kilobits/Second",
+        "Kilobytes",
+        "Kilobytes/Second",
+        "Megabits",
+        "Megabits/Second",
+        "Megabytes",
+        "Megabytes/Second",
+        "Microseconds",
+        "Milliseconds",
+        "None",
+        "Percent",
+        "Seconds",
+        "Terabits",
+        "Terabits/Second",
+        "Terabytes",
+        "Terabytes/Second"
+      ]
+    },
+    "CloudWatchEventBusPolicyAction": {
+      "AllowedValues": [
+        "events:PutEvents"
+      ]
+    },
+    "CloudWatchEventBusPolicyConditionKey": {
+      "AllowedValues": [
+        "aws:PrincipalOrgID"
+      ]
+    },
+    "CloudWatchEventBusPolicyConditionType": {
+      "AllowedValues": [
+        "StringEquals"
+      ]
+    },
+    "CloudWatchEventRuleState": {
+      "AllowedValues": [
+        "DISABLED",
+        "ENABLED"
       ]
     },
     "CodeBuildArtifactPackaging": {

--- a/src/cfnlint/data/CloudSpecs/ca-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/ca-central-1.json
@@ -9600,13 +9600,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-events-eventbuspolicy-condition.html#cfn-events-eventbuspolicy-condition-key",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchEventBusPolicyConditionKey"
+          }
         },
         "Type": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-events-eventbuspolicy-condition.html#cfn-events-eventbuspolicy-condition-type",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchEventBusPolicyConditionType"
+          }
         },
         "Value": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-events-eventbuspolicy-condition.html#cfn-events-eventbuspolicy-condition-value",
@@ -16111,7 +16117,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-comparisonoperator",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchAlarmComparisonOperator"
+          }
         },
         "DatapointsToAlarm": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-datapointstoalarm",
@@ -16190,7 +16199,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-statistic",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchAlarmStatistic"
+          }
         },
         "Threshold": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-threshold",
@@ -16202,13 +16214,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-treatmissingdata",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchAlarmTreatMissingData"
+          }
         },
         "Unit": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-unit",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchAlarmUnit"
+          }
         }
       }
     },
@@ -21111,7 +21129,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbuspolicy.html#cfn-events-eventbuspolicy-action",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchEventBusPolicyAction"
+          }
         },
         "Condition": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbuspolicy.html#cfn-events-eventbuspolicy-condition",
@@ -21175,7 +21196,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-rule.html#cfn-events-rule-state",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchEventRuleState"
+          }
         },
         "Targets": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-rule.html#cfn-events-rule-targets",
@@ -26469,6 +26493,83 @@
       "AllowedValues": [
         "DNS",
         "EMAIL"
+      ]
+    },
+    "CloudWatchAlarmComparisonOperator": {
+      "AllowedValues": [
+        "GreaterThanOrEqualToThreshold",
+        "GreaterThanThreshold",
+        "LessThanOrEqualToThreshold.",
+        "LessThanThreshold"
+      ]
+    },
+    "CloudWatchAlarmStatistic": {
+      "AllowedValues": [
+        "Average",
+        "Maximum",
+        "Minimum",
+        "SampleCount",
+        "Sum"
+      ]
+    },
+    "CloudWatchAlarmTreatMissingData": {
+      "AllowedValues": [
+        "breaching",
+        "ignore",
+        "missing",
+        "notBreaching"
+      ]
+    },
+    "CloudWatchAlarmUnit": {
+      "AllowedValues": [
+        "Bits",
+        "Bits/Second",
+        "Bytes",
+        "Bytes/Second",
+        "Count",
+        "Count/Second",
+        "Gigabits",
+        "Gigabits/Second",
+        "Gigabytes",
+        "Gigabytes/Second",
+        "Kilobits",
+        "Kilobits/Second",
+        "Kilobytes",
+        "Kilobytes/Second",
+        "Megabits",
+        "Megabits/Second",
+        "Megabytes",
+        "Megabytes/Second",
+        "Microseconds",
+        "Milliseconds",
+        "None",
+        "Percent",
+        "Seconds",
+        "Terabits",
+        "Terabits/Second",
+        "Terabytes",
+        "Terabytes/Second"
+      ]
+    },
+    "CloudWatchEventBusPolicyAction": {
+      "AllowedValues": [
+        "events:PutEvents"
+      ]
+    },
+    "CloudWatchEventBusPolicyConditionKey": {
+      "AllowedValues": [
+        "aws:PrincipalOrgID"
+      ]
+    },
+    "CloudWatchEventBusPolicyConditionType": {
+      "AllowedValues": [
+        "StringEquals"
+      ]
+    },
+    "CloudWatchEventRuleState": {
+      "AllowedValues": [
+        "DISABLED",
+        "ENABLED"
       ]
     },
     "CodeBuildArtifactPackaging": {

--- a/src/cfnlint/data/CloudSpecs/eu-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-central-1.json
@@ -10663,13 +10663,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-events-eventbuspolicy-condition.html#cfn-events-eventbuspolicy-condition-key",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchEventBusPolicyConditionKey"
+          }
         },
         "Type": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-events-eventbuspolicy-condition.html#cfn-events-eventbuspolicy-condition-type",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchEventBusPolicyConditionType"
+          }
         },
         "Value": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-events-eventbuspolicy-condition.html#cfn-events-eventbuspolicy-condition-value",
@@ -19400,7 +19406,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-comparisonoperator",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchAlarmComparisonOperator"
+          }
         },
         "DatapointsToAlarm": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-datapointstoalarm",
@@ -19479,7 +19488,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-statistic",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchAlarmStatistic"
+          }
         },
         "Threshold": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-threshold",
@@ -19491,13 +19503,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-treatmissingdata",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchAlarmTreatMissingData"
+          }
         },
         "Unit": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-unit",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchAlarmUnit"
+          }
         }
       }
     },
@@ -24825,7 +24843,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbuspolicy.html#cfn-events-eventbuspolicy-action",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchEventBusPolicyAction"
+          }
         },
         "Condition": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbuspolicy.html#cfn-events-eventbuspolicy-condition",
@@ -24889,7 +24910,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-rule.html#cfn-events-rule-state",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchEventRuleState"
+          }
         },
         "Targets": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-rule.html#cfn-events-rule-targets",
@@ -31200,6 +31224,83 @@
       "AllowedValues": [
         "DNS",
         "EMAIL"
+      ]
+    },
+    "CloudWatchAlarmComparisonOperator": {
+      "AllowedValues": [
+        "GreaterThanOrEqualToThreshold",
+        "GreaterThanThreshold",
+        "LessThanOrEqualToThreshold.",
+        "LessThanThreshold"
+      ]
+    },
+    "CloudWatchAlarmStatistic": {
+      "AllowedValues": [
+        "Average",
+        "Maximum",
+        "Minimum",
+        "SampleCount",
+        "Sum"
+      ]
+    },
+    "CloudWatchAlarmTreatMissingData": {
+      "AllowedValues": [
+        "breaching",
+        "ignore",
+        "missing",
+        "notBreaching"
+      ]
+    },
+    "CloudWatchAlarmUnit": {
+      "AllowedValues": [
+        "Bits",
+        "Bits/Second",
+        "Bytes",
+        "Bytes/Second",
+        "Count",
+        "Count/Second",
+        "Gigabits",
+        "Gigabits/Second",
+        "Gigabytes",
+        "Gigabytes/Second",
+        "Kilobits",
+        "Kilobits/Second",
+        "Kilobytes",
+        "Kilobytes/Second",
+        "Megabits",
+        "Megabits/Second",
+        "Megabytes",
+        "Megabytes/Second",
+        "Microseconds",
+        "Milliseconds",
+        "None",
+        "Percent",
+        "Seconds",
+        "Terabits",
+        "Terabits/Second",
+        "Terabytes",
+        "Terabytes/Second"
+      ]
+    },
+    "CloudWatchEventBusPolicyAction": {
+      "AllowedValues": [
+        "events:PutEvents"
+      ]
+    },
+    "CloudWatchEventBusPolicyConditionKey": {
+      "AllowedValues": [
+        "aws:PrincipalOrgID"
+      ]
+    },
+    "CloudWatchEventBusPolicyConditionType": {
+      "AllowedValues": [
+        "StringEquals"
+      ]
+    },
+    "CloudWatchEventRuleState": {
+      "AllowedValues": [
+        "DISABLED",
+        "ENABLED"
       ]
     },
     "CodeBuildArtifactPackaging": {

--- a/src/cfnlint/data/CloudSpecs/eu-north-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-north-1.json
@@ -12841,7 +12841,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-comparisonoperator",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchAlarmComparisonOperator"
+          }
         },
         "DatapointsToAlarm": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-datapointstoalarm",
@@ -12920,7 +12923,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-statistic",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchAlarmStatistic"
+          }
         },
         "Threshold": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-threshold",
@@ -12932,13 +12938,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-treatmissingdata",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchAlarmTreatMissingData"
+          }
         },
         "Unit": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-unit",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchAlarmUnit"
+          }
         }
       }
     },
@@ -17561,7 +17573,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-rule.html#cfn-events-rule-state",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchEventRuleState"
+          }
         },
         "Targets": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-rule.html#cfn-events-rule-targets",
@@ -21916,6 +21931,83 @@
       "AllowedValues": [
         "DNS",
         "EMAIL"
+      ]
+    },
+    "CloudWatchAlarmComparisonOperator": {
+      "AllowedValues": [
+        "GreaterThanOrEqualToThreshold",
+        "GreaterThanThreshold",
+        "LessThanOrEqualToThreshold.",
+        "LessThanThreshold"
+      ]
+    },
+    "CloudWatchAlarmStatistic": {
+      "AllowedValues": [
+        "Average",
+        "Maximum",
+        "Minimum",
+        "SampleCount",
+        "Sum"
+      ]
+    },
+    "CloudWatchAlarmTreatMissingData": {
+      "AllowedValues": [
+        "breaching",
+        "ignore",
+        "missing",
+        "notBreaching"
+      ]
+    },
+    "CloudWatchAlarmUnit": {
+      "AllowedValues": [
+        "Bits",
+        "Bits/Second",
+        "Bytes",
+        "Bytes/Second",
+        "Count",
+        "Count/Second",
+        "Gigabits",
+        "Gigabits/Second",
+        "Gigabytes",
+        "Gigabytes/Second",
+        "Kilobits",
+        "Kilobits/Second",
+        "Kilobytes",
+        "Kilobytes/Second",
+        "Megabits",
+        "Megabits/Second",
+        "Megabytes",
+        "Megabytes/Second",
+        "Microseconds",
+        "Milliseconds",
+        "None",
+        "Percent",
+        "Seconds",
+        "Terabits",
+        "Terabits/Second",
+        "Terabytes",
+        "Terabytes/Second"
+      ]
+    },
+    "CloudWatchEventBusPolicyAction": {
+      "AllowedValues": [
+        "events:PutEvents"
+      ]
+    },
+    "CloudWatchEventBusPolicyConditionKey": {
+      "AllowedValues": [
+        "aws:PrincipalOrgID"
+      ]
+    },
+    "CloudWatchEventBusPolicyConditionType": {
+      "AllowedValues": [
+        "StringEquals"
+      ]
+    },
+    "CloudWatchEventRuleState": {
+      "AllowedValues": [
+        "DISABLED",
+        "ENABLED"
       ]
     },
     "CodeBuildArtifactPackaging": {

--- a/src/cfnlint/data/CloudSpecs/eu-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-1.json
@@ -11056,13 +11056,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-events-eventbuspolicy-condition.html#cfn-events-eventbuspolicy-condition-key",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchEventBusPolicyConditionKey"
+          }
         },
         "Type": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-events-eventbuspolicy-condition.html#cfn-events-eventbuspolicy-condition-type",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchEventBusPolicyConditionType"
+          }
         },
         "Value": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-events-eventbuspolicy-condition.html#cfn-events-eventbuspolicy-condition-value",
@@ -21179,7 +21185,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-comparisonoperator",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchAlarmComparisonOperator"
+          }
         },
         "DatapointsToAlarm": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-datapointstoalarm",
@@ -21258,7 +21267,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-statistic",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchAlarmStatistic"
+          }
         },
         "Threshold": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-threshold",
@@ -21270,13 +21282,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-treatmissingdata",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchAlarmTreatMissingData"
+          }
         },
         "Unit": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-unit",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchAlarmUnit"
+          }
         }
       }
     },
@@ -27141,7 +27159,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbuspolicy.html#cfn-events-eventbuspolicy-action",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchEventBusPolicyAction"
+          }
         },
         "Condition": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbuspolicy.html#cfn-events-eventbuspolicy-condition",
@@ -27205,7 +27226,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-rule.html#cfn-events-rule-state",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchEventRuleState"
+          }
         },
         "Targets": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-rule.html#cfn-events-rule-targets",
@@ -34248,6 +34272,83 @@
       "AllowedValues": [
         "DNS",
         "EMAIL"
+      ]
+    },
+    "CloudWatchAlarmComparisonOperator": {
+      "AllowedValues": [
+        "GreaterThanOrEqualToThreshold",
+        "GreaterThanThreshold",
+        "LessThanOrEqualToThreshold.",
+        "LessThanThreshold"
+      ]
+    },
+    "CloudWatchAlarmStatistic": {
+      "AllowedValues": [
+        "Average",
+        "Maximum",
+        "Minimum",
+        "SampleCount",
+        "Sum"
+      ]
+    },
+    "CloudWatchAlarmTreatMissingData": {
+      "AllowedValues": [
+        "breaching",
+        "ignore",
+        "missing",
+        "notBreaching"
+      ]
+    },
+    "CloudWatchAlarmUnit": {
+      "AllowedValues": [
+        "Bits",
+        "Bits/Second",
+        "Bytes",
+        "Bytes/Second",
+        "Count",
+        "Count/Second",
+        "Gigabits",
+        "Gigabits/Second",
+        "Gigabytes",
+        "Gigabytes/Second",
+        "Kilobits",
+        "Kilobits/Second",
+        "Kilobytes",
+        "Kilobytes/Second",
+        "Megabits",
+        "Megabits/Second",
+        "Megabytes",
+        "Megabytes/Second",
+        "Microseconds",
+        "Milliseconds",
+        "None",
+        "Percent",
+        "Seconds",
+        "Terabits",
+        "Terabits/Second",
+        "Terabytes",
+        "Terabytes/Second"
+      ]
+    },
+    "CloudWatchEventBusPolicyAction": {
+      "AllowedValues": [
+        "events:PutEvents"
+      ]
+    },
+    "CloudWatchEventBusPolicyConditionKey": {
+      "AllowedValues": [
+        "aws:PrincipalOrgID"
+      ]
+    },
+    "CloudWatchEventBusPolicyConditionType": {
+      "AllowedValues": [
+        "StringEquals"
+      ]
+    },
+    "CloudWatchEventRuleState": {
+      "AllowedValues": [
+        "DISABLED",
+        "ENABLED"
       ]
     },
     "CodeBuildArtifactPackaging": {

--- a/src/cfnlint/data/CloudSpecs/eu-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-2.json
@@ -10039,13 +10039,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-events-eventbuspolicy-condition.html#cfn-events-eventbuspolicy-condition-key",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchEventBusPolicyConditionKey"
+          }
         },
         "Type": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-events-eventbuspolicy-condition.html#cfn-events-eventbuspolicy-condition-type",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchEventBusPolicyConditionType"
+          }
         },
         "Value": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-events-eventbuspolicy-condition.html#cfn-events-eventbuspolicy-condition-value",
@@ -16643,7 +16649,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-comparisonoperator",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchAlarmComparisonOperator"
+          }
         },
         "DatapointsToAlarm": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-datapointstoalarm",
@@ -16722,7 +16731,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-statistic",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchAlarmStatistic"
+          }
         },
         "Threshold": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-threshold",
@@ -16734,13 +16746,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-treatmissingdata",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchAlarmTreatMissingData"
+          }
         },
         "Unit": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-unit",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchAlarmUnit"
+          }
         }
       }
     },
@@ -22027,7 +22045,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbuspolicy.html#cfn-events-eventbuspolicy-action",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchEventBusPolicyAction"
+          }
         },
         "Condition": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbuspolicy.html#cfn-events-eventbuspolicy-condition",
@@ -22091,7 +22112,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-rule.html#cfn-events-rule-state",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchEventRuleState"
+          }
         },
         "Targets": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-rule.html#cfn-events-rule-targets",
@@ -27770,6 +27794,83 @@
       "AllowedValues": [
         "DNS",
         "EMAIL"
+      ]
+    },
+    "CloudWatchAlarmComparisonOperator": {
+      "AllowedValues": [
+        "GreaterThanOrEqualToThreshold",
+        "GreaterThanThreshold",
+        "LessThanOrEqualToThreshold.",
+        "LessThanThreshold"
+      ]
+    },
+    "CloudWatchAlarmStatistic": {
+      "AllowedValues": [
+        "Average",
+        "Maximum",
+        "Minimum",
+        "SampleCount",
+        "Sum"
+      ]
+    },
+    "CloudWatchAlarmTreatMissingData": {
+      "AllowedValues": [
+        "breaching",
+        "ignore",
+        "missing",
+        "notBreaching"
+      ]
+    },
+    "CloudWatchAlarmUnit": {
+      "AllowedValues": [
+        "Bits",
+        "Bits/Second",
+        "Bytes",
+        "Bytes/Second",
+        "Count",
+        "Count/Second",
+        "Gigabits",
+        "Gigabits/Second",
+        "Gigabytes",
+        "Gigabytes/Second",
+        "Kilobits",
+        "Kilobits/Second",
+        "Kilobytes",
+        "Kilobytes/Second",
+        "Megabits",
+        "Megabits/Second",
+        "Megabytes",
+        "Megabytes/Second",
+        "Microseconds",
+        "Milliseconds",
+        "None",
+        "Percent",
+        "Seconds",
+        "Terabits",
+        "Terabits/Second",
+        "Terabytes",
+        "Terabytes/Second"
+      ]
+    },
+    "CloudWatchEventBusPolicyAction": {
+      "AllowedValues": [
+        "events:PutEvents"
+      ]
+    },
+    "CloudWatchEventBusPolicyConditionKey": {
+      "AllowedValues": [
+        "aws:PrincipalOrgID"
+      ]
+    },
+    "CloudWatchEventBusPolicyConditionType": {
+      "AllowedValues": [
+        "StringEquals"
+      ]
+    },
+    "CloudWatchEventRuleState": {
+      "AllowedValues": [
+        "DISABLED",
+        "ENABLED"
       ]
     },
     "CodeBuildArtifactPackaging": {

--- a/src/cfnlint/data/CloudSpecs/eu-west-3.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-3.json
@@ -8791,13 +8791,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-events-eventbuspolicy-condition.html#cfn-events-eventbuspolicy-condition-key",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchEventBusPolicyConditionKey"
+          }
         },
         "Type": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-events-eventbuspolicy-condition.html#cfn-events-eventbuspolicy-condition-type",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchEventBusPolicyConditionType"
+          }
         },
         "Value": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-events-eventbuspolicy-condition.html#cfn-events-eventbuspolicy-condition-value",
@@ -15067,7 +15073,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-comparisonoperator",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchAlarmComparisonOperator"
+          }
         },
         "DatapointsToAlarm": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-datapointstoalarm",
@@ -15146,7 +15155,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-statistic",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchAlarmStatistic"
+          }
         },
         "Threshold": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-threshold",
@@ -15158,13 +15170,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-treatmissingdata",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchAlarmTreatMissingData"
+          }
         },
         "Unit": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-unit",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchAlarmUnit"
+          }
         }
       }
     },
@@ -19623,7 +19641,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbuspolicy.html#cfn-events-eventbuspolicy-action",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchEventBusPolicyAction"
+          }
         },
         "Condition": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbuspolicy.html#cfn-events-eventbuspolicy-condition",
@@ -19687,7 +19708,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-rule.html#cfn-events-rule-state",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchEventRuleState"
+          }
         },
         "Targets": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-rule.html#cfn-events-rule-targets",
@@ -24652,6 +24676,83 @@
       "AllowedValues": [
         "DNS",
         "EMAIL"
+      ]
+    },
+    "CloudWatchAlarmComparisonOperator": {
+      "AllowedValues": [
+        "GreaterThanOrEqualToThreshold",
+        "GreaterThanThreshold",
+        "LessThanOrEqualToThreshold.",
+        "LessThanThreshold"
+      ]
+    },
+    "CloudWatchAlarmStatistic": {
+      "AllowedValues": [
+        "Average",
+        "Maximum",
+        "Minimum",
+        "SampleCount",
+        "Sum"
+      ]
+    },
+    "CloudWatchAlarmTreatMissingData": {
+      "AllowedValues": [
+        "breaching",
+        "ignore",
+        "missing",
+        "notBreaching"
+      ]
+    },
+    "CloudWatchAlarmUnit": {
+      "AllowedValues": [
+        "Bits",
+        "Bits/Second",
+        "Bytes",
+        "Bytes/Second",
+        "Count",
+        "Count/Second",
+        "Gigabits",
+        "Gigabits/Second",
+        "Gigabytes",
+        "Gigabytes/Second",
+        "Kilobits",
+        "Kilobits/Second",
+        "Kilobytes",
+        "Kilobytes/Second",
+        "Megabits",
+        "Megabits/Second",
+        "Megabytes",
+        "Megabytes/Second",
+        "Microseconds",
+        "Milliseconds",
+        "None",
+        "Percent",
+        "Seconds",
+        "Terabits",
+        "Terabits/Second",
+        "Terabytes",
+        "Terabytes/Second"
+      ]
+    },
+    "CloudWatchEventBusPolicyAction": {
+      "AllowedValues": [
+        "events:PutEvents"
+      ]
+    },
+    "CloudWatchEventBusPolicyConditionKey": {
+      "AllowedValues": [
+        "aws:PrincipalOrgID"
+      ]
+    },
+    "CloudWatchEventBusPolicyConditionType": {
+      "AllowedValues": [
+        "StringEquals"
+      ]
+    },
+    "CloudWatchEventRuleState": {
+      "AllowedValues": [
+        "DISABLED",
+        "ENABLED"
       ]
     },
     "CodeBuildArtifactPackaging": {

--- a/src/cfnlint/data/CloudSpecs/sa-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/sa-east-1.json
@@ -9286,13 +9286,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-events-eventbuspolicy-condition.html#cfn-events-eventbuspolicy-condition-key",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchEventBusPolicyConditionKey"
+          }
         },
         "Type": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-events-eventbuspolicy-condition.html#cfn-events-eventbuspolicy-condition-type",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchEventBusPolicyConditionType"
+          }
         },
         "Value": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-events-eventbuspolicy-condition.html#cfn-events-eventbuspolicy-condition-value",
@@ -15648,7 +15654,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-comparisonoperator",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchAlarmComparisonOperator"
+          }
         },
         "DatapointsToAlarm": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-datapointstoalarm",
@@ -15727,7 +15736,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-statistic",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchAlarmStatistic"
+          }
         },
         "Threshold": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-threshold",
@@ -15739,13 +15751,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-treatmissingdata",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchAlarmTreatMissingData"
+          }
         },
         "Unit": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-unit",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchAlarmUnit"
+          }
         }
       }
     },
@@ -20479,7 +20497,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbuspolicy.html#cfn-events-eventbuspolicy-action",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchEventBusPolicyAction"
+          }
         },
         "Condition": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbuspolicy.html#cfn-events-eventbuspolicy-condition",
@@ -20543,7 +20564,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-rule.html#cfn-events-rule-state",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchEventRuleState"
+          }
         },
         "Targets": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-rule.html#cfn-events-rule-targets",
@@ -25643,6 +25667,83 @@
       "AllowedValues": [
         "DNS",
         "EMAIL"
+      ]
+    },
+    "CloudWatchAlarmComparisonOperator": {
+      "AllowedValues": [
+        "GreaterThanOrEqualToThreshold",
+        "GreaterThanThreshold",
+        "LessThanOrEqualToThreshold.",
+        "LessThanThreshold"
+      ]
+    },
+    "CloudWatchAlarmStatistic": {
+      "AllowedValues": [
+        "Average",
+        "Maximum",
+        "Minimum",
+        "SampleCount",
+        "Sum"
+      ]
+    },
+    "CloudWatchAlarmTreatMissingData": {
+      "AllowedValues": [
+        "breaching",
+        "ignore",
+        "missing",
+        "notBreaching"
+      ]
+    },
+    "CloudWatchAlarmUnit": {
+      "AllowedValues": [
+        "Bits",
+        "Bits/Second",
+        "Bytes",
+        "Bytes/Second",
+        "Count",
+        "Count/Second",
+        "Gigabits",
+        "Gigabits/Second",
+        "Gigabytes",
+        "Gigabytes/Second",
+        "Kilobits",
+        "Kilobits/Second",
+        "Kilobytes",
+        "Kilobytes/Second",
+        "Megabits",
+        "Megabits/Second",
+        "Megabytes",
+        "Megabytes/Second",
+        "Microseconds",
+        "Milliseconds",
+        "None",
+        "Percent",
+        "Seconds",
+        "Terabits",
+        "Terabits/Second",
+        "Terabytes",
+        "Terabytes/Second"
+      ]
+    },
+    "CloudWatchEventBusPolicyAction": {
+      "AllowedValues": [
+        "events:PutEvents"
+      ]
+    },
+    "CloudWatchEventBusPolicyConditionKey": {
+      "AllowedValues": [
+        "aws:PrincipalOrgID"
+      ]
+    },
+    "CloudWatchEventBusPolicyConditionType": {
+      "AllowedValues": [
+        "StringEquals"
+      ]
+    },
+    "CloudWatchEventRuleState": {
+      "AllowedValues": [
+        "DISABLED",
+        "ENABLED"
       ]
     },
     "CodeBuildArtifactPackaging": {

--- a/src/cfnlint/data/CloudSpecs/us-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-1.json
@@ -11075,13 +11075,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-events-eventbuspolicy-condition.html#cfn-events-eventbuspolicy-condition-key",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchEventBusPolicyConditionKey"
+          }
         },
         "Type": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-events-eventbuspolicy-condition.html#cfn-events-eventbuspolicy-condition-type",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchEventBusPolicyConditionType"
+          }
         },
         "Value": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-events-eventbuspolicy-condition.html#cfn-events-eventbuspolicy-condition-value",
@@ -21180,7 +21186,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-comparisonoperator",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchAlarmComparisonOperator"
+          }
         },
         "DatapointsToAlarm": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-datapointstoalarm",
@@ -21259,7 +21268,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-statistic",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchAlarmStatistic"
+          }
         },
         "Threshold": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-threshold",
@@ -21271,13 +21283,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-treatmissingdata",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchAlarmTreatMissingData"
+          }
         },
         "Unit": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-unit",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchAlarmUnit"
+          }
         }
       }
     },
@@ -27212,7 +27230,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbuspolicy.html#cfn-events-eventbuspolicy-action",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchEventBusPolicyAction"
+          }
         },
         "Condition": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbuspolicy.html#cfn-events-eventbuspolicy-condition",
@@ -27276,7 +27297,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-rule.html#cfn-events-rule-state",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchEventRuleState"
+          }
         },
         "Targets": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-rule.html#cfn-events-rule-targets",
@@ -34319,6 +34343,83 @@
       "AllowedValues": [
         "DNS",
         "EMAIL"
+      ]
+    },
+    "CloudWatchAlarmComparisonOperator": {
+      "AllowedValues": [
+        "GreaterThanOrEqualToThreshold",
+        "GreaterThanThreshold",
+        "LessThanOrEqualToThreshold.",
+        "LessThanThreshold"
+      ]
+    },
+    "CloudWatchAlarmStatistic": {
+      "AllowedValues": [
+        "Average",
+        "Maximum",
+        "Minimum",
+        "SampleCount",
+        "Sum"
+      ]
+    },
+    "CloudWatchAlarmTreatMissingData": {
+      "AllowedValues": [
+        "breaching",
+        "ignore",
+        "missing",
+        "notBreaching"
+      ]
+    },
+    "CloudWatchAlarmUnit": {
+      "AllowedValues": [
+        "Bits",
+        "Bits/Second",
+        "Bytes",
+        "Bytes/Second",
+        "Count",
+        "Count/Second",
+        "Gigabits",
+        "Gigabits/Second",
+        "Gigabytes",
+        "Gigabytes/Second",
+        "Kilobits",
+        "Kilobits/Second",
+        "Kilobytes",
+        "Kilobytes/Second",
+        "Megabits",
+        "Megabits/Second",
+        "Megabytes",
+        "Megabytes/Second",
+        "Microseconds",
+        "Milliseconds",
+        "None",
+        "Percent",
+        "Seconds",
+        "Terabits",
+        "Terabits/Second",
+        "Terabytes",
+        "Terabytes/Second"
+      ]
+    },
+    "CloudWatchEventBusPolicyAction": {
+      "AllowedValues": [
+        "events:PutEvents"
+      ]
+    },
+    "CloudWatchEventBusPolicyConditionKey": {
+      "AllowedValues": [
+        "aws:PrincipalOrgID"
+      ]
+    },
+    "CloudWatchEventBusPolicyConditionType": {
+      "AllowedValues": [
+        "StringEquals"
+      ]
+    },
+    "CloudWatchEventRuleState": {
+      "AllowedValues": [
+        "DISABLED",
+        "ENABLED"
       ]
     },
     "CodeBuildArtifactPackaging": {

--- a/src/cfnlint/data/CloudSpecs/us-east-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-2.json
@@ -10524,13 +10524,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-events-eventbuspolicy-condition.html#cfn-events-eventbuspolicy-condition-key",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchEventBusPolicyConditionKey"
+          }
         },
         "Type": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-events-eventbuspolicy-condition.html#cfn-events-eventbuspolicy-condition-type",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchEventBusPolicyConditionType"
+          }
         },
         "Value": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-events-eventbuspolicy-condition.html#cfn-events-eventbuspolicy-condition-value",
@@ -19679,7 +19685,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-comparisonoperator",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchAlarmComparisonOperator"
+          }
         },
         "DatapointsToAlarm": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-datapointstoalarm",
@@ -19758,7 +19767,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-statistic",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchAlarmStatistic"
+          }
         },
         "Threshold": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-threshold",
@@ -19770,13 +19782,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-treatmissingdata",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchAlarmTreatMissingData"
+          }
         },
         "Unit": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-unit",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchAlarmUnit"
+          }
         }
       }
     },
@@ -25383,7 +25401,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbuspolicy.html#cfn-events-eventbuspolicy-action",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchEventBusPolicyAction"
+          }
         },
         "Condition": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbuspolicy.html#cfn-events-eventbuspolicy-condition",
@@ -25447,7 +25468,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-rule.html#cfn-events-rule-state",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchEventRuleState"
+          }
         },
         "Targets": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-rule.html#cfn-events-rule-targets",
@@ -32234,6 +32258,83 @@
       "AllowedValues": [
         "DNS",
         "EMAIL"
+      ]
+    },
+    "CloudWatchAlarmComparisonOperator": {
+      "AllowedValues": [
+        "GreaterThanOrEqualToThreshold",
+        "GreaterThanThreshold",
+        "LessThanOrEqualToThreshold.",
+        "LessThanThreshold"
+      ]
+    },
+    "CloudWatchAlarmStatistic": {
+      "AllowedValues": [
+        "Average",
+        "Maximum",
+        "Minimum",
+        "SampleCount",
+        "Sum"
+      ]
+    },
+    "CloudWatchAlarmTreatMissingData": {
+      "AllowedValues": [
+        "breaching",
+        "ignore",
+        "missing",
+        "notBreaching"
+      ]
+    },
+    "CloudWatchAlarmUnit": {
+      "AllowedValues": [
+        "Bits",
+        "Bits/Second",
+        "Bytes",
+        "Bytes/Second",
+        "Count",
+        "Count/Second",
+        "Gigabits",
+        "Gigabits/Second",
+        "Gigabytes",
+        "Gigabytes/Second",
+        "Kilobits",
+        "Kilobits/Second",
+        "Kilobytes",
+        "Kilobytes/Second",
+        "Megabits",
+        "Megabits/Second",
+        "Megabytes",
+        "Megabytes/Second",
+        "Microseconds",
+        "Milliseconds",
+        "None",
+        "Percent",
+        "Seconds",
+        "Terabits",
+        "Terabits/Second",
+        "Terabytes",
+        "Terabytes/Second"
+      ]
+    },
+    "CloudWatchEventBusPolicyAction": {
+      "AllowedValues": [
+        "events:PutEvents"
+      ]
+    },
+    "CloudWatchEventBusPolicyConditionKey": {
+      "AllowedValues": [
+        "aws:PrincipalOrgID"
+      ]
+    },
+    "CloudWatchEventBusPolicyConditionType": {
+      "AllowedValues": [
+        "StringEquals"
+      ]
+    },
+    "CloudWatchEventRuleState": {
+      "AllowedValues": [
+        "DISABLED",
+        "ENABLED"
       ]
     },
     "CodeBuildArtifactPackaging": {

--- a/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
@@ -12602,7 +12602,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-comparisonoperator",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchAlarmComparisonOperator"
+          }
         },
         "DatapointsToAlarm": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-datapointstoalarm",
@@ -12681,7 +12684,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-statistic",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchAlarmStatistic"
+          }
         },
         "Threshold": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-threshold",
@@ -12693,13 +12699,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-treatmissingdata",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchAlarmTreatMissingData"
+          }
         },
         "Unit": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-unit",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchAlarmUnit"
+          }
         }
       }
     },
@@ -16846,7 +16858,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-rule.html#cfn-events-rule-state",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchEventRuleState"
+          }
         },
         "Targets": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-rule.html#cfn-events-rule-targets",
@@ -20860,6 +20875,83 @@
       "AllowedValues": [
         "DNS",
         "EMAIL"
+      ]
+    },
+    "CloudWatchAlarmComparisonOperator": {
+      "AllowedValues": [
+        "GreaterThanOrEqualToThreshold",
+        "GreaterThanThreshold",
+        "LessThanOrEqualToThreshold.",
+        "LessThanThreshold"
+      ]
+    },
+    "CloudWatchAlarmStatistic": {
+      "AllowedValues": [
+        "Average",
+        "Maximum",
+        "Minimum",
+        "SampleCount",
+        "Sum"
+      ]
+    },
+    "CloudWatchAlarmTreatMissingData": {
+      "AllowedValues": [
+        "breaching",
+        "ignore",
+        "missing",
+        "notBreaching"
+      ]
+    },
+    "CloudWatchAlarmUnit": {
+      "AllowedValues": [
+        "Bits",
+        "Bits/Second",
+        "Bytes",
+        "Bytes/Second",
+        "Count",
+        "Count/Second",
+        "Gigabits",
+        "Gigabits/Second",
+        "Gigabytes",
+        "Gigabytes/Second",
+        "Kilobits",
+        "Kilobits/Second",
+        "Kilobytes",
+        "Kilobytes/Second",
+        "Megabits",
+        "Megabits/Second",
+        "Megabytes",
+        "Megabytes/Second",
+        "Microseconds",
+        "Milliseconds",
+        "None",
+        "Percent",
+        "Seconds",
+        "Terabits",
+        "Terabits/Second",
+        "Terabytes",
+        "Terabytes/Second"
+      ]
+    },
+    "CloudWatchEventBusPolicyAction": {
+      "AllowedValues": [
+        "events:PutEvents"
+      ]
+    },
+    "CloudWatchEventBusPolicyConditionKey": {
+      "AllowedValues": [
+        "aws:PrincipalOrgID"
+      ]
+    },
+    "CloudWatchEventBusPolicyConditionType": {
+      "AllowedValues": [
+        "StringEquals"
+      ]
+    },
+    "CloudWatchEventRuleState": {
+      "AllowedValues": [
+        "DISABLED",
+        "ENABLED"
       ]
     },
     "CodeBuildArtifactPackaging": {

--- a/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
@@ -7037,13 +7037,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-events-eventbuspolicy-condition.html#cfn-events-eventbuspolicy-condition-key",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchEventBusPolicyConditionKey"
+          }
         },
         "Type": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-events-eventbuspolicy-condition.html#cfn-events-eventbuspolicy-condition-type",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchEventBusPolicyConditionType"
+          }
         },
         "Value": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-events-eventbuspolicy-condition.html#cfn-events-eventbuspolicy-condition-value",
@@ -12690,7 +12696,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-comparisonoperator",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchAlarmComparisonOperator"
+          }
         },
         "DatapointsToAlarm": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-datapointstoalarm",
@@ -12769,7 +12778,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-statistic",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchAlarmStatistic"
+          }
         },
         "Threshold": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-threshold",
@@ -12781,13 +12793,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-treatmissingdata",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchAlarmTreatMissingData"
+          }
         },
         "Unit": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-unit",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchAlarmUnit"
+          }
         }
       }
     },
@@ -16899,7 +16917,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbuspolicy.html#cfn-events-eventbuspolicy-action",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchEventBusPolicyAction"
+          }
         },
         "Condition": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbuspolicy.html#cfn-events-eventbuspolicy-condition",
@@ -16963,7 +16984,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-rule.html#cfn-events-rule-state",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchEventRuleState"
+          }
         },
         "Targets": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-rule.html#cfn-events-rule-targets",
@@ -21095,6 +21119,83 @@
       "AllowedValues": [
         "DNS",
         "EMAIL"
+      ]
+    },
+    "CloudWatchAlarmComparisonOperator": {
+      "AllowedValues": [
+        "GreaterThanOrEqualToThreshold",
+        "GreaterThanThreshold",
+        "LessThanOrEqualToThreshold.",
+        "LessThanThreshold"
+      ]
+    },
+    "CloudWatchAlarmStatistic": {
+      "AllowedValues": [
+        "Average",
+        "Maximum",
+        "Minimum",
+        "SampleCount",
+        "Sum"
+      ]
+    },
+    "CloudWatchAlarmTreatMissingData": {
+      "AllowedValues": [
+        "breaching",
+        "ignore",
+        "missing",
+        "notBreaching"
+      ]
+    },
+    "CloudWatchAlarmUnit": {
+      "AllowedValues": [
+        "Bits",
+        "Bits/Second",
+        "Bytes",
+        "Bytes/Second",
+        "Count",
+        "Count/Second",
+        "Gigabits",
+        "Gigabits/Second",
+        "Gigabytes",
+        "Gigabytes/Second",
+        "Kilobits",
+        "Kilobits/Second",
+        "Kilobytes",
+        "Kilobytes/Second",
+        "Megabits",
+        "Megabits/Second",
+        "Megabytes",
+        "Megabytes/Second",
+        "Microseconds",
+        "Milliseconds",
+        "None",
+        "Percent",
+        "Seconds",
+        "Terabits",
+        "Terabits/Second",
+        "Terabytes",
+        "Terabytes/Second"
+      ]
+    },
+    "CloudWatchEventBusPolicyAction": {
+      "AllowedValues": [
+        "events:PutEvents"
+      ]
+    },
+    "CloudWatchEventBusPolicyConditionKey": {
+      "AllowedValues": [
+        "aws:PrincipalOrgID"
+      ]
+    },
+    "CloudWatchEventBusPolicyConditionType": {
+      "AllowedValues": [
+        "StringEquals"
+      ]
+    },
+    "CloudWatchEventRuleState": {
+      "AllowedValues": [
+        "DISABLED",
+        "ENABLED"
       ]
     },
     "CodeBuildArtifactPackaging": {

--- a/src/cfnlint/data/CloudSpecs/us-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-1.json
@@ -9798,13 +9798,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-events-eventbuspolicy-condition.html#cfn-events-eventbuspolicy-condition-key",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchEventBusPolicyConditionKey"
+          }
         },
         "Type": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-events-eventbuspolicy-condition.html#cfn-events-eventbuspolicy-condition-type",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchEventBusPolicyConditionType"
+          }
         },
         "Value": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-events-eventbuspolicy-condition.html#cfn-events-eventbuspolicy-condition-value",
@@ -16494,7 +16500,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-comparisonoperator",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchAlarmComparisonOperator"
+          }
         },
         "DatapointsToAlarm": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-datapointstoalarm",
@@ -16573,7 +16582,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-statistic",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchAlarmStatistic"
+          }
         },
         "Threshold": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-threshold",
@@ -16585,13 +16597,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-treatmissingdata",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchAlarmTreatMissingData"
+          }
         },
         "Unit": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-unit",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchAlarmUnit"
+          }
         }
       }
     },
@@ -21675,7 +21693,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbuspolicy.html#cfn-events-eventbuspolicy-action",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchEventBusPolicyAction"
+          }
         },
         "Condition": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbuspolicy.html#cfn-events-eventbuspolicy-condition",
@@ -21739,7 +21760,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-rule.html#cfn-events-rule-state",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchEventRuleState"
+          }
         },
         "Targets": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-rule.html#cfn-events-rule-targets",
@@ -27240,6 +27264,83 @@
       "AllowedValues": [
         "DNS",
         "EMAIL"
+      ]
+    },
+    "CloudWatchAlarmComparisonOperator": {
+      "AllowedValues": [
+        "GreaterThanOrEqualToThreshold",
+        "GreaterThanThreshold",
+        "LessThanOrEqualToThreshold.",
+        "LessThanThreshold"
+      ]
+    },
+    "CloudWatchAlarmStatistic": {
+      "AllowedValues": [
+        "Average",
+        "Maximum",
+        "Minimum",
+        "SampleCount",
+        "Sum"
+      ]
+    },
+    "CloudWatchAlarmTreatMissingData": {
+      "AllowedValues": [
+        "breaching",
+        "ignore",
+        "missing",
+        "notBreaching"
+      ]
+    },
+    "CloudWatchAlarmUnit": {
+      "AllowedValues": [
+        "Bits",
+        "Bits/Second",
+        "Bytes",
+        "Bytes/Second",
+        "Count",
+        "Count/Second",
+        "Gigabits",
+        "Gigabits/Second",
+        "Gigabytes",
+        "Gigabytes/Second",
+        "Kilobits",
+        "Kilobits/Second",
+        "Kilobytes",
+        "Kilobytes/Second",
+        "Megabits",
+        "Megabits/Second",
+        "Megabytes",
+        "Megabytes/Second",
+        "Microseconds",
+        "Milliseconds",
+        "None",
+        "Percent",
+        "Seconds",
+        "Terabits",
+        "Terabits/Second",
+        "Terabytes",
+        "Terabytes/Second"
+      ]
+    },
+    "CloudWatchEventBusPolicyAction": {
+      "AllowedValues": [
+        "events:PutEvents"
+      ]
+    },
+    "CloudWatchEventBusPolicyConditionKey": {
+      "AllowedValues": [
+        "aws:PrincipalOrgID"
+      ]
+    },
+    "CloudWatchEventBusPolicyConditionType": {
+      "AllowedValues": [
+        "StringEquals"
+      ]
+    },
+    "CloudWatchEventRuleState": {
+      "AllowedValues": [
+        "DISABLED",
+        "ENABLED"
       ]
     },
     "CodeBuildArtifactPackaging": {

--- a/src/cfnlint/data/CloudSpecs/us-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-2.json
@@ -11075,13 +11075,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-events-eventbuspolicy-condition.html#cfn-events-eventbuspolicy-condition-key",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchEventBusPolicyConditionKey"
+          }
         },
         "Type": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-events-eventbuspolicy-condition.html#cfn-events-eventbuspolicy-condition-type",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchEventBusPolicyConditionType"
+          }
         },
         "Value": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-events-eventbuspolicy-condition.html#cfn-events-eventbuspolicy-condition-value",
@@ -21198,7 +21204,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-comparisonoperator",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchAlarmComparisonOperator"
+          }
         },
         "DatapointsToAlarm": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-datapointstoalarm",
@@ -21277,7 +21286,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-statistic",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchAlarmStatistic"
+          }
         },
         "Threshold": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-threshold",
@@ -21289,13 +21301,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-treatmissingdata",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchAlarmTreatMissingData"
+          }
         },
         "Unit": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-unit",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchAlarmUnit"
+          }
         }
       }
     },
@@ -27200,7 +27218,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbuspolicy.html#cfn-events-eventbuspolicy-action",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchEventBusPolicyAction"
+          }
         },
         "Condition": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbuspolicy.html#cfn-events-eventbuspolicy-condition",
@@ -27264,7 +27285,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-rule.html#cfn-events-rule-state",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudWatchEventRuleState"
+          }
         },
         "Targets": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-rule.html#cfn-events-rule-targets",
@@ -34307,6 +34331,83 @@
       "AllowedValues": [
         "DNS",
         "EMAIL"
+      ]
+    },
+    "CloudWatchAlarmComparisonOperator": {
+      "AllowedValues": [
+        "GreaterThanOrEqualToThreshold",
+        "GreaterThanThreshold",
+        "LessThanOrEqualToThreshold.",
+        "LessThanThreshold"
+      ]
+    },
+    "CloudWatchAlarmStatistic": {
+      "AllowedValues": [
+        "Average",
+        "Maximum",
+        "Minimum",
+        "SampleCount",
+        "Sum"
+      ]
+    },
+    "CloudWatchAlarmTreatMissingData": {
+      "AllowedValues": [
+        "breaching",
+        "ignore",
+        "missing",
+        "notBreaching"
+      ]
+    },
+    "CloudWatchAlarmUnit": {
+      "AllowedValues": [
+        "Bits",
+        "Bits/Second",
+        "Bytes",
+        "Bytes/Second",
+        "Count",
+        "Count/Second",
+        "Gigabits",
+        "Gigabits/Second",
+        "Gigabytes",
+        "Gigabytes/Second",
+        "Kilobits",
+        "Kilobits/Second",
+        "Kilobytes",
+        "Kilobytes/Second",
+        "Megabits",
+        "Megabits/Second",
+        "Megabytes",
+        "Megabytes/Second",
+        "Microseconds",
+        "Milliseconds",
+        "None",
+        "Percent",
+        "Seconds",
+        "Terabits",
+        "Terabits/Second",
+        "Terabytes",
+        "Terabytes/Second"
+      ]
+    },
+    "CloudWatchEventBusPolicyAction": {
+      "AllowedValues": [
+        "events:PutEvents"
+      ]
+    },
+    "CloudWatchEventBusPolicyConditionKey": {
+      "AllowedValues": [
+        "aws:PrincipalOrgID"
+      ]
+    },
+    "CloudWatchEventBusPolicyConditionType": {
+      "AllowedValues": [
+        "StringEquals"
+      ]
+    },
+    "CloudWatchEventRuleState": {
+      "AllowedValues": [
+        "DISABLED",
+        "ENABLED"
       ]
     },
     "CodeBuildArtifactPackaging": {

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
@@ -234,6 +234,83 @@
           "EMAIL"
         ]
       },
+      "CloudWatchAlarmComparisonOperator": {
+        "AllowedValues": [
+          "GreaterThanOrEqualToThreshold",
+          "GreaterThanThreshold",
+          "LessThanOrEqualToThreshold.",
+          "LessThanThreshold"
+        ]
+      },
+      "CloudWatchAlarmStatistic": {
+        "AllowedValues": [
+          "Average",
+          "Maximum",
+          "Minimum",
+          "SampleCount",
+          "Sum"
+        ]
+      },
+      "CloudWatchAlarmTreatMissingData": {
+        "AllowedValues": [
+          "breaching",
+          "ignore",
+          "missing",
+          "notBreaching"
+        ]
+      },
+      "CloudWatchAlarmUnit": {
+        "AllowedValues": [
+          "Bits",
+          "Bits/Second",
+          "Bytes",
+          "Bytes/Second",
+          "Count",
+          "Count/Second",
+          "Gigabits",
+          "Gigabits/Second",
+          "Gigabytes",
+          "Gigabytes/Second",
+          "Kilobits",
+          "Kilobits/Second",
+          "Kilobytes",
+          "Kilobytes/Second",
+          "Megabits",
+          "Megabits/Second",
+          "Megabytes",
+          "Megabytes/Second",
+          "Microseconds",
+          "Milliseconds",
+          "None",
+          "Percent",
+          "Seconds",
+          "Terabits",
+          "Terabits/Second",
+          "Terabytes",
+          "Terabytes/Second"
+        ]
+      },
+      "CloudWatchEventRuleState": {
+        "AllowedValues": [
+          "DISABLED",
+          "ENABLED"
+        ]
+      },
+      "CloudWatchEventBusPolicyAction": {
+        "AllowedValues": [
+          "events:PutEvents"
+        ]
+      },
+      "CloudWatchEventBusPolicyConditionKey": {
+        "AllowedValues": [
+          "aws:PrincipalOrgID"
+        ]
+      },
+      "CloudWatchEventBusPolicyConditionType": {
+        "AllowedValues": [
+          "StringEquals"
+        ]
+      },
       "CodeBuildArtifactPackaging": {
         "AllowedValues": [
           "NONE",

--- a/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
@@ -141,6 +141,20 @@
   },
   {
     "op": "add",
+    "path": "/PropertyTypes/AWS::Events::EventBusPolicy.Condition/Properties/Key/Value",
+    "value": {
+      "ValueType": "CloudWatchEventBusPolicyConditionKey"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/PropertyTypes/AWS::Events::EventBusPolicy.Condition/Properties/Type/Value",
+    "value": {
+      "ValueType": "CloudWatchEventBusPolicyConditionType"
+    }
+  },
+  {
+    "op": "add",
     "path": "/PropertyTypes/AWS::CodeBuild::Project.Artifacts/Properties/Packaging/Value",
     "value": {
       "ValueType": "CodeBuildArtifactPackaging"
@@ -707,6 +721,34 @@
   },
   {
     "op": "add",
+    "path": "/ResourceTypes/AWS::CloudWatch::Alarm/Properties/ComparisonOperator/Value",
+    "value": {
+      "ValueType": "CloudWatchAlarmComparisonOperator"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/ResourceTypes/AWS::CloudWatch::Alarm/Properties/Statistic/Value",
+    "value": {
+      "ValueType": "CloudWatchAlarmStatistic"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/ResourceTypes/AWS::CloudWatch::Alarm/Properties/TreatMissingData/Value",
+    "value": {
+      "ValueType": "CloudWatchAlarmTreatMissingData"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/ResourceTypes/AWS::CloudWatch::Alarm/Properties/Unit/Value",
+    "value": {
+      "ValueType": "CloudWatchAlarmUnit"
+    }
+  },
+  {
+    "op": "add",
     "path": "/ResourceTypes/AWS::CodeBuild::Project/Properties/ServiceRole/Value",
     "value": {
       "ValueType": "IamRole.Arn"
@@ -934,6 +976,20 @@
     "path": "/ResourceTypes/AWS::ElasticLoadBalancingV2::TargetGroup/Properties/VpcId/Value",
     "value": {
       "ValueType": "VpcId"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/ResourceTypes/AWS::Events::Rule/Properties/State/Value",
+    "value": {
+      "ValueType": "CloudWatchEventRuleState"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/ResourceTypes/AWS::Events::EventBusPolicy/Properties/Action/Value",
+    "value": {
+      "ValueType": "CloudWatchEventBusPolicyAction"
     }
   },
   {

--- a/test/fixtures/templates/bad/resources/properties/allowed_values.yaml
+++ b/test/fixtures/templates/bad/resources/properties/allowed_values.yaml
@@ -172,6 +172,30 @@ Resources:
     Properties:
       DomainName: "example.com"
       ValidationMethod: "Dns" # Invalid AllowedValue
+  CloudWatchAlarm:
+    Type: "AWS::CloudWatch::Alarm"
+    Properties:
+      ComparisonOperator: "GreaterThan" # Invalid AllowedValue
+      EvaluationPeriods: 1
+      Statistic: "Total" # Invalid AllowedValue
+      Threshold: 0.0
+      TreatMissingData: "not_breaching" # Invalid AllowedValue
+      Unit: "Teraflops" # Invalid AllowedValue
+  CloudWatchEventRule:
+    Type: "AWS::Events::Rule"
+    Properties:
+      EventPattern: ""
+      State: "SUSPENDED" # Invalid AllowedValue
+  CloudWatchEventBusPolicy:
+    Type: "AWS::Events::EventBusPolicy"
+    Properties:
+      Action: "events:GetEvents" # Invalid AllowedValue
+      Condition:
+        Type: "GreaterOrEquals" # Invalid AllowedValue
+        Key: "aws:PrincipalOrg" # Invalid AllowedValue
+        Value: "o-1234567890"
+      Principal: "*"
+      StatementId: "x"
   CodeBuildProject:
     Type: "AWS::CodeBuild::Project"
     Properties:

--- a/test/fixtures/templates/good/resources/properties/allowed_values.yaml
+++ b/test/fixtures/templates/good/resources/properties/allowed_values.yaml
@@ -172,6 +172,30 @@ Resources:
     Properties:
       DomainName: "example.com"
       ValidationMethod: "DNS" # Valid AllowedValue
+  CloudWatchAlarm:
+    Type: "AWS::CloudWatch::Alarm"
+    Properties:
+      ComparisonOperator: "GreaterThanOrEqualToThreshold" # Valid AllowedValue
+      EvaluationPeriods: 1
+      Statistic: "SampleCount" # Valid AllowedValue
+      Threshold: 0.0
+      TreatMissingData: "notBreaching" # Valid AllowedValue
+      Unit: "Terabits/Second" # Valid AllowedValue
+  CloudWatchEventRule:
+    Type: "AWS::Events::Rule"
+    Properties:
+      EventPattern: ""
+      State: "ENABLED" # Valid AllowedValue
+  CloudWatchEventBusPolicy:
+    Type: "AWS::Events::EventBusPolicy"
+    Properties:
+      Action: "events:PutEvents" # Valid AllowedValue
+      Condition:
+        Type: "StringEquals" # Valid AllowedValue
+        Key: "aws:PrincipalOrgID" # Valid AllowedValue
+        Value: "o-1234567890"
+      Principal: "*"
+      StatementId: "x"
   CodeBuildProject:
     Type: "AWS::CodeBuild::Project"
     Properties:

--- a/test/rules/resources/properties/test_allowed_value.py
+++ b/test/rules/resources/properties/test_allowed_value.py
@@ -34,4 +34,4 @@ class TestAllowedValue(BaseRuleTestCase):
 
     def test_file_negative(self):
         """Test failure"""
-        self.helper_file_negative('test/fixtures/templates/bad/resources/properties/allowed_values.yaml', 92)
+        self.helper_file_negative('test/fixtures/templates/bad/resources/properties/allowed_values.yaml', 100)


### PR DESCRIPTION
*Issue https://github.com/awslabs/cfn-python-lint/issues/50, if available:*

Add all the allowed values of the [`AWS::CloudWatch`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-reference-cloudwatch.html) Allowed Resources

Along the way added some configuration of these resources to the [only_one](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-statistic) and [atleast_one](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-rule.html#cfn-events-rule-eventpattern).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
