### PR TITLE
NLB listeners now support the TLS protocol

### DIFF
--- a/src/cfnlint/rules/resources/elb/Elb.py
+++ b/src/cfnlint/rules/resources/elb/Elb.py
@@ -55,8 +55,8 @@ HTTPS has certificate HTTP has no certificate'
                 cfn.check_value(
                     result['Value'], 'Protocol', result['Path'],
                     check_value=self.check_protocol_value,
-                    accepted_protocols=['HTTP', 'HTTPS', 'TCP'],
-                    certificate_protocols=['HTTPS'],
+                    accepted_protocols=['HTTP', 'HTTPS', 'TCP', 'TLS'],
+                    certificate_protocols=['HTTPS', 'TLS'],
                     certificates=result['Value'].get('Certificates')))
 
         results = cfn.get_resource_properties(['AWS::ElasticLoadBalancing::LoadBalancer', 'Listeners'])

--- a/test/fixtures/templates/good/properties_elb.yaml
+++ b/test/fixtures/templates/good/properties_elb.yaml
@@ -181,6 +181,56 @@ Resources:
           Value: 'true'
         InstancePorts:
         - '80'
+  NetworkLoadBalancer:
+    Type: 'AWS::ElasticLoadBalancingV2::LoadBalancer'
+    Properties:
+      LoadBalancerAttributes:
+        - Key: 'load_balancing.cross_zone.enabled'
+          Value: true
+        - Key: access_logs.s3.enabled
+          Value: 'false'
+        # - Key: access_logs.s3.bucket
+        #   Value:
+        # - Key: access_logs.s3.prefix
+        #   Value:
+      Scheme: !Ref Scheme
+      Subnets: !Ref Subnets
+      Type: network
+  NlbTargetGroup:
+    Type: 'AWS::ElasticLoadBalancingV2::TargetGroup'
+    Properties:
+      HealthCheckIntervalSeconds: 30
+      HealthCheckProtocol: TCP
+      HealthCheckTimeoutSeconds: 10
+      HealthyThresholdCount: 2
+      UnhealthyThresholdCount: 2
+      Port: 8080
+      Protocol: TCP
+      TargetType: ip
+      TargetGroupAttributes:
+      - Key: 'deregistration_delay.timeout_seconds'
+        Value: 60
+      VpcId: !Ref Vpc
+  NlbListenerTcp:
+    Type: 'AWS::ElasticLoadBalancingV2::Listener'
+    Properties:
+      DefaultActions:
+      - TargetGroupArn: !Ref NlbTargetGroup
+        Type: forward
+      LoadBalancerArn: !Ref NetworkLoadBalancer
+      Port: 80
+      Protocol: TCP
+  NlbListenerTls:
+    Type: 'AWS::ElasticLoadBalancingV2::Listener'
+    Properties:
+      Certificates:
+        - arn:aws:iam::782895515015:server-certificate/self-signed-test
+      DefaultActions:
+      - TargetGroupArn: !Ref NlbTargetGroup
+        Type: forward
+      LoadBalancerArn: !Ref NetworkLoadBalancer
+      Port: 443
+      Protocol: TLS
 Outputs:
   Arn:
     Value: !Ref LoadBalancer


### PR DESCRIPTION
*Description of changes:*

NLB listeners now support the TLS protocol as documented here https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_CreateListener.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
