### PR TITLE
Fix AmazonMQEngineVersion AllowedValues

### DIFF
--- a/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
@@ -32451,9 +32451,9 @@
     },
     "AmazonMQEngineVersion": {
       "AllowedValues": [
-        "ActiveMQ 5.15.0",
-        "ActiveMQ 5.15.6",
-        "ActiveMQ 5.15.8"
+        "5.15.0",
+        "5.15.6",
+        "5.15.8"
       ]
     },
     "AmazonMQHostInstanceType": {

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
@@ -29796,9 +29796,9 @@
     },
     "AmazonMQEngineVersion": {
       "AllowedValues": [
-        "ActiveMQ 5.15.0",
-        "ActiveMQ 5.15.6",
-        "ActiveMQ 5.15.8"
+        "5.15.0",
+        "5.15.6",
+        "5.15.8"
       ]
     },
     "AmazonMQHostInstanceType": {

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
@@ -20896,9 +20896,9 @@
     },
     "AmazonMQEngineVersion": {
       "AllowedValues": [
-        "ActiveMQ 5.15.0",
-        "ActiveMQ 5.15.6",
-        "ActiveMQ 5.15.8"
+        "5.15.0",
+        "5.15.6",
+        "5.15.8"
       ]
     },
     "AmazonMQHostInstanceType": {

--- a/src/cfnlint/data/CloudSpecs/ap-south-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-south-1.json
@@ -28609,9 +28609,9 @@
     },
     "AmazonMQEngineVersion": {
       "AllowedValues": [
-        "ActiveMQ 5.15.0",
-        "ActiveMQ 5.15.6",
-        "ActiveMQ 5.15.8"
+        "5.15.0",
+        "5.15.6",
+        "5.15.8"
       ]
     },
     "AmazonMQHostInstanceType": {

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
@@ -29899,9 +29899,9 @@
     },
     "AmazonMQEngineVersion": {
       "AllowedValues": [
-        "ActiveMQ 5.15.0",
-        "ActiveMQ 5.15.6",
-        "ActiveMQ 5.15.8"
+        "5.15.0",
+        "5.15.6",
+        "5.15.8"
       ]
     },
     "AmazonMQHostInstanceType": {

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
@@ -30804,9 +30804,9 @@
     },
     "AmazonMQEngineVersion": {
       "AllowedValues": [
-        "ActiveMQ 5.15.0",
-        "ActiveMQ 5.15.6",
-        "ActiveMQ 5.15.8"
+        "5.15.0",
+        "5.15.6",
+        "5.15.8"
       ]
     },
     "AmazonMQHostInstanceType": {

--- a/src/cfnlint/data/CloudSpecs/ca-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/ca-central-1.json
@@ -26969,9 +26969,9 @@
     },
     "AmazonMQEngineVersion": {
       "AllowedValues": [
-        "ActiveMQ 5.15.0",
-        "ActiveMQ 5.15.6",
-        "ActiveMQ 5.15.8"
+        "5.15.0",
+        "5.15.6",
+        "5.15.8"
       ]
     },
     "AmazonMQHostInstanceType": {

--- a/src/cfnlint/data/CloudSpecs/eu-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-central-1.json
@@ -31609,9 +31609,9 @@
     },
     "AmazonMQEngineVersion": {
       "AllowedValues": [
-        "ActiveMQ 5.15.0",
-        "ActiveMQ 5.15.6",
-        "ActiveMQ 5.15.8"
+        "5.15.0",
+        "5.15.6",
+        "5.15.8"
       ]
     },
     "AmazonMQHostInstanceType": {

--- a/src/cfnlint/data/CloudSpecs/eu-north-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-north-1.json
@@ -22297,9 +22297,9 @@
     },
     "AmazonMQEngineVersion": {
       "AllowedValues": [
-        "ActiveMQ 5.15.0",
-        "ActiveMQ 5.15.6",
-        "ActiveMQ 5.15.8"
+        "5.15.0",
+        "5.15.6",
+        "5.15.8"
       ]
     },
     "AmazonMQHostInstanceType": {

--- a/src/cfnlint/data/CloudSpecs/eu-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-1.json
@@ -34770,9 +34770,9 @@
     },
     "AmazonMQEngineVersion": {
       "AllowedValues": [
-        "ActiveMQ 5.15.0",
-        "ActiveMQ 5.15.6",
-        "ActiveMQ 5.15.8"
+        "5.15.0",
+        "5.15.6",
+        "5.15.8"
       ]
     },
     "AmazonMQHostInstanceType": {

--- a/src/cfnlint/data/CloudSpecs/eu-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-2.json
@@ -28297,9 +28297,9 @@
     },
     "AmazonMQEngineVersion": {
       "AllowedValues": [
-        "ActiveMQ 5.15.0",
-        "ActiveMQ 5.15.6",
-        "ActiveMQ 5.15.8"
+        "5.15.0",
+        "5.15.6",
+        "5.15.8"
       ]
     },
     "AmazonMQHostInstanceType": {

--- a/src/cfnlint/data/CloudSpecs/eu-west-3.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-3.json
@@ -25152,9 +25152,9 @@
     },
     "AmazonMQEngineVersion": {
       "AllowedValues": [
-        "ActiveMQ 5.15.0",
-        "ActiveMQ 5.15.6",
-        "ActiveMQ 5.15.8"
+        "5.15.0",
+        "5.15.6",
+        "5.15.8"
       ]
     },
     "AmazonMQHostInstanceType": {

--- a/src/cfnlint/data/CloudSpecs/sa-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/sa-east-1.json
@@ -26143,9 +26143,9 @@
     },
     "AmazonMQEngineVersion": {
       "AllowedValues": [
-        "ActiveMQ 5.15.0",
-        "ActiveMQ 5.15.6",
-        "ActiveMQ 5.15.8"
+        "5.15.0",
+        "5.15.6",
+        "5.15.8"
       ]
     },
     "AmazonMQHostInstanceType": {

--- a/src/cfnlint/data/CloudSpecs/us-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-1.json
@@ -34884,9 +34884,9 @@
     },
     "AmazonMQEngineVersion": {
       "AllowedValues": [
-        "ActiveMQ 5.15.0",
-        "ActiveMQ 5.15.6",
-        "ActiveMQ 5.15.8"
+        "5.15.0",
+        "5.15.6",
+        "5.15.8"
       ]
     },
     "AmazonMQHostInstanceType": {

--- a/src/cfnlint/data/CloudSpecs/us-east-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-2.json
@@ -32756,9 +32756,9 @@
     },
     "AmazonMQEngineVersion": {
       "AllowedValues": [
-        "ActiveMQ 5.15.0",
-        "ActiveMQ 5.15.6",
-        "ActiveMQ 5.15.8"
+        "5.15.0",
+        "5.15.6",
+        "5.15.8"
       ]
     },
     "AmazonMQHostInstanceType": {

--- a/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
@@ -21241,9 +21241,9 @@
     },
     "AmazonMQEngineVersion": {
       "AllowedValues": [
-        "ActiveMQ 5.15.0",
-        "ActiveMQ 5.15.6",
-        "ActiveMQ 5.15.8"
+        "5.15.0",
+        "5.15.6",
+        "5.15.8"
       ]
     },
     "AmazonMQHostInstanceType": {

--- a/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
@@ -21485,9 +21485,9 @@
     },
     "AmazonMQEngineVersion": {
       "AllowedValues": [
-        "ActiveMQ 5.15.0",
-        "ActiveMQ 5.15.6",
-        "ActiveMQ 5.15.8"
+        "5.15.0",
+        "5.15.6",
+        "5.15.8"
       ]
     },
     "AmazonMQHostInstanceType": {

--- a/src/cfnlint/data/CloudSpecs/us-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-1.json
@@ -27735,9 +27735,9 @@
     },
     "AmazonMQEngineVersion": {
       "AllowedValues": [
-        "ActiveMQ 5.15.0",
-        "ActiveMQ 5.15.6",
-        "ActiveMQ 5.15.8"
+        "5.15.0",
+        "5.15.6",
+        "5.15.8"
       ]
     },
     "AmazonMQHostInstanceType": {

--- a/src/cfnlint/data/CloudSpecs/us-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-2.json
@@ -34829,9 +34829,9 @@
     },
     "AmazonMQEngineVersion": {
       "AllowedValues": [
-        "ActiveMQ 5.15.0",
-        "ActiveMQ 5.15.6",
-        "ActiveMQ 5.15.8"
+        "5.15.0",
+        "5.15.6",
+        "5.15.8"
       ]
     },
     "AmazonMQHostInstanceType": {

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
@@ -26,9 +26,9 @@
       },
       "AmazonMQEngineVersion": {
         "AllowedValues": [
-          "ActiveMQ 5.15.0",
-          "ActiveMQ 5.15.6",
-          "ActiveMQ 5.15.8"
+          "5.15.0",
+          "5.15.6",
+          "5.15.8"
         ]
       },
       "AmazonMQHostInstanceType": {

--- a/test/fixtures/templates/good/resources/properties/allowed_values.yaml
+++ b/test/fixtures/templates/good/resources/properties/allowed_values.yaml
@@ -25,7 +25,7 @@ Resources:
       BrokerName: "myBroker"
       DeploymentMode: "SINGLE_INSTANCE" # Valid AllowedValue
       EngineType: "ACTIVEMQ" # Valid AllowedValue
-      EngineVersion: "ActiveMQ 5.15.8" # Valid AllowedValue
+      EngineVersion: "5.15.8" # Valid AllowedValue
       PubliclyAccessible: false
       HostInstanceType: "mq.t2.micro" # Valid AllowedValue
       Users:
@@ -39,7 +39,7 @@ Resources:
     Properties:
       Data: ""
       EngineType: "ACTIVEMQ" # Valid AllowedValue
-      EngineVersion: "ActiveMQ 5.15.8" # Valid AllowedValue
+      EngineVersion: "5.15.8" # Valid AllowedValue
       Name: "Configuration"
   ApiGatewayAuthorizer:
     Type: "AWS::ApiGateway::Authorizer"


### PR DESCRIPTION

*Description of changes:*

 - Fix AmazonMQEngineVersion AllowedValues

As per https://github.com/awsdocs/amazon-mq-developer-guide/issues/1 the documentation is wrong on this service, as such cfn-lint gives a false positive error.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
