### PR TITLE
Switched logo to URL for external sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CloudFormation Linter
 
-<img src="logo.png?raw=true" width="150" align="right">
+<img src="https://github.com/awslabs/cfn-python-lint/blob/master/logo.png?raw=true" width="150" align="right">
 
 [![Build Status](https://travis-ci.com/awslabs/cfn-python-lint.svg?branch=master)](https://travis-ci.com/awslabs/cfn-python-lint)
 [![PyPI version](https://badge.fury.io/py/cfn-lint.svg)](https://badge.fury.io/py/cfn-lint)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Local URI for logo was broke when viewing from external sites like pypi. Switched to full URL.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
