### PR TITLE
Fix CloudWatchAlarmComparisonOperator allowed value for LessThanOrEqualToThreshold

### DIFF
--- a/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
@@ -31978,7 +31978,7 @@
       "AllowedValues": [
         "GreaterThanOrEqualToThreshold",
         "GreaterThanThreshold",
-        "LessThanOrEqualToThreshold.",
+        "LessThanOrEqualToThreshold",
         "LessThanThreshold"
       ]
     },

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
@@ -29326,7 +29326,7 @@
       "AllowedValues": [
         "GreaterThanOrEqualToThreshold",
         "GreaterThanThreshold",
-        "LessThanOrEqualToThreshold.",
+        "LessThanOrEqualToThreshold",
         "LessThanThreshold"
       ]
     },

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
@@ -21096,7 +21096,7 @@
       "AllowedValues": [
         "GreaterThanOrEqualToThreshold",
         "GreaterThanThreshold",
-        "LessThanOrEqualToThreshold.",
+        "LessThanOrEqualToThreshold",
         "LessThanThreshold"
       ]
     },

--- a/src/cfnlint/data/CloudSpecs/ap-south-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-south-1.json
@@ -28158,7 +28158,7 @@
       "AllowedValues": [
         "GreaterThanOrEqualToThreshold",
         "GreaterThanThreshold",
-        "LessThanOrEqualToThreshold.",
+        "LessThanOrEqualToThreshold",
         "LessThanThreshold"
       ]
     },

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
@@ -29453,7 +29453,7 @@
       "AllowedValues": [
         "GreaterThanOrEqualToThreshold",
         "GreaterThanThreshold",
-        "LessThanOrEqualToThreshold.",
+        "LessThanOrEqualToThreshold",
         "LessThanThreshold"
       ]
     },

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
@@ -30331,7 +30331,7 @@
       "AllowedValues": [
         "GreaterThanOrEqualToThreshold",
         "GreaterThanThreshold",
-        "LessThanOrEqualToThreshold.",
+        "LessThanOrEqualToThreshold",
         "LessThanThreshold"
       ]
     },

--- a/src/cfnlint/data/CloudSpecs/ca-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/ca-central-1.json
@@ -26518,7 +26518,7 @@
       "AllowedValues": [
         "GreaterThanOrEqualToThreshold",
         "GreaterThanThreshold",
-        "LessThanOrEqualToThreshold.",
+        "LessThanOrEqualToThreshold",
         "LessThanThreshold"
       ]
     },

--- a/src/cfnlint/data/CloudSpecs/eu-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-central-1.json
@@ -31249,7 +31249,7 @@
       "AllowedValues": [
         "GreaterThanOrEqualToThreshold",
         "GreaterThanThreshold",
-        "LessThanOrEqualToThreshold.",
+        "LessThanOrEqualToThreshold",
         "LessThanThreshold"
       ]
     },

--- a/src/cfnlint/data/CloudSpecs/eu-north-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-north-1.json
@@ -21956,7 +21956,7 @@
       "AllowedValues": [
         "GreaterThanOrEqualToThreshold",
         "GreaterThanThreshold",
-        "LessThanOrEqualToThreshold.",
+        "LessThanOrEqualToThreshold",
         "LessThanThreshold"
       ]
     },

--- a/src/cfnlint/data/CloudSpecs/eu-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-1.json
@@ -34297,7 +34297,7 @@
       "AllowedValues": [
         "GreaterThanOrEqualToThreshold",
         "GreaterThanThreshold",
-        "LessThanOrEqualToThreshold.",
+        "LessThanOrEqualToThreshold",
         "LessThanThreshold"
       ]
     },

--- a/src/cfnlint/data/CloudSpecs/eu-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-2.json
@@ -27819,7 +27819,7 @@
       "AllowedValues": [
         "GreaterThanOrEqualToThreshold",
         "GreaterThanThreshold",
-        "LessThanOrEqualToThreshold.",
+        "LessThanOrEqualToThreshold",
         "LessThanThreshold"
       ]
     },

--- a/src/cfnlint/data/CloudSpecs/eu-west-3.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-3.json
@@ -24701,7 +24701,7 @@
       "AllowedValues": [
         "GreaterThanOrEqualToThreshold",
         "GreaterThanThreshold",
-        "LessThanOrEqualToThreshold.",
+        "LessThanOrEqualToThreshold",
         "LessThanThreshold"
       ]
     },

--- a/src/cfnlint/data/CloudSpecs/sa-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/sa-east-1.json
@@ -25692,7 +25692,7 @@
       "AllowedValues": [
         "GreaterThanOrEqualToThreshold",
         "GreaterThanThreshold",
-        "LessThanOrEqualToThreshold.",
+        "LessThanOrEqualToThreshold",
         "LessThanThreshold"
       ]
     },

--- a/src/cfnlint/data/CloudSpecs/us-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-1.json
@@ -34368,7 +34368,7 @@
       "AllowedValues": [
         "GreaterThanOrEqualToThreshold",
         "GreaterThanThreshold",
-        "LessThanOrEqualToThreshold.",
+        "LessThanOrEqualToThreshold",
         "LessThanThreshold"
       ]
     },

--- a/src/cfnlint/data/CloudSpecs/us-east-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-2.json
@@ -32283,7 +32283,7 @@
       "AllowedValues": [
         "GreaterThanOrEqualToThreshold",
         "GreaterThanThreshold",
-        "LessThanOrEqualToThreshold.",
+        "LessThanOrEqualToThreshold",
         "LessThanThreshold"
       ]
     },

--- a/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
@@ -20900,7 +20900,7 @@
       "AllowedValues": [
         "GreaterThanOrEqualToThreshold",
         "GreaterThanThreshold",
-        "LessThanOrEqualToThreshold.",
+        "LessThanOrEqualToThreshold",
         "LessThanThreshold"
       ]
     },

--- a/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
@@ -21144,7 +21144,7 @@
       "AllowedValues": [
         "GreaterThanOrEqualToThreshold",
         "GreaterThanThreshold",
-        "LessThanOrEqualToThreshold.",
+        "LessThanOrEqualToThreshold",
         "LessThanThreshold"
       ]
     },

--- a/src/cfnlint/data/CloudSpecs/us-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-1.json
@@ -27289,7 +27289,7 @@
       "AllowedValues": [
         "GreaterThanOrEqualToThreshold",
         "GreaterThanThreshold",
-        "LessThanOrEqualToThreshold.",
+        "LessThanOrEqualToThreshold",
         "LessThanThreshold"
       ]
     },

--- a/src/cfnlint/data/CloudSpecs/us-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-2.json
@@ -34356,7 +34356,7 @@
       "AllowedValues": [
         "GreaterThanOrEqualToThreshold",
         "GreaterThanThreshold",
-        "LessThanOrEqualToThreshold.",
+        "LessThanOrEqualToThreshold",
         "LessThanThreshold"
       ]
     },

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
@@ -251,7 +251,7 @@
         "AllowedValues": [
           "GreaterThanOrEqualToThreshold",
           "GreaterThanThreshold",
-          "LessThanOrEqualToThreshold.",
+          "LessThanOrEqualToThreshold",
           "LessThanThreshold"
         ]
       },


### PR DESCRIPTION
Issue: https://github.com/awslabs/cfn-python-lint/issues/628

Looks like someone just copy-pasted the period from `LessThanOrEqualToThreshold.` here https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html

This PR changes all instances of `LessThanOrEqualToThreshold.` to `LessThanOrEqualToThreshold`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
