### PR TITLE
Add Cloud Map allowed Values

### DIFF
--- a/src/cfnlint/data/AdditionalSpecs/OnlyOne.json
+++ b/src/cfnlint/data/AdditionalSpecs/OnlyOne.json
@@ -69,6 +69,12 @@
         "HostedZoneId",
         "HostedZoneName"
       ]
+    ],
+    "AWS::ServiceDiscovery::Service": [
+      [
+        "HealthCheckConfig",
+        "HealthCheckCustomConfig"
+      ]
     ]
   }
 }

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
@@ -16540,7 +16540,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-servicediscovery-service-dnsrecord.html#cfn-servicediscovery-service-dnsrecord-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ServiceDiscoveryDnsType"
+          }
         }
       }
     },
@@ -16563,7 +16566,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-servicediscovery-service-healthcheckconfig.html#cfn-servicediscovery-service-healthcheckconfig-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ServiceDiscoveryHealthCheckConfigType"
+          }
         }
       }
     },
@@ -33785,6 +33791,20 @@
           "AWS::EC2::SecurityGroup"
         ]
       }
+    },
+    "ServiceDiscoveryDnsType": {
+      "AllowedValues": [
+        "A",
+        "AAAA",
+        "SRV"
+      ]
+    },
+    "ServiceDiscoveryHealthCheckConfigType": {
+      "AllowedValues": [
+        "HTTP",
+        "HTTPS",
+        "TCP"
+      ]
     },
     "SesReceiptRuleTlsPolicy": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
@@ -15679,7 +15679,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-servicediscovery-service-dnsrecord.html#cfn-servicediscovery-service-dnsrecord-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ServiceDiscoveryDnsType"
+          }
         }
       }
     },
@@ -15702,7 +15705,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-servicediscovery-service-healthcheckconfig.html#cfn-servicediscovery-service-healthcheckconfig-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ServiceDiscoveryHealthCheckConfigType"
+          }
         }
       }
     },
@@ -30849,7 +30855,6 @@
         "AWS::ServiceCatalog::CloudFormationProduct",
         "AWS::ServiceCatalog::CloudFormationProvisionedProduct",
         "AWS::ServiceCatalog::Portfolio",
-        "AWS::ShieldRegional::Protection",
         "AWS::SSM::AssociationCompliance",
         "AWS::SSM::ManagedInstanceInventory",
         "AWS::SSM::PatchCompliance",
@@ -31564,6 +31569,20 @@
           "AWS::EC2::SecurityGroup"
         ]
       }
+    },
+    "ServiceDiscoveryDnsType": {
+      "AllowedValues": [
+        "A",
+        "AAAA",
+        "SRV"
+      ]
+    },
+    "ServiceDiscoveryHealthCheckConfigType": {
+      "AllowedValues": [
+        "HTTP",
+        "HTTPS",
+        "TCP"
+      ]
     },
     "SesReceiptRuleTlsPolicy": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
@@ -21457,7 +21457,6 @@
         "AWS::ServiceCatalog::CloudFormationProduct",
         "AWS::ServiceCatalog::CloudFormationProvisionedProduct",
         "AWS::ServiceCatalog::Portfolio",
-        "AWS::ShieldRegional::Protection",
         "AWS::SSM::AssociationCompliance",
         "AWS::SSM::ManagedInstanceInventory",
         "AWS::SSM::PatchCompliance",
@@ -22082,6 +22081,20 @@
           "AWS::EC2::SecurityGroup"
         ]
       }
+    },
+    "ServiceDiscoveryDnsType": {
+      "AllowedValues": [
+        "A",
+        "AAAA",
+        "SRV"
+      ]
+    },
+    "ServiceDiscoveryHealthCheckConfigType": {
+      "AllowedValues": [
+        "HTTP",
+        "HTTPS",
+        "TCP"
+      ]
     },
     "SesReceiptRuleTlsPolicy": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ap-south-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-south-1.json
@@ -14955,7 +14955,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-servicediscovery-service-dnsrecord.html#cfn-servicediscovery-service-dnsrecord-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ServiceDiscoveryDnsType"
+          }
         }
       }
     },
@@ -14978,7 +14981,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-servicediscovery-service-healthcheckconfig.html#cfn-servicediscovery-service-healthcheckconfig-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ServiceDiscoveryHealthCheckConfigType"
+          }
         }
       }
     },
@@ -29170,7 +29176,6 @@
         "AWS::ServiceCatalog::CloudFormationProduct",
         "AWS::ServiceCatalog::CloudFormationProvisionedProduct",
         "AWS::ServiceCatalog::Portfolio",
-        "AWS::ShieldRegional::Protection",
         "AWS::SSM::AssociationCompliance",
         "AWS::SSM::ManagedInstanceInventory",
         "AWS::SSM::PatchCompliance",
@@ -29859,6 +29864,20 @@
           "AWS::EC2::SecurityGroup"
         ]
       }
+    },
+    "ServiceDiscoveryDnsType": {
+      "AllowedValues": [
+        "A",
+        "AAAA",
+        "SRV"
+      ]
+    },
+    "ServiceDiscoveryHealthCheckConfigType": {
+      "AllowedValues": [
+        "HTTP",
+        "HTTPS",
+        "TCP"
+      ]
     },
     "SesReceiptRuleTlsPolicy": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
@@ -15368,7 +15368,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-servicediscovery-service-dnsrecord.html#cfn-servicediscovery-service-dnsrecord-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ServiceDiscoveryDnsType"
+          }
         }
       }
     },
@@ -15391,7 +15394,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-servicediscovery-service-healthcheckconfig.html#cfn-servicediscovery-service-healthcheckconfig-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ServiceDiscoveryHealthCheckConfigType"
+          }
         }
       }
     },
@@ -31227,6 +31233,20 @@
           "AWS::EC2::SecurityGroup"
         ]
       }
+    },
+    "ServiceDiscoveryDnsType": {
+      "AllowedValues": [
+        "A",
+        "AAAA",
+        "SRV"
+      ]
+    },
+    "ServiceDiscoveryHealthCheckConfigType": {
+      "AllowedValues": [
+        "HTTP",
+        "HTTPS",
+        "TCP"
+      ]
     },
     "SesReceiptRuleTlsPolicy": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
@@ -15837,7 +15837,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-servicediscovery-service-dnsrecord.html#cfn-servicediscovery-service-dnsrecord-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ServiceDiscoveryDnsType"
+          }
         }
       }
     },
@@ -15860,7 +15863,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-servicediscovery-service-healthcheckconfig.html#cfn-servicediscovery-service-healthcheckconfig-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ServiceDiscoveryHealthCheckConfigType"
+          }
         }
       }
     },
@@ -32131,6 +32137,20 @@
           "AWS::EC2::SecurityGroup"
         ]
       }
+    },
+    "ServiceDiscoveryDnsType": {
+      "AllowedValues": [
+        "A",
+        "AAAA",
+        "SRV"
+      ]
+    },
+    "ServiceDiscoveryHealthCheckConfigType": {
+      "AllowedValues": [
+        "HTTP",
+        "HTTPS",
+        "TCP"
+      ]
     },
     "SesReceiptRuleTlsPolicy": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ca-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/ca-central-1.json
@@ -14009,7 +14009,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-servicediscovery-service-dnsrecord.html#cfn-servicediscovery-service-dnsrecord-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ServiceDiscoveryDnsType"
+          }
         }
       }
     },
@@ -14032,7 +14035,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-servicediscovery-service-healthcheckconfig.html#cfn-servicediscovery-service-healthcheckconfig-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ServiceDiscoveryHealthCheckConfigType"
+          }
         }
       }
     },
@@ -27530,7 +27536,6 @@
         "AWS::ServiceCatalog::CloudFormationProduct",
         "AWS::ServiceCatalog::CloudFormationProvisionedProduct",
         "AWS::ServiceCatalog::Portfolio",
-        "AWS::ShieldRegional::Protection",
         "AWS::SSM::AssociationCompliance",
         "AWS::SSM::ManagedInstanceInventory",
         "AWS::SSM::PatchCompliance",
@@ -28217,6 +28222,20 @@
           "AWS::EC2::SecurityGroup"
         ]
       }
+    },
+    "ServiceDiscoveryDnsType": {
+      "AllowedValues": [
+        "A",
+        "AAAA",
+        "SRV"
+      ]
+    },
+    "ServiceDiscoveryHealthCheckConfigType": {
+      "AllowedValues": [
+        "HTTP",
+        "HTTPS",
+        "TCP"
+      ]
     },
     "SesReceiptRuleTlsPolicy": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/eu-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-central-1.json
@@ -16386,7 +16386,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-servicediscovery-service-dnsrecord.html#cfn-servicediscovery-service-dnsrecord-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ServiceDiscoveryDnsType"
+          }
         }
       }
     },
@@ -16409,7 +16412,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-servicediscovery-service-healthcheckconfig.html#cfn-servicediscovery-service-healthcheckconfig-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ServiceDiscoveryHealthCheckConfigType"
+          }
         }
       }
     },
@@ -32911,6 +32917,20 @@
           "AWS::EC2::SecurityGroup"
         ]
       }
+    },
+    "ServiceDiscoveryDnsType": {
+      "AllowedValues": [
+        "A",
+        "AAAA",
+        "SRV"
+      ]
+    },
+    "ServiceDiscoveryHealthCheckConfigType": {
+      "AllowedValues": [
+        "HTTP",
+        "HTTPS",
+        "TCP"
+      ]
     },
     "SesReceiptRuleTlsPolicy": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/eu-north-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-north-1.json
@@ -22858,7 +22858,6 @@
         "AWS::ServiceCatalog::CloudFormationProduct",
         "AWS::ServiceCatalog::CloudFormationProvisionedProduct",
         "AWS::ServiceCatalog::Portfolio",
-        "AWS::ShieldRegional::Protection",
         "AWS::SSM::AssociationCompliance",
         "AWS::SSM::ManagedInstanceInventory",
         "AWS::SSM::PatchCompliance",
@@ -23490,6 +23489,20 @@
           "AWS::EC2::SecurityGroup"
         ]
       }
+    },
+    "ServiceDiscoveryDnsType": {
+      "AllowedValues": [
+        "A",
+        "AAAA",
+        "SRV"
+      ]
+    },
+    "ServiceDiscoveryHealthCheckConfigType": {
+      "AllowedValues": [
+        "HTTP",
+        "HTTPS",
+        "TCP"
+      ]
     },
     "SesReceiptRuleTlsPolicy": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/eu-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-1.json
@@ -18674,7 +18674,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-servicediscovery-service-dnsrecord.html#cfn-servicediscovery-service-dnsrecord-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ServiceDiscoveryDnsType"
+          }
         }
       }
     },
@@ -18697,7 +18700,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-servicediscovery-service-healthcheckconfig.html#cfn-servicediscovery-service-healthcheckconfig-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ServiceDiscoveryHealthCheckConfigType"
+          }
         }
       }
     },
@@ -37105,6 +37111,20 @@
           "AWS::EC2::SecurityGroup"
         ]
       }
+    },
+    "ServiceDiscoveryDnsType": {
+      "AllowedValues": [
+        "A",
+        "AAAA",
+        "SRV"
+      ]
+    },
+    "ServiceDiscoveryHealthCheckConfigType": {
+      "AllowedValues": [
+        "HTTP",
+        "HTTPS",
+        "TCP"
+      ]
     },
     "SesReceiptRuleTlsPolicy": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/eu-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-2.json
@@ -14488,7 +14488,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-servicediscovery-service-dnsrecord.html#cfn-servicediscovery-service-dnsrecord-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ServiceDiscoveryDnsType"
+          }
         }
       }
     },
@@ -14511,7 +14514,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-servicediscovery-service-healthcheckconfig.html#cfn-servicediscovery-service-healthcheckconfig-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ServiceDiscoveryHealthCheckConfigType"
+          }
         }
       }
     },
@@ -28858,7 +28864,6 @@
         "AWS::ServiceCatalog::CloudFormationProduct",
         "AWS::ServiceCatalog::CloudFormationProvisionedProduct",
         "AWS::ServiceCatalog::Portfolio",
-        "AWS::ShieldRegional::Protection",
         "AWS::SSM::AssociationCompliance",
         "AWS::SSM::ManagedInstanceInventory",
         "AWS::SSM::PatchCompliance",
@@ -29543,6 +29548,20 @@
           "AWS::EC2::SecurityGroup"
         ]
       }
+    },
+    "ServiceDiscoveryDnsType": {
+      "AllowedValues": [
+        "A",
+        "AAAA",
+        "SRV"
+      ]
+    },
+    "ServiceDiscoveryHealthCheckConfigType": {
+      "AllowedValues": [
+        "HTTP",
+        "HTTPS",
+        "TCP"
+      ]
     },
     "SesReceiptRuleTlsPolicy": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/eu-west-3.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-3.json
@@ -13003,7 +13003,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-servicediscovery-service-dnsrecord.html#cfn-servicediscovery-service-dnsrecord-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ServiceDiscoveryDnsType"
+          }
         }
       }
     },
@@ -13026,7 +13029,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-servicediscovery-service-healthcheckconfig.html#cfn-servicediscovery-service-healthcheckconfig-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ServiceDiscoveryHealthCheckConfigType"
+          }
         }
       }
     },
@@ -25713,7 +25719,6 @@
         "AWS::ServiceCatalog::CloudFormationProduct",
         "AWS::ServiceCatalog::CloudFormationProvisionedProduct",
         "AWS::ServiceCatalog::Portfolio",
-        "AWS::ShieldRegional::Protection",
         "AWS::SSM::AssociationCompliance",
         "AWS::SSM::ManagedInstanceInventory",
         "AWS::SSM::PatchCompliance",
@@ -26385,6 +26390,20 @@
           "AWS::EC2::SecurityGroup"
         ]
       }
+    },
+    "ServiceDiscoveryDnsType": {
+      "AllowedValues": [
+        "A",
+        "AAAA",
+        "SRV"
+      ]
+    },
+    "ServiceDiscoveryHealthCheckConfigType": {
+      "AllowedValues": [
+        "HTTP",
+        "HTTPS",
+        "TCP"
+      ]
     },
     "SesReceiptRuleTlsPolicy": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/sa-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/sa-east-1.json
@@ -26747,7 +26747,6 @@
         "AWS::ServiceCatalog::CloudFormationProduct",
         "AWS::ServiceCatalog::CloudFormationProvisionedProduct",
         "AWS::ServiceCatalog::Portfolio",
-        "AWS::ShieldRegional::Protection",
         "AWS::SSM::AssociationCompliance",
         "AWS::SSM::ManagedInstanceInventory",
         "AWS::SSM::PatchCompliance",
@@ -27437,6 +27436,20 @@
           "AWS::EC2::SecurityGroup"
         ]
       }
+    },
+    "ServiceDiscoveryDnsType": {
+      "AllowedValues": [
+        "A",
+        "AAAA",
+        "SRV"
+      ]
+    },
+    "ServiceDiscoveryHealthCheckConfigType": {
+      "AllowedValues": [
+        "HTTP",
+        "HTTPS",
+        "TCP"
+      ]
     },
     "SesReceiptRuleTlsPolicy": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/us-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-1.json
@@ -18675,7 +18675,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-servicediscovery-service-dnsrecord.html#cfn-servicediscovery-service-dnsrecord-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ServiceDiscoveryDnsType"
+          }
         }
       }
     },
@@ -18698,7 +18701,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-servicediscovery-service-healthcheckconfig.html#cfn-servicediscovery-service-healthcheckconfig-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ServiceDiscoveryHealthCheckConfigType"
+          }
         }
       }
     },
@@ -37185,6 +37191,20 @@
           "AWS::EC2::SecurityGroup"
         ]
       }
+    },
+    "ServiceDiscoveryDnsType": {
+      "AllowedValues": [
+        "A",
+        "AAAA",
+        "SRV"
+      ]
+    },
+    "ServiceDiscoveryHealthCheckConfigType": {
+      "AllowedValues": [
+        "HTTP",
+        "HTTPS",
+        "TCP"
+      ]
     },
     "SesReceiptRuleTlsPolicy": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/us-east-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-2.json
@@ -17706,7 +17706,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-servicediscovery-service-dnsrecord.html#cfn-servicediscovery-service-dnsrecord-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ServiceDiscoveryDnsType"
+          }
         }
       }
     },
@@ -17729,7 +17732,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-servicediscovery-service-healthcheckconfig.html#cfn-servicediscovery-service-healthcheckconfig-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ServiceDiscoveryHealthCheckConfigType"
+          }
         }
       }
     },
@@ -34997,6 +35003,20 @@
           "AWS::EC2::SecurityGroup"
         ]
       }
+    },
+    "ServiceDiscoveryDnsType": {
+      "AllowedValues": [
+        "A",
+        "AAAA",
+        "SRV"
+      ]
+    },
+    "ServiceDiscoveryHealthCheckConfigType": {
+      "AllowedValues": [
+        "HTTP",
+        "HTTPS",
+        "TCP"
+      ]
     },
     "SesReceiptRuleTlsPolicy": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
@@ -21802,7 +21802,6 @@
         "AWS::ServiceCatalog::CloudFormationProduct",
         "AWS::ServiceCatalog::CloudFormationProvisionedProduct",
         "AWS::ServiceCatalog::Portfolio",
-        "AWS::ShieldRegional::Protection",
         "AWS::SSM::AssociationCompliance",
         "AWS::SSM::ManagedInstanceInventory",
         "AWS::SSM::PatchCompliance",
@@ -22410,6 +22409,20 @@
           "AWS::EC2::SecurityGroup"
         ]
       }
+    },
+    "ServiceDiscoveryDnsType": {
+      "AllowedValues": [
+        "A",
+        "AAAA",
+        "SRV"
+      ]
+    },
+    "ServiceDiscoveryHealthCheckConfigType": {
+      "AllowedValues": [
+        "HTTP",
+        "HTTPS",
+        "TCP"
+      ]
     },
     "SesReceiptRuleTlsPolicy": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
@@ -22046,7 +22046,6 @@
         "AWS::ServiceCatalog::CloudFormationProduct",
         "AWS::ServiceCatalog::CloudFormationProvisionedProduct",
         "AWS::ServiceCatalog::Portfolio",
-        "AWS::ShieldRegional::Protection",
         "AWS::SSM::AssociationCompliance",
         "AWS::SSM::ManagedInstanceInventory",
         "AWS::SSM::PatchCompliance",
@@ -22787,6 +22786,20 @@
           "AWS::EC2::SecurityGroup"
         ]
       }
+    },
+    "ServiceDiscoveryDnsType": {
+      "AllowedValues": [
+        "A",
+        "AAAA",
+        "SRV"
+      ]
+    },
+    "ServiceDiscoveryHealthCheckConfigType": {
+      "AllowedValues": [
+        "HTTP",
+        "HTTPS",
+        "TCP"
+      ]
     },
     "SesReceiptRuleTlsPolicy": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/us-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-1.json
@@ -14176,7 +14176,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-servicediscovery-service-dnsrecord.html#cfn-servicediscovery-service-dnsrecord-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ServiceDiscoveryDnsType"
+          }
         }
       }
     },
@@ -14199,7 +14202,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-servicediscovery-service-healthcheckconfig.html#cfn-servicediscovery-service-healthcheckconfig-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ServiceDiscoveryHealthCheckConfigType"
+          }
         }
       }
     },
@@ -29047,6 +29053,20 @@
           "AWS::EC2::SecurityGroup"
         ]
       }
+    },
+    "ServiceDiscoveryDnsType": {
+      "AllowedValues": [
+        "A",
+        "AAAA",
+        "SRV"
+      ]
+    },
+    "ServiceDiscoveryHealthCheckConfigType": {
+      "AllowedValues": [
+        "HTTP",
+        "HTTPS",
+        "TCP"
+      ]
     },
     "SesReceiptRuleTlsPolicy": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/us-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-2.json
@@ -18693,7 +18693,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-servicediscovery-service-dnsrecord.html#cfn-servicediscovery-service-dnsrecord-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ServiceDiscoveryDnsType"
+          }
         }
       }
     },
@@ -18716,7 +18719,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-servicediscovery-service-healthcheckconfig.html#cfn-servicediscovery-service-healthcheckconfig-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ServiceDiscoveryHealthCheckConfigType"
+          }
         }
       }
     },
@@ -37166,6 +37172,20 @@
           "AWS::EC2::SecurityGroup"
         ]
       }
+    },
+    "ServiceDiscoveryDnsType": {
+      "AllowedValues": [
+        "A",
+        "AAAA",
+        "SRV"
+      ]
+    },
+    "ServiceDiscoveryHealthCheckConfigType": {
+      "AllowedValues": [
+        "HTTP",
+        "HTTPS",
+        "TCP"
+      ]
     },
     "SesReceiptRuleTlsPolicy": {
       "AllowedValues": [

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
@@ -1098,6 +1098,20 @@
           ]
         }
       },
+      "ServiceDiscoveryDnsType": {
+        "AllowedValues": [
+          "A",
+          "AAAA",
+          "SRV"
+        ]
+      },
+      "ServiceDiscoveryHealthCheckConfigType": {
+        "AllowedValues": [
+          "HTTP",
+          "HTTPS",
+          "TCP"
+        ]
+      },
       "SesReceiptRuleTlsPolicy": {
         "AllowedValues": [
           "Optional",

--- a/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
@@ -562,6 +562,20 @@
   },
   {
     "op": "add",
+    "path": "/PropertyTypes/AWS::ServiceDiscovery::Service.DnsRecord/Properties/Type/Value",
+    "value": {
+      "ValueType": "ServiceDiscoveryDnsType"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/PropertyTypes/AWS::ServiceDiscovery::Service.HealthCheckConfig/Properties/Type/Value",
+    "value": {
+      "ValueType": "ServiceDiscoveryHealthCheckConfigType"
+    }
+  },
+  {
+    "op": "add",
     "path": "/PropertyTypes/AWS::WorkSpaces::Workspace.WorkspaceProperties/Properties/ComputeTypeName/Value",
     "value": {
       "ValueType": "WorkspacePropertyComputeType"

--- a/test/fixtures/templates/bad/resources/properties/allowed_values.yaml
+++ b/test/fixtures/templates/bad/resources/properties/allowed_values.yaml
@@ -468,6 +468,15 @@ Resources:
       SecretId: "SecretArn"
       TargetId: "RefToCluster"
       TargetType: "AWS::RDS:DBCluster" # Invalid AllowedValue
+  ServiceDiscoveryService:
+    Type: "AWS::ServiceDiscovery::Service"
+    Properties:
+      HealthCheckConfig:
+        Type: "SSH" # Invalid AllowedValue
+      DnsConfig:
+        DnsRecords:
+          - Type: "CNAME" # Invalid AllowedValue
+            TTL: "60"
   SesReceiptRule:
     Type: "AWS::SES::ReceiptRule"
     Properties:

--- a/test/fixtures/templates/good/resources/properties/allowed_values.yaml
+++ b/test/fixtures/templates/good/resources/properties/allowed_values.yaml
@@ -475,6 +475,15 @@ Resources:
       SecretId: "SecretArn"
       TargetId: "RefToCluster"
       TargetType: "AWS::RDS::DBCluster" # Valid AllowedValue
+  ServiceDiscoveryService:
+    Type: "AWS::ServiceDiscovery::Service"
+    Properties:
+      HealthCheckConfig:
+        Type: "HTTP" # Valid AllowedValue
+      DnsConfig:
+        DnsRecords:
+          - Type: "A" # Valid AllowedValue
+            TTL: "60"
   SesReceiptRule:
     Type: "AWS::SES::ReceiptRule"
     Properties:

--- a/test/rules/resources/properties/test_allowed_value.py
+++ b/test/rules/resources/properties/test_allowed_value.py
@@ -34,4 +34,4 @@ class TestAllowedValue(BaseRuleTestCase):
 
     def test_file_negative(self):
         """Test failure"""
-        self.helper_file_negative('test/fixtures/templates/bad/resources/properties/allowed_values.yaml', 120)
+        self.helper_file_negative('test/fixtures/templates/bad/resources/properties/allowed_values.yaml', 122)


### PR DESCRIPTION
*Issue https://github.com/awslabs/cfn-python-lint/issues/50, if available:*

Add all the allowed values of the [`AWS::ServiceDiscovery`]( https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-reference-servicediscovery.html) (AWS CloudMap... No clue why the naming is different..) Resources

Also Added a configuration to the `OnlyOne`: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-servicediscovery-service.html#cfn-servicediscovery-service-healthcheckconfig

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
