### PR TITLE
Add CloudTrail Allowed Values

### DIFF
--- a/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
@@ -3594,7 +3594,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudtrail-trail-dataresource.html#cfn-cloudtrail-trail-dataresource-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudTrailEventSelectorDataResourceType"
+          }
         },
         "Values": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudtrail-trail-dataresource.html#cfn-cloudtrail-trail-dataresource-values",
@@ -3627,7 +3630,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudtrail-trail-eventselector.html#cfn-cloudtrail-trail-eventselector-readwritetype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudTrailEventSelectorReadWriteType"
+          }
         }
       }
     },
@@ -31953,6 +31959,19 @@
       "AllowedValues": [
         "DNS",
         "EMAIL"
+      ]
+    },
+    "CloudTrailEventSelectorDataResourceType": {
+      "AllowedValues": [
+        "AWS::Lambda::Function",
+        "AWS::S3::Object"
+      ]
+    },
+    "CloudTrailEventSelectorReadWriteType": {
+      "AllowedValues": [
+        "All",
+        "ReadOnly",
+        "WriteOnly"
       ]
     },
     "CloudWatchAlarmComparisonOperator": {

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
@@ -3344,7 +3344,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudtrail-trail-dataresource.html#cfn-cloudtrail-trail-dataresource-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudTrailEventSelectorDataResourceType"
+          }
         },
         "Values": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudtrail-trail-dataresource.html#cfn-cloudtrail-trail-dataresource-values",
@@ -3377,7 +3380,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudtrail-trail-eventselector.html#cfn-cloudtrail-trail-eventselector-readwritetype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudTrailEventSelectorReadWriteType"
+          }
         }
       }
     },
@@ -29301,6 +29307,19 @@
       "AllowedValues": [
         "DNS",
         "EMAIL"
+      ]
+    },
+    "CloudTrailEventSelectorDataResourceType": {
+      "AllowedValues": [
+        "AWS::Lambda::Function",
+        "AWS::S3::Object"
+      ]
+    },
+    "CloudTrailEventSelectorReadWriteType": {
+      "AllowedValues": [
+        "All",
+        "ReadOnly",
+        "WriteOnly"
       ]
     },
     "CloudWatchAlarmComparisonOperator": {

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
@@ -1433,7 +1433,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudtrail-trail-dataresource.html#cfn-cloudtrail-trail-dataresource-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudTrailEventSelectorDataResourceType"
+          }
         },
         "Values": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudtrail-trail-dataresource.html#cfn-cloudtrail-trail-dataresource-values",
@@ -1466,7 +1469,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudtrail-trail-eventselector.html#cfn-cloudtrail-trail-eventselector-readwritetype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudTrailEventSelectorReadWriteType"
+          }
         }
       }
     },
@@ -21071,6 +21077,19 @@
       "AllowedValues": [
         "DNS",
         "EMAIL"
+      ]
+    },
+    "CloudTrailEventSelectorDataResourceType": {
+      "AllowedValues": [
+        "AWS::Lambda::Function",
+        "AWS::S3::Object"
+      ]
+    },
+    "CloudTrailEventSelectorReadWriteType": {
+      "AllowedValues": [
+        "All",
+        "ReadOnly",
+        "WriteOnly"
       ]
     },
     "CloudWatchAlarmComparisonOperator": {

--- a/src/cfnlint/data/CloudSpecs/ap-south-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-south-1.json
@@ -3206,7 +3206,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudtrail-trail-dataresource.html#cfn-cloudtrail-trail-dataresource-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudTrailEventSelectorDataResourceType"
+          }
         },
         "Values": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudtrail-trail-dataresource.html#cfn-cloudtrail-trail-dataresource-values",
@@ -3239,7 +3242,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudtrail-trail-eventselector.html#cfn-cloudtrail-trail-eventselector-readwritetype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudTrailEventSelectorReadWriteType"
+          }
         }
       }
     },
@@ -28133,6 +28139,19 @@
       "AllowedValues": [
         "DNS",
         "EMAIL"
+      ]
+    },
+    "CloudTrailEventSelectorDataResourceType": {
+      "AllowedValues": [
+        "AWS::Lambda::Function",
+        "AWS::S3::Object"
+      ]
+    },
+    "CloudTrailEventSelectorReadWriteType": {
+      "AllowedValues": [
+        "All",
+        "ReadOnly",
+        "WriteOnly"
       ]
     },
     "CloudWatchAlarmComparisonOperator": {

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
@@ -3519,7 +3519,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudtrail-trail-dataresource.html#cfn-cloudtrail-trail-dataresource-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudTrailEventSelectorDataResourceType"
+          }
         },
         "Values": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudtrail-trail-dataresource.html#cfn-cloudtrail-trail-dataresource-values",
@@ -3552,7 +3555,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudtrail-trail-eventselector.html#cfn-cloudtrail-trail-eventselector-readwritetype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudTrailEventSelectorReadWriteType"
+          }
         }
       }
     },
@@ -29428,6 +29434,19 @@
       "AllowedValues": [
         "DNS",
         "EMAIL"
+      ]
+    },
+    "CloudTrailEventSelectorDataResourceType": {
+      "AllowedValues": [
+        "AWS::Lambda::Function",
+        "AWS::S3::Object"
+      ]
+    },
+    "CloudTrailEventSelectorReadWriteType": {
+      "AllowedValues": [
+        "All",
+        "ReadOnly",
+        "WriteOnly"
       ]
     },
     "CloudWatchAlarmComparisonOperator": {

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
@@ -3594,7 +3594,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudtrail-trail-dataresource.html#cfn-cloudtrail-trail-dataresource-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudTrailEventSelectorDataResourceType"
+          }
         },
         "Values": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudtrail-trail-dataresource.html#cfn-cloudtrail-trail-dataresource-values",
@@ -3627,7 +3630,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudtrail-trail-eventselector.html#cfn-cloudtrail-trail-eventselector-readwritetype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudTrailEventSelectorReadWriteType"
+          }
         }
       }
     },
@@ -30306,6 +30312,19 @@
       "AllowedValues": [
         "DNS",
         "EMAIL"
+      ]
+    },
+    "CloudTrailEventSelectorDataResourceType": {
+      "AllowedValues": [
+        "AWS::Lambda::Function",
+        "AWS::S3::Object"
+      ]
+    },
+    "CloudTrailEventSelectorReadWriteType": {
+      "AllowedValues": [
+        "All",
+        "ReadOnly",
+        "WriteOnly"
       ]
     },
     "CloudWatchAlarmComparisonOperator": {

--- a/src/cfnlint/data/CloudSpecs/ca-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/ca-central-1.json
@@ -3040,7 +3040,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudtrail-trail-dataresource.html#cfn-cloudtrail-trail-dataresource-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudTrailEventSelectorDataResourceType"
+          }
         },
         "Values": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudtrail-trail-dataresource.html#cfn-cloudtrail-trail-dataresource-values",
@@ -3073,7 +3076,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudtrail-trail-eventselector.html#cfn-cloudtrail-trail-eventselector-readwritetype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudTrailEventSelectorReadWriteType"
+          }
         }
       }
     },
@@ -26493,6 +26499,19 @@
       "AllowedValues": [
         "DNS",
         "EMAIL"
+      ]
+    },
+    "CloudTrailEventSelectorDataResourceType": {
+      "AllowedValues": [
+        "AWS::Lambda::Function",
+        "AWS::S3::Object"
+      ]
+    },
+    "CloudTrailEventSelectorReadWriteType": {
+      "AllowedValues": [
+        "All",
+        "ReadOnly",
+        "WriteOnly"
       ]
     },
     "CloudWatchAlarmComparisonOperator": {

--- a/src/cfnlint/data/CloudSpecs/eu-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-central-1.json
@@ -3519,7 +3519,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudtrail-trail-dataresource.html#cfn-cloudtrail-trail-dataresource-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudTrailEventSelectorDataResourceType"
+          }
         },
         "Values": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudtrail-trail-dataresource.html#cfn-cloudtrail-trail-dataresource-values",
@@ -3552,7 +3555,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudtrail-trail-eventselector.html#cfn-cloudtrail-trail-eventselector-readwritetype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudTrailEventSelectorReadWriteType"
+          }
         }
       }
     },
@@ -31224,6 +31230,19 @@
       "AllowedValues": [
         "DNS",
         "EMAIL"
+      ]
+    },
+    "CloudTrailEventSelectorDataResourceType": {
+      "AllowedValues": [
+        "AWS::Lambda::Function",
+        "AWS::S3::Object"
+      ]
+    },
+    "CloudTrailEventSelectorReadWriteType": {
+      "AllowedValues": [
+        "All",
+        "ReadOnly",
+        "WriteOnly"
       ]
     },
     "CloudWatchAlarmComparisonOperator": {

--- a/src/cfnlint/data/CloudSpecs/eu-north-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-north-1.json
@@ -1433,7 +1433,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudtrail-trail-dataresource.html#cfn-cloudtrail-trail-dataresource-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudTrailEventSelectorDataResourceType"
+          }
         },
         "Values": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudtrail-trail-dataresource.html#cfn-cloudtrail-trail-dataresource-values",
@@ -1466,7 +1469,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudtrail-trail-eventselector.html#cfn-cloudtrail-trail-eventselector-readwritetype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudTrailEventSelectorReadWriteType"
+          }
         }
       }
     },
@@ -21931,6 +21937,19 @@
       "AllowedValues": [
         "DNS",
         "EMAIL"
+      ]
+    },
+    "CloudTrailEventSelectorDataResourceType": {
+      "AllowedValues": [
+        "AWS::Lambda::Function",
+        "AWS::S3::Object"
+      ]
+    },
+    "CloudTrailEventSelectorReadWriteType": {
+      "AllowedValues": [
+        "All",
+        "ReadOnly",
+        "WriteOnly"
       ]
     },
     "CloudWatchAlarmComparisonOperator": {

--- a/src/cfnlint/data/CloudSpecs/eu-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-1.json
@@ -3611,7 +3611,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudtrail-trail-dataresource.html#cfn-cloudtrail-trail-dataresource-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudTrailEventSelectorDataResourceType"
+          }
         },
         "Values": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudtrail-trail-dataresource.html#cfn-cloudtrail-trail-dataresource-values",
@@ -3644,7 +3647,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudtrail-trail-eventselector.html#cfn-cloudtrail-trail-eventselector-readwritetype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudTrailEventSelectorReadWriteType"
+          }
         }
       }
     },
@@ -34272,6 +34278,19 @@
       "AllowedValues": [
         "DNS",
         "EMAIL"
+      ]
+    },
+    "CloudTrailEventSelectorDataResourceType": {
+      "AllowedValues": [
+        "AWS::Lambda::Function",
+        "AWS::S3::Object"
+      ]
+    },
+    "CloudTrailEventSelectorReadWriteType": {
+      "AllowedValues": [
+        "All",
+        "ReadOnly",
+        "WriteOnly"
       ]
     },
     "CloudWatchAlarmComparisonOperator": {

--- a/src/cfnlint/data/CloudSpecs/eu-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-2.json
@@ -3057,7 +3057,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudtrail-trail-dataresource.html#cfn-cloudtrail-trail-dataresource-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudTrailEventSelectorDataResourceType"
+          }
         },
         "Values": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudtrail-trail-dataresource.html#cfn-cloudtrail-trail-dataresource-values",
@@ -3090,7 +3093,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudtrail-trail-eventselector.html#cfn-cloudtrail-trail-eventselector-readwritetype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudTrailEventSelectorReadWriteType"
+          }
         }
       }
     },
@@ -27794,6 +27800,19 @@
       "AllowedValues": [
         "DNS",
         "EMAIL"
+      ]
+    },
+    "CloudTrailEventSelectorDataResourceType": {
+      "AllowedValues": [
+        "AWS::Lambda::Function",
+        "AWS::S3::Object"
+      ]
+    },
+    "CloudTrailEventSelectorReadWriteType": {
+      "AllowedValues": [
+        "All",
+        "ReadOnly",
+        "WriteOnly"
       ]
     },
     "CloudWatchAlarmComparisonOperator": {

--- a/src/cfnlint/data/CloudSpecs/eu-west-3.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-3.json
@@ -2509,7 +2509,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudtrail-trail-dataresource.html#cfn-cloudtrail-trail-dataresource-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudTrailEventSelectorDataResourceType"
+          }
         },
         "Values": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudtrail-trail-dataresource.html#cfn-cloudtrail-trail-dataresource-values",
@@ -2542,7 +2545,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudtrail-trail-eventselector.html#cfn-cloudtrail-trail-eventselector-readwritetype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudTrailEventSelectorReadWriteType"
+          }
         }
       }
     },
@@ -24676,6 +24682,19 @@
       "AllowedValues": [
         "DNS",
         "EMAIL"
+      ]
+    },
+    "CloudTrailEventSelectorDataResourceType": {
+      "AllowedValues": [
+        "AWS::Lambda::Function",
+        "AWS::S3::Object"
+      ]
+    },
+    "CloudTrailEventSelectorReadWriteType": {
+      "AllowedValues": [
+        "All",
+        "ReadOnly",
+        "WriteOnly"
       ]
     },
     "CloudWatchAlarmComparisonOperator": {

--- a/src/cfnlint/data/CloudSpecs/sa-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/sa-east-1.json
@@ -2726,7 +2726,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudtrail-trail-dataresource.html#cfn-cloudtrail-trail-dataresource-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudTrailEventSelectorDataResourceType"
+          }
         },
         "Values": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudtrail-trail-dataresource.html#cfn-cloudtrail-trail-dataresource-values",
@@ -2759,7 +2762,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudtrail-trail-eventselector.html#cfn-cloudtrail-trail-eventselector-readwritetype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudTrailEventSelectorReadWriteType"
+          }
         }
       }
     },
@@ -25667,6 +25673,19 @@
       "AllowedValues": [
         "DNS",
         "EMAIL"
+      ]
+    },
+    "CloudTrailEventSelectorDataResourceType": {
+      "AllowedValues": [
+        "AWS::Lambda::Function",
+        "AWS::S3::Object"
+      ]
+    },
+    "CloudTrailEventSelectorReadWriteType": {
+      "AllowedValues": [
+        "All",
+        "ReadOnly",
+        "WriteOnly"
       ]
     },
     "CloudWatchAlarmComparisonOperator": {

--- a/src/cfnlint/data/CloudSpecs/us-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-1.json
@@ -3611,7 +3611,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudtrail-trail-dataresource.html#cfn-cloudtrail-trail-dataresource-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudTrailEventSelectorDataResourceType"
+          }
         },
         "Values": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudtrail-trail-dataresource.html#cfn-cloudtrail-trail-dataresource-values",
@@ -3644,7 +3647,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudtrail-trail-eventselector.html#cfn-cloudtrail-trail-eventselector-readwritetype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudTrailEventSelectorReadWriteType"
+          }
         }
       }
     },
@@ -34343,6 +34349,19 @@
       "AllowedValues": [
         "DNS",
         "EMAIL"
+      ]
+    },
+    "CloudTrailEventSelectorDataResourceType": {
+      "AllowedValues": [
+        "AWS::Lambda::Function",
+        "AWS::S3::Object"
+      ]
+    },
+    "CloudTrailEventSelectorReadWriteType": {
+      "AllowedValues": [
+        "All",
+        "ReadOnly",
+        "WriteOnly"
       ]
     },
     "CloudWatchAlarmComparisonOperator": {

--- a/src/cfnlint/data/CloudSpecs/us-east-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-2.json
@@ -3453,7 +3453,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudtrail-trail-dataresource.html#cfn-cloudtrail-trail-dataresource-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudTrailEventSelectorDataResourceType"
+          }
         },
         "Values": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudtrail-trail-dataresource.html#cfn-cloudtrail-trail-dataresource-values",
@@ -3486,7 +3489,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudtrail-trail-eventselector.html#cfn-cloudtrail-trail-eventselector-readwritetype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudTrailEventSelectorReadWriteType"
+          }
         }
       }
     },
@@ -32258,6 +32264,19 @@
       "AllowedValues": [
         "DNS",
         "EMAIL"
+      ]
+    },
+    "CloudTrailEventSelectorDataResourceType": {
+      "AllowedValues": [
+        "AWS::Lambda::Function",
+        "AWS::S3::Object"
+      ]
+    },
+    "CloudTrailEventSelectorReadWriteType": {
+      "AllowedValues": [
+        "All",
+        "ReadOnly",
+        "WriteOnly"
       ]
     },
     "CloudWatchAlarmComparisonOperator": {

--- a/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
@@ -1433,7 +1433,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudtrail-trail-dataresource.html#cfn-cloudtrail-trail-dataresource-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudTrailEventSelectorDataResourceType"
+          }
         },
         "Values": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudtrail-trail-dataresource.html#cfn-cloudtrail-trail-dataresource-values",
@@ -1466,7 +1469,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudtrail-trail-eventselector.html#cfn-cloudtrail-trail-eventselector-readwritetype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudTrailEventSelectorReadWriteType"
+          }
         }
       }
     },
@@ -20875,6 +20881,19 @@
       "AllowedValues": [
         "DNS",
         "EMAIL"
+      ]
+    },
+    "CloudTrailEventSelectorDataResourceType": {
+      "AllowedValues": [
+        "AWS::Lambda::Function",
+        "AWS::S3::Object"
+      ]
+    },
+    "CloudTrailEventSelectorReadWriteType": {
+      "AllowedValues": [
+        "All",
+        "ReadOnly",
+        "WriteOnly"
       ]
     },
     "CloudWatchAlarmComparisonOperator": {

--- a/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
@@ -1433,7 +1433,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudtrail-trail-dataresource.html#cfn-cloudtrail-trail-dataresource-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudTrailEventSelectorDataResourceType"
+          }
         },
         "Values": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudtrail-trail-dataresource.html#cfn-cloudtrail-trail-dataresource-values",
@@ -1466,7 +1469,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudtrail-trail-eventselector.html#cfn-cloudtrail-trail-eventselector-readwritetype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudTrailEventSelectorReadWriteType"
+          }
         }
       }
     },
@@ -21119,6 +21125,19 @@
       "AllowedValues": [
         "DNS",
         "EMAIL"
+      ]
+    },
+    "CloudTrailEventSelectorDataResourceType": {
+      "AllowedValues": [
+        "AWS::Lambda::Function",
+        "AWS::S3::Object"
+      ]
+    },
+    "CloudTrailEventSelectorReadWriteType": {
+      "AllowedValues": [
+        "All",
+        "ReadOnly",
+        "WriteOnly"
       ]
     },
     "CloudWatchAlarmComparisonOperator": {

--- a/src/cfnlint/data/CloudSpecs/us-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-1.json
@@ -3178,7 +3178,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudtrail-trail-dataresource.html#cfn-cloudtrail-trail-dataresource-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudTrailEventSelectorDataResourceType"
+          }
         },
         "Values": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudtrail-trail-dataresource.html#cfn-cloudtrail-trail-dataresource-values",
@@ -3211,7 +3214,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudtrail-trail-eventselector.html#cfn-cloudtrail-trail-eventselector-readwritetype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudTrailEventSelectorReadWriteType"
+          }
         }
       }
     },
@@ -27264,6 +27270,19 @@
       "AllowedValues": [
         "DNS",
         "EMAIL"
+      ]
+    },
+    "CloudTrailEventSelectorDataResourceType": {
+      "AllowedValues": [
+        "AWS::Lambda::Function",
+        "AWS::S3::Object"
+      ]
+    },
+    "CloudTrailEventSelectorReadWriteType": {
+      "AllowedValues": [
+        "All",
+        "ReadOnly",
+        "WriteOnly"
       ]
     },
     "CloudWatchAlarmComparisonOperator": {

--- a/src/cfnlint/data/CloudSpecs/us-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-2.json
@@ -3611,7 +3611,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudtrail-trail-dataresource.html#cfn-cloudtrail-trail-dataresource-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudTrailEventSelectorDataResourceType"
+          }
         },
         "Values": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudtrail-trail-dataresource.html#cfn-cloudtrail-trail-dataresource-values",
@@ -3644,7 +3647,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudtrail-trail-eventselector.html#cfn-cloudtrail-trail-eventselector-readwritetype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CloudTrailEventSelectorReadWriteType"
+          }
         }
       }
     },
@@ -34331,6 +34337,19 @@
       "AllowedValues": [
         "DNS",
         "EMAIL"
+      ]
+    },
+    "CloudTrailEventSelectorDataResourceType": {
+      "AllowedValues": [
+        "AWS::Lambda::Function",
+        "AWS::S3::Object"
+      ]
+    },
+    "CloudTrailEventSelectorReadWriteType": {
+      "AllowedValues": [
+        "All",
+        "ReadOnly",
+        "WriteOnly"
       ]
     },
     "CloudWatchAlarmComparisonOperator": {

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
@@ -234,6 +234,19 @@
           "EMAIL"
         ]
       },
+      "CloudTrailEventSelectorDataResourceType": {
+        "AllowedValues": [
+          "AWS::Lambda::Function",
+          "AWS::S3::Object"
+        ]
+      },
+      "CloudTrailEventSelectorReadWriteType": {
+        "AllowedValues": [
+          "All",
+          "ReadOnly",
+          "WriteOnly"
+        ]
+      },
       "CloudWatchAlarmComparisonOperator": {
         "AllowedValues": [
           "GreaterThanOrEqualToThreshold",

--- a/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
@@ -141,6 +141,20 @@
   },
   {
     "op": "add",
+    "path": "/PropertyTypes/AWS::CloudTrail::Trail.DataResource/Properties/Type/Value",
+    "value": {
+      "ValueType": "CloudTrailEventSelectorDataResourceType"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/PropertyTypes/AWS::CloudTrail::Trail.EventSelector/Properties/ReadWriteType/Value",
+    "value": {
+      "ValueType": "CloudTrailEventSelectorReadWriteType"
+    }
+  },
+  {
+    "op": "add",
     "path": "/PropertyTypes/AWS::Events::EventBusPolicy.Condition/Properties/Key/Value",
     "value": {
       "ValueType": "CloudWatchEventBusPolicyConditionKey"

--- a/test/fixtures/templates/bad/resources/properties/allowed_values.yaml
+++ b/test/fixtures/templates/bad/resources/properties/allowed_values.yaml
@@ -172,6 +172,18 @@ Resources:
     Properties:
       DomainName: "example.com"
       ValidationMethod: "Dns" # Invalid AllowedValue
+  CloudTrail:
+    Type: "AWS::CloudTrail::Trail"
+    Properties:
+      EventSelectors:
+        - ReadWriteType: "Read" # Invalid AllowedValue
+          DataResources:
+            - Type: "AWS::S3:Object" # Invalid AllowedValue
+              Values:
+                - "Arn1"
+                - "Arn2"
+      IsLogging: True
+      S3BucketName: "MyBucket"
   CloudWatchAlarm:
     Type: "AWS::CloudWatch::Alarm"
     Properties:

--- a/test/fixtures/templates/good/resources/properties/allowed_values.yaml
+++ b/test/fixtures/templates/good/resources/properties/allowed_values.yaml
@@ -172,6 +172,18 @@ Resources:
     Properties:
       DomainName: "example.com"
       ValidationMethod: "DNS" # Valid AllowedValue
+  CloudTrail:
+    Type: "AWS::CloudTrail::Trail"
+    Properties:
+      EventSelectors:
+        - ReadWriteType: "All" # Valid AllowedValue
+          DataResources:
+            - Type: "AWS::S3::Object" # Valid AllowedValue
+              Values:
+                - "Arn1"
+                - "Arn2"
+      IsLogging: True
+      S3BucketName: "MyBucket"
   CloudWatchAlarm:
     Type: "AWS::CloudWatch::Alarm"
     Properties:

--- a/test/rules/resources/properties/test_allowed_value.py
+++ b/test/rules/resources/properties/test_allowed_value.py
@@ -34,4 +34,4 @@ class TestAllowedValue(BaseRuleTestCase):
 
     def test_file_negative(self):
         """Test failure"""
-        self.helper_file_negative('test/fixtures/templates/bad/resources/properties/allowed_values.yaml', 100)
+        self.helper_file_negative('test/fixtures/templates/bad/resources/properties/allowed_values.yaml', 102)


### PR DESCRIPTION
*Issue https://github.com/awslabs/cfn-python-lint/issues/50, if available:*

Add all the allowed values of the [`AWS::CloutTrail`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-reference-cloudtrail.html) Resources

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
