### PR TITLE
When looking for values of list make sure its expecting a list

### DIFF
--- a/src/cfnlint/rules/resources/properties/ValueRefGetAtt.py
+++ b/src/cfnlint/rules/resources/properties/ValueRefGetAtt.py
@@ -140,8 +140,7 @@ class ValueRefGetAtt(CloudFormationLintRule):
             # Nested Stack Outputs
             # if its a string type we are good and return matches
             # if its a list its a failure as Outputs can only be strings
-
-            if is_value_a_list:
+            if is_value_a_list and property_type == 'List':
                 message = 'CloudFormation stack outputs need to be strings not lists at {0}'
                 matches.append(RuleMatch(path, message.format('/'.join(map(str, path)))))
 

--- a/test/fixtures/templates/good/resources/properties/value.yaml
+++ b/test/fixtures/templates/good/resources/properties/value.yaml
@@ -125,3 +125,7 @@ Resources:
         Value: '50'
       SecurityGroups:
       - !GetAtt SubStack.Outputs.SecurityGroups
+  Listener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      LoadBalancerArn: !GetAtt SubStack.Outputs.LoadBalancerArn


### PR DESCRIPTION
*Issue #, if available:*
Fix #657
*Description of changes:*
-  When checking for lists from CloudFormation stacks make sure the property type is a list as well.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
