### PR TITLE
Better support for nested And, Or, and Not when processing Conditions

### DIFF
--- a/test/module/conditions/test_conditions.py
+++ b/test/module/conditions/test_conditions.py
@@ -59,7 +59,6 @@ class TestConditions(BaseTestCase):
         """Test success run"""
         self.assertEqual(len(self.conditions.Conditions), 9)
         self.assertEqual(len(self.conditions.Parameters), 2)
-        print(self.conditions.Parameters)
         self.assertListEqual(self.conditions.Parameters['55caa18684cddafa866bdb947fb31ea563b2ea73'], ['None', 'Single NAT', 'High Availability'])
 
     def test_success_is_production(self):


### PR DESCRIPTION
*Issue #, if available:*
Fix #643
*Description of changes:*
- Fix Conditions processing when looking at nested And, Or, and Not blocks.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
