### PR TITLE
Require NoDevice with Ebs or VirtualName for BlockDeviceMappings

### DIFF
--- a/src/cfnlint/data/AdditionalSpecs/OnlyOne.json
+++ b/src/cfnlint/data/AdditionalSpecs/OnlyOne.json
@@ -3,31 +3,36 @@
     "AWS::EC2::Instance.BlockDeviceMapping": [
       [
         "VirtualName",
-        "Ebs"
+        "Ebs",
+        "NoDevice"
       ]
     ],
     "AWS::EC2::SpotFleet.BlockDeviceMapping": [
       [
         "VirtualName",
-        "Ebs"
+        "Ebs",
+        "NoDevice"
       ]
     ],
     "AWS::AutoScaling::LaunchConfiguration.BlockDeviceMapping": [
       [
         "VirtualName",
-        "Ebs"
+        "Ebs",
+        "NoDevice"
       ]
     ],
     "AWS::EC2::LaunchTemplate.BlockDeviceMapping": [
       [
         "VirtualName",
-        "Ebs"
+        "Ebs",
+        "NoDevice"
       ]
     ],
     "AWS::OpsWorks::Instance.BlockDeviceMapping": [
       [
         "VirtualName",
-        "Ebs"
+        "Ebs",
+        "NoDevice"
       ]
     ],
     "AWS::S3::Bucket.RoutingRuleCondition": [


### PR DESCRIPTION
*Issue #, if available:*
Fix #534 
*Description of changes:*
- BlockDeviceMappings need at least one of NoDevice, Ebs, or VirtualName

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
