### PR TITLE
Use the cfn-lint YAML decoders and force the Path to be a string

### DIFF
--- a/src/cfnlint/config.py
+++ b/src/cfnlint/config.py
@@ -21,8 +21,8 @@ import glob
 import json
 import os
 import six
-import yaml
 import jsonschema
+import cfnlint.decode.cfn_yaml
 from cfnlint.version import __version__
 try:  # pragma: no cover
     from pathlib import Path
@@ -208,7 +208,7 @@ class ConfigFileArgs(object):
 
         if self._has_file(config):
             LOGGER.debug('Parsing CFNLINTRC')
-            config_template = yaml.safe_load(config.read_text())
+            config_template = cfnlint.decode.cfn_yaml.load(str(config))
 
         if not config_template:
             config_template = {}

--- a/test/fixtures/configs/cfnlintrc_read.yaml
+++ b/test/fixtures/configs/cfnlintrc_read.yaml
@@ -1,0 +1,4 @@
+templates:
+- test/fixtures/templates/good/**/*.yaml
+include_checks:
+- I

--- a/test/module/config/test_config_file_args.py
+++ b/test/module/config/test_config_file_args.py
@@ -19,6 +19,10 @@ from mock import patch, mock_open, Mock
 import jsonschema
 import cfnlint.config  # pylint: disable=E0401
 from testlib.testcase import BaseTestCase
+try:  # pragma: no cover
+    from pathlib import Path
+except ImportError:  # pragma: no cover
+    from pathlib2 import Path
 
 
 LOGGER = logging.getLogger('cfnlint')
@@ -30,6 +34,20 @@ class TestConfigFileArgs(BaseTestCase):
         """Setup"""
         for handler in LOGGER.handlers:
             LOGGER.removeHandler(handler)
+
+    def test_config_parser_read_config(self):
+        """ Testing one file successful """
+        # cfnlintrc_mock.return_value.side_effect = [Mock(return_value=True), Mock(return_value=False)]
+        config = cfnlint.config.ConfigFileArgs()
+        config_file = Path('test/fixtures/configs/cfnlintrc_read.yaml')
+        config_template = config._read_config(config_file)
+        self.assertEqual(
+            config_template,
+            {
+                'templates': ['test/fixtures/templates/good/**/*.yaml'],
+                'include_checks': ['I']
+            }
+        )
 
     @patch('cfnlint.config.ConfigFileArgs._read_config', create=True)
     def test_config_parser_read(self, yaml_mock):


### PR DESCRIPTION
*Issue #, if available:*
Fix #673 
*Description of changes:*
Use the built-in cfn-lint YAML decoders

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
