### PR TITLE
Update SAM dependency version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ setup(
         'pyyaml',
         'six~=1.11',
         'requests>=2.15.0',
-        'aws-sam-translator>=1.8.0',
+        'aws-sam-translator>=1.9.0',
         'jsonpatch',
         'jsonschema~=2.6',
         'pathlib2>=2.3.0;python_version<"3.4"'

--- a/src/cfnlint/transform.py
+++ b/src/cfnlint/transform.py
@@ -17,6 +17,7 @@
 import os
 import logging
 import six
+import samtranslator
 from samtranslator.parser import parser
 from samtranslator.translator.translator import Translator
 from samtranslator.public.exceptions import InvalidDocumentException
@@ -81,6 +82,9 @@ class Transform(object):
         matches = []
 
         try:
+            # Output the SAM Translator version in debug mode
+            LOGGER.debug('SAM Translator: %s', samtranslator.__version__)
+
             sam_translator = Translator(managed_policy_map=self._managed_policy_map,
                                         sam_parser=self._sam_parser)
 


### PR DESCRIPTION
*Issue https://github.com/awslabs/cfn-python-lint/issues/633, if available:*

The "latest" version of SAM ([From November](https://github.com/awslabs/serverless-application-model/releases/tag/v1.9.0)) supports Layers. This PR "updates" the requirement to SAM.

Not 100% sure if we should "enforce" this latest version, feedback is really welcome on this
🤔 

To get insights I added a Debug message of the SAM Translator when performing a Transform to get better insights on the Version currently "installed"


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
