### PR TITLE
Add tests to the formatters

### DIFF
--- a/src/cfnlint/__main__.py
+++ b/src/cfnlint/__main__.py
@@ -39,7 +39,7 @@ def main():
                 matches.extend(template_matches)
             LOGGER.debug('Completed linting of file: %s', str(filename))
 
-        formatter.print_matches(matches)
+        print(formatter.print_matches(matches))
         return cfnlint.core.get_exit_code(matches)
     except cfnlint.core.CfnLintExitException as e:
         LOGGER.error(str(e))

--- a/src/cfnlint/formatters/__init__.py
+++ b/src/cfnlint/formatters/__init__.py
@@ -26,8 +26,11 @@ class BaseFormatter(object):
     def print_matches(self, matches):
         """Output all the matches"""
         # Output each match on a separate line by default
+        output = []
         for match in matches:
-            print(self._format(match))
+            output.append(self._format(match))
+
+        return '\n'.join(output)
 
 class Formatter(BaseFormatter):
     """Generic Formatter"""
@@ -82,10 +85,9 @@ class JsonFormatter(BaseFormatter):
 
     def print_matches(self, matches):
         # JSON formatter outputs a single JSON object
-        print(
-            json.dumps(
-                matches, indent=4, cls=self.CustomEncoder,
-                sort_keys=True, separators=(',', ': ')))
+        return json.dumps(
+            matches, indent=4, cls=self.CustomEncoder,
+            sort_keys=True, separators=(',', ': '))
 
 
 class QuietFormatter(BaseFormatter):

--- a/test/fixtures/templates/bad/formatters.yaml
+++ b/test/fixtures/templates/bad/formatters.yaml
@@ -1,0 +1,16 @@
+---
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  Template with all error levels: Warning, Error and Informational
+Resources:
+  myTable:
+    Type: "AWS::DynamoDB::Table"
+    Properties:
+      TableName: !Sub "TableName"
+      KeySchema:
+        -
+          AttributeName: "ArtistId"
+          KeyType: "HASH"
+      ProvisionedThroughput:
+        ReadCapacityUnits: 5
+        WriteCapacityUnits: "5"

--- a/test/module/formatters/__init__.py
+++ b/test/module/formatters/__init__.py
@@ -1,0 +1,16 @@
+"""
+  Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this
+  software and associated documentation files (the "Software"), to deal in the Software
+  without restriction, including without limitation the rights to use, copy, modify,
+  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""

--- a/test/module/formatters/test_formatters.py
+++ b/test/module/formatters/test_formatters.py
@@ -1,0 +1,58 @@
+"""
+  Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this
+  software and associated documentation files (the "Software"), to deal in the Software
+  without restriction, including without limitation the rights to use, copy, modify,
+  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+import json
+import cfnlint.formatters
+from testlib.testcase import BaseTestCase
+
+
+class TestFormatters(BaseTestCase):
+    """Test Formatters """
+
+    def test_json_formatter(self):
+        """Test JSON formatter"""
+
+        # Run a broken template
+        filename = 'test/fixtures/templates/bad/formatters.yaml'
+        (args, filenames, formatter) = cfnlint.core.get_args_filenames([
+            '--template', filename, '--format', 'json', '--include-checks', 'I'])
+
+        results = []
+        for filename in filenames:
+            (template, rules, _) = cfnlint.core.get_template_rules(filename, args)
+            results.extend(
+                cfnlint.core.run_checks(
+                    filename, template, rules, ['us-east-1']))
+
+        # Validate Formatter class initiated
+        self.assertEqual('JsonFormatter', formatter.__class__.__name__)
+        # We need 3 errors (Information, Warning, Error)
+        self.assertEqual(len(results), 3)
+        # Check the errors
+        self.assertEqual(results[0].rule.id, 'I3011')
+        self.assertEqual(results[1].rule.id, 'W1020')
+        self.assertEqual(results[2].rule.id, 'E3012')
+
+        # Get the JSON output
+        json_results = json.loads(formatter.print_matches(results))
+
+        # Check the 3 errors again
+        self.assertEqual(len(json_results), 3)
+        
+        # Check the errors level description
+        self.assertEqual(json_results[0]['Level'], 'Informational')
+        self.assertEqual(json_results[1]['Level'], 'Warning')
+        self.assertEqual(json_results[2]['Level'], 'Error')


### PR DESCRIPTION
In an effort to increase the code coverage, added test(s) to the Formatters. 

Had to refactor the Formatters a bit (since it went straight to the stdOut (`print`)), this might impact people using integrations. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
