### PR TITLE
 Add DAX allowed values

### DIFF
--- a/scripts/update_specs_from_pricing.py
+++ b/scripts/update_specs_from_pricing.py
@@ -51,7 +51,7 @@ region_map = {
     'US West (N. California)': 'us-west-1',
 }
 
-session = boto3.session.Session()
+session = boto3.session.Session(profile_name='development')
 client = session.client('pricing', region_name='us-east-1')
 
 def configure_logging():
@@ -130,6 +130,30 @@ def get_redshift_pricing():
                     )
     return results
 
+def get_dax_pricing():
+
+    LOGGER.info('Get DAX pricing')
+    paginator = client.get_paginator('get_products')
+    page_iterator = paginator.paginate(
+        ServiceCode='AmazonDAX',
+        FormatVersion='aws_v1',
+    )
+
+    results = {}
+    for page in page_iterator:
+        for price_item in page.get('PriceList', []):
+            products = json.loads(price_item)
+            product = products.get('product', {})
+            if product:
+                if product.get('productFamily') == 'DAX':
+                    if not results.get(region_map[product.get('attributes').get('location')]):
+                        results[region_map[product.get('attributes').get('location')]] = set()
+                    usage_type = product.get('attributes').get('usagetype').split(':')[1]
+                    results[region_map[product.get('attributes').get('location')]].add(
+                        usage_type
+                    )
+    return results
+
 
 def get_mq_pricing():
     """ Get MQ Instance Pricing """
@@ -197,6 +221,7 @@ def main():
     outputs = update_outputs('AmazonMQHostInstanceType', get_mq_pricing(), outputs)
     outputs = update_outputs('RdsInstanceType', get_rds_pricing(), outputs)
     outputs = update_outputs('RedshiftInstanceType', get_redshift_pricing(), outputs)
+    outputs = update_outputs('DAXInstanceType', get_dax_pricing(), outputs)
 
     LOGGER.info('Updating spec files')
     for region, patches in outputs.items():

--- a/scripts/update_specs_from_pricing.py
+++ b/scripts/update_specs_from_pricing.py
@@ -51,7 +51,7 @@ region_map = {
     'US West (N. California)': 'us-west-1',
 }
 
-session = boto3.session.Session(profile_name='development')
+session = boto3.session.Session()
 client = session.client('pricing', region_name='us-east-1')
 
 def configure_logging():

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
@@ -21524,7 +21524,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dax-cluster.html#cfn-dax-cluster-nodetype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "DAXInstanceType"
+          }
         },
         "NotificationTopicARN": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dax-cluster.html#cfn-dax-cluster-notificationtopicarn",
@@ -33494,6 +33497,28 @@
         "ZW"
       ]
     },
+    "DAXInstanceType": {
+      "AllowedValues": [
+        "dax.r3.2xlarge",
+        "dax.r3.4xlarge",
+        "dax.r3.8xlarge",
+        "dax.r3.large",
+        "dax.r3.xlarge",
+        "dax.r4.16xlarge",
+        "dax.r4.2xlarge",
+        "dax.r4.4xlarge",
+        "dax.r4.8xlarge",
+        "dax.r4.large",
+        "dax.r4.xlarge",
+        "dax.t2.medium",
+        "dax.t2.small"
+      ],
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
+    },
     "DmsEndpointEngineName": {
       "AllowedValues": [
         "aurora-postgresql",
@@ -34014,6 +34039,23 @@
         "SRV",
         "TXT"
       ]
+    },
+    "RedshiftInstanceType": {
+      "AllowedValues": [
+        "dc1.8xlarge",
+        "dc1.large",
+        "dc2.8xlarge",
+        "dc2.large",
+        "ds1.8xlarge",
+        "ds1.xlarge",
+        "ds2.8xlarge",
+        "ds2.xlarge"
+      ],
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
     },
     "Region": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
@@ -31312,6 +31312,13 @@
         "ZW"
       ]
     },
+    "DAXInstanceType": {
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
+    },
     "DmsEndpointEngineName": {
       "AllowedValues": [
         "aurora-postgresql",
@@ -31792,6 +31799,21 @@
         "SRV",
         "TXT"
       ]
+    },
+    "RedshiftInstanceType": {
+      "AllowedValues": [
+        "dc1.8xlarge",
+        "dc1.large",
+        "dc2.8xlarge",
+        "dc2.large",
+        "ds2.8xlarge",
+        "ds2.xlarge"
+      ],
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
     },
     "Region": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
@@ -21829,6 +21829,13 @@
         "ZW"
       ]
     },
+    "DAXInstanceType": {
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
+    },
     "DmsEndpointEngineName": {
       "AllowedValues": [
         "aurora-postgresql",
@@ -22219,6 +22226,19 @@
         "SRV",
         "TXT"
       ]
+    },
+    "RedshiftInstanceType": {
+      "AllowedValues": [
+        "dc2.8xlarge",
+        "dc2.large",
+        "ds2.8xlarge",
+        "ds2.xlarge"
+      ],
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
     },
     "Region": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ap-south-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-south-1.json
@@ -29633,6 +29633,28 @@
         "ZW"
       ]
     },
+    "DAXInstanceType": {
+      "AllowedValues": [
+        "dax.r3.2xlarge",
+        "dax.r3.4xlarge",
+        "dax.r3.8xlarge",
+        "dax.r3.large",
+        "dax.r3.xlarge",
+        "dax.r4.16xlarge",
+        "dax.r4.2xlarge",
+        "dax.r4.4xlarge",
+        "dax.r4.8xlarge",
+        "dax.r4.large",
+        "dax.r4.xlarge",
+        "dax.t2.medium",
+        "dax.t2.small"
+      ],
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
+    },
     "DmsEndpointEngineName": {
       "AllowedValues": [
         "aurora-postgresql",
@@ -30034,6 +30056,11 @@
         "db.r4.8xlarge",
         "db.r4.large",
         "db.r4.xlarge",
+        "db.r5.12xlarge",
+        "db.r5.2xlarge",
+        "db.r5.4xlarge",
+        "db.r5.large",
+        "db.r5.xlarge",
         "db.t2.2xlarge",
         "db.t2.large",
         "db.t2.medium",
@@ -30087,6 +30114,21 @@
         "SRV",
         "TXT"
       ]
+    },
+    "RedshiftInstanceType": {
+      "AllowedValues": [
+        "dc1.8xlarge",
+        "dc1.large",
+        "dc2.8xlarge",
+        "dc2.large",
+        "ds2.8xlarge",
+        "ds2.xlarge"
+      ],
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
     },
     "Region": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
@@ -30938,6 +30938,28 @@
         "ZW"
       ]
     },
+    "DAXInstanceType": {
+      "AllowedValues": [
+        "dax.r3.2xlarge",
+        "dax.r3.4xlarge",
+        "dax.r3.8xlarge",
+        "dax.r3.large",
+        "dax.r3.xlarge",
+        "dax.r4.16xlarge",
+        "dax.r4.2xlarge",
+        "dax.r4.4xlarge",
+        "dax.r4.8xlarge",
+        "dax.r4.large",
+        "dax.r4.xlarge",
+        "dax.t2.medium",
+        "dax.t2.small"
+      ],
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
+    },
     "DmsEndpointEngineName": {
       "AllowedValues": [
         "aurora-postgresql",
@@ -31456,6 +31478,23 @@
         "SRV",
         "TXT"
       ]
+    },
+    "RedshiftInstanceType": {
+      "AllowedValues": [
+        "dc1.8xlarge",
+        "dc1.large",
+        "dc2.8xlarge",
+        "dc2.large",
+        "ds1.8xlarge",
+        "ds1.xlarge",
+        "ds2.8xlarge",
+        "ds2.xlarge"
+      ],
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
     },
     "Region": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
@@ -31847,6 +31847,28 @@
         "ZW"
       ]
     },
+    "DAXInstanceType": {
+      "AllowedValues": [
+        "dax.r3.2xlarge",
+        "dax.r3.4xlarge",
+        "dax.r3.8xlarge",
+        "dax.r3.large",
+        "dax.r3.xlarge",
+        "dax.r4.16xlarge",
+        "dax.r4.2xlarge",
+        "dax.r4.4xlarge",
+        "dax.r4.8xlarge",
+        "dax.r4.large",
+        "dax.r4.xlarge",
+        "dax.t2.medium",
+        "dax.t2.small"
+      ],
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
+    },
     "DmsEndpointEngineName": {
       "AllowedValues": [
         "aurora-postgresql",
@@ -32360,6 +32382,23 @@
         "SRV",
         "TXT"
       ]
+    },
+    "RedshiftInstanceType": {
+      "AllowedValues": [
+        "dc1.8xlarge",
+        "dc1.large",
+        "dc2.8xlarge",
+        "dc2.large",
+        "ds1.8xlarge",
+        "ds1.xlarge",
+        "ds2.8xlarge",
+        "ds2.xlarge"
+      ],
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
     },
     "Region": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ca-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/ca-central-1.json
@@ -27993,6 +27993,13 @@
         "ZW"
       ]
     },
+    "DAXInstanceType": {
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
+    },
     "DmsEndpointEngineName": {
       "AllowedValues": [
         "aurora-postgresql",
@@ -28445,6 +28452,21 @@
         "SRV",
         "TXT"
       ]
+    },
+    "RedshiftInstanceType": {
+      "AllowedValues": [
+        "dc1.8xlarge",
+        "dc1.large",
+        "dc2.8xlarge",
+        "dc2.large",
+        "ds2.8xlarge",
+        "ds2.xlarge"
+      ],
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
     },
     "Region": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/eu-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-central-1.json
@@ -32652,6 +32652,23 @@
         "ZW"
       ]
     },
+    "DAXInstanceType": {
+      "AllowedValues": [
+        "dax.r4.16xlarge",
+        "dax.r4.2xlarge",
+        "dax.r4.4xlarge",
+        "dax.r4.8xlarge",
+        "dax.r4.large",
+        "dax.r4.xlarge",
+        "dax.t2.medium",
+        "dax.t2.small"
+      ],
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
+    },
     "DmsEndpointEngineName": {
       "AllowedValues": [
         "aurora-postgresql",
@@ -33140,6 +33157,23 @@
         "SRV",
         "TXT"
       ]
+    },
+    "RedshiftInstanceType": {
+      "AllowedValues": [
+        "dc1.8xlarge",
+        "dc1.large",
+        "dc2.8xlarge",
+        "dc2.large",
+        "ds1.8xlarge",
+        "ds1.xlarge",
+        "ds2.8xlarge",
+        "ds2.xlarge"
+      ],
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
     },
     "Region": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/eu-north-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-north-1.json
@@ -23230,6 +23230,13 @@
         "ZW"
       ]
     },
+    "DAXInstanceType": {
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
+    },
     "DmsEndpointEngineName": {
       "AllowedValues": [
         "aurora-postgresql",
@@ -23627,6 +23634,23 @@
         "SRV",
         "TXT"
       ]
+    },
+    "RedshiftInstanceType": {
+      "AllowedValues": [
+        "dc1.8xlarge",
+        "dc1.large",
+        "dc2.8xlarge",
+        "dc2.large",
+        "ds1.8xlarge",
+        "ds1.xlarge",
+        "ds2.8xlarge",
+        "ds2.xlarge"
+      ],
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
     },
     "Region": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/eu-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-1.json
@@ -24060,7 +24060,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dax-cluster.html#cfn-dax-cluster-nodetype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "DAXInstanceType"
+          }
         },
         "NotificationTopicARN": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dax-cluster.html#cfn-dax-cluster-notificationtopicarn",
@@ -37095,6 +37098,28 @@
         "ZW"
       ]
     },
+    "DAXInstanceType": {
+      "AllowedValues": [
+        "dax.r3.2xlarge",
+        "dax.r3.4xlarge",
+        "dax.r3.8xlarge",
+        "dax.r3.large",
+        "dax.r3.xlarge",
+        "dax.r4.16xlarge",
+        "dax.r4.2xlarge",
+        "dax.r4.4xlarge",
+        "dax.r4.8xlarge",
+        "dax.r4.large",
+        "dax.r4.xlarge",
+        "dax.t2.medium",
+        "dax.t2.small"
+      ],
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
+    },
     "DmsEndpointEngineName": {
       "AllowedValues": [
         "aurora-postgresql",
@@ -37646,6 +37671,23 @@
         "SRV",
         "TXT"
       ]
+    },
+    "RedshiftInstanceType": {
+      "AllowedValues": [
+        "dc1.8xlarge",
+        "dc1.large",
+        "dc2.8xlarge",
+        "dc2.large",
+        "ds1.8xlarge",
+        "ds1.xlarge",
+        "ds2.8xlarge",
+        "ds2.xlarge"
+      ],
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
     },
     "Region": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/eu-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-2.json
@@ -29321,6 +29321,13 @@
         "ZW"
       ]
     },
+    "DAXInstanceType": {
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
+    },
     "DmsEndpointEngineName": {
       "AllowedValues": [
         "aurora-postgresql",
@@ -29771,6 +29778,21 @@
         "SRV",
         "TXT"
       ]
+    },
+    "RedshiftInstanceType": {
+      "AllowedValues": [
+        "dc1.8xlarge",
+        "dc1.large",
+        "dc2.8xlarge",
+        "dc2.large",
+        "ds2.8xlarge",
+        "ds2.xlarge"
+      ],
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
     },
     "Region": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/eu-west-3.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-3.json
@@ -26176,6 +26176,13 @@
         "ZW"
       ]
     },
+    "DAXInstanceType": {
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
+    },
     "DmsEndpointEngineName": {
       "AllowedValues": [
         "aurora-postgresql",
@@ -26613,6 +26620,19 @@
         "SRV",
         "TXT"
       ]
+    },
+    "RedshiftInstanceType": {
+      "AllowedValues": [
+        "dc2.8xlarge",
+        "dc2.large",
+        "ds2.8xlarge",
+        "ds2.xlarge"
+      ],
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
     },
     "Region": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/sa-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/sa-east-1.json
@@ -27161,6 +27161,28 @@
         "ZW"
       ]
     },
+    "DAXInstanceType": {
+      "AllowedValues": [
+        "dax.r3.2xlarge",
+        "dax.r3.4xlarge",
+        "dax.r3.8xlarge",
+        "dax.r3.large",
+        "dax.r3.xlarge",
+        "dax.r4.16xlarge",
+        "dax.r4.2xlarge",
+        "dax.r4.4xlarge",
+        "dax.r4.8xlarge",
+        "dax.r4.large",
+        "dax.r4.xlarge",
+        "dax.t2.medium",
+        "dax.t2.small"
+      ],
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
+    },
     "DmsEndpointEngineName": {
       "AllowedValues": [
         "aurora-postgresql",
@@ -27616,6 +27638,21 @@
         "SRV",
         "TXT"
       ]
+    },
+    "RedshiftInstanceType": {
+      "AllowedValues": [
+        "dc1.8xlarge",
+        "dc1.large",
+        "dc2.8xlarge",
+        "dc2.large",
+        "ds2.8xlarge",
+        "ds2.xlarge"
+      ],
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
     },
     "Region": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/us-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-1.json
@@ -24061,7 +24061,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dax-cluster.html#cfn-dax-cluster-nodetype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "DAXInstanceType"
+          }
         },
         "NotificationTopicARN": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dax-cluster.html#cfn-dax-cluster-notificationtopicarn",
@@ -37173,6 +37176,28 @@
         "ZW"
       ]
     },
+    "DAXInstanceType": {
+      "AllowedValues": [
+        "dax.r3.2xlarge",
+        "dax.r3.4xlarge",
+        "dax.r3.8xlarge",
+        "dax.r3.large",
+        "dax.r3.xlarge",
+        "dax.r4.16xlarge",
+        "dax.r4.2xlarge",
+        "dax.r4.4xlarge",
+        "dax.r4.8xlarge",
+        "dax.r4.large",
+        "dax.r4.xlarge",
+        "dax.t2.medium",
+        "dax.t2.small"
+      ],
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
+    },
     "DmsEndpointEngineName": {
       "AllowedValues": [
         "aurora-postgresql",
@@ -37726,6 +37751,23 @@
         "SRV",
         "TXT"
       ]
+    },
+    "RedshiftInstanceType": {
+      "AllowedValues": [
+        "dc1.8xlarge",
+        "dc1.large",
+        "dc2.8xlarge",
+        "dc2.large",
+        "ds1.8xlarge",
+        "ds1.xlarge",
+        "ds2.8xlarge",
+        "ds2.xlarge"
+      ],
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
     },
     "Region": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/us-east-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-2.json
@@ -34732,6 +34732,23 @@
         "ZW"
       ]
     },
+    "DAXInstanceType": {
+      "AllowedValues": [
+        "dax.r4.16xlarge",
+        "dax.r4.2xlarge",
+        "dax.r4.4xlarge",
+        "dax.r4.8xlarge",
+        "dax.r4.large",
+        "dax.r4.xlarge",
+        "dax.t2.medium",
+        "dax.t2.small"
+      ],
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
+    },
     "DmsEndpointEngineName": {
       "AllowedValues": [
         "aurora-postgresql",
@@ -35226,6 +35243,21 @@
         "SRV",
         "TXT"
       ]
+    },
+    "RedshiftInstanceType": {
+      "AllowedValues": [
+        "dc1.8xlarge",
+        "dc1.large",
+        "dc2.8xlarge",
+        "dc2.large",
+        "ds2.8xlarge",
+        "ds2.xlarge"
+      ],
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
     },
     "Region": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
@@ -22174,6 +22174,13 @@
         "ZW"
       ]
     },
+    "DAXInstanceType": {
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
+    },
     "DmsEndpointEngineName": {
       "AllowedValues": [
         "aurora-postgresql",
@@ -22547,6 +22554,19 @@
         "SRV",
         "TXT"
       ]
+    },
+    "RedshiftInstanceType": {
+      "AllowedValues": [
+        "dc2.8xlarge",
+        "dc2.large",
+        "ds2.8xlarge",
+        "ds2.xlarge"
+      ],
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
     },
     "Region": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
@@ -22418,6 +22418,13 @@
         "ZW"
       ]
     },
+    "DAXInstanceType": {
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
+    },
     "DmsEndpointEngineName": {
       "AllowedValues": [
         "aurora-postgresql",
@@ -22924,6 +22931,23 @@
         "SRV",
         "TXT"
       ]
+    },
+    "RedshiftInstanceType": {
+      "AllowedValues": [
+        "dc1.8xlarge",
+        "dc1.large",
+        "dc2.8xlarge",
+        "dc2.large",
+        "ds1.8xlarge",
+        "ds1.xlarge",
+        "ds2.8xlarge",
+        "ds2.xlarge"
+      ],
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
     },
     "Region": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/us-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-1.json
@@ -17865,7 +17865,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dax-cluster.html#cfn-dax-cluster-nodetype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "DAXInstanceType"
+          }
         },
         "NotificationTopicARN": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dax-cluster.html#cfn-dax-cluster-notificationtopicarn",
@@ -28778,6 +28781,28 @@
         "ZW"
       ]
     },
+    "DAXInstanceType": {
+      "AllowedValues": [
+        "dax.r3.2xlarge",
+        "dax.r3.4xlarge",
+        "dax.r3.8xlarge",
+        "dax.r3.large",
+        "dax.r3.xlarge",
+        "dax.r4.16xlarge",
+        "dax.r4.2xlarge",
+        "dax.r4.4xlarge",
+        "dax.r4.8xlarge",
+        "dax.r4.large",
+        "dax.r4.xlarge",
+        "dax.t2.medium",
+        "dax.t2.small"
+      ],
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
+    },
     "DmsEndpointEngineName": {
       "AllowedValues": [
         "aurora-postgresql",
@@ -29276,6 +29301,21 @@
         "SRV",
         "TXT"
       ]
+    },
+    "RedshiftInstanceType": {
+      "AllowedValues": [
+        "dc1.8xlarge",
+        "dc1.large",
+        "dc2.8xlarge",
+        "dc2.large",
+        "ds2.8xlarge",
+        "ds2.xlarge"
+      ],
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
     },
     "Region": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/us-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-2.json
@@ -24079,7 +24079,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dax-cluster.html#cfn-dax-cluster-nodetype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "DAXInstanceType"
+          }
         },
         "NotificationTopicARN": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dax-cluster.html#cfn-dax-cluster-notificationtopicarn",
@@ -37154,6 +37157,28 @@
         "ZW"
       ]
     },
+    "DAXInstanceType": {
+      "AllowedValues": [
+        "dax.r3.2xlarge",
+        "dax.r3.4xlarge",
+        "dax.r3.8xlarge",
+        "dax.r3.large",
+        "dax.r3.xlarge",
+        "dax.r4.16xlarge",
+        "dax.r4.2xlarge",
+        "dax.r4.4xlarge",
+        "dax.r4.8xlarge",
+        "dax.r4.large",
+        "dax.r4.xlarge",
+        "dax.t2.medium",
+        "dax.t2.small"
+      ],
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
+    },
     "DmsEndpointEngineName": {
       "AllowedValues": [
         "aurora-postgresql",
@@ -37707,6 +37732,23 @@
         "SRV",
         "TXT"
       ]
+    },
+    "RedshiftInstanceType": {
+      "AllowedValues": [
+        "dc1.8xlarge",
+        "dc1.large",
+        "dc2.8xlarge",
+        "dc2.large",
+        "ds1.8xlarge",
+        "ds1.xlarge",
+        "ds2.8xlarge",
+        "ds2.xlarge"
+      ],
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
     },
     "Region": {
       "AllowedValues": [

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
@@ -902,6 +902,13 @@
           "ZW"
         ]
       },
+      "DAXInstanceType": {
+        "Ref": {
+          "Parameters": [
+            "String"
+          ]
+        }
+      },
       "DmsEndpointEngineName": {
         "AllowedValues": [
           "aurora-postgresql",
@@ -1232,6 +1239,13 @@
           "SRV",
           "TXT"
         ]
+      },
+      "RedshiftInstanceType": {
+        "Ref": {
+          "Parameters": [
+            "String"
+          ]
+        }
       },
       "Region": {
         "AllowedValues": [

--- a/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
@@ -1438,6 +1438,13 @@
   },
   {
     "op": "add",
+    "path": "/ResourceTypes/AWS::DAX::Cluster/Properties/NodeType/Value",
+    "value": {
+      "ValueType": "DAXInstanceType"
+    }
+  },
+  {
+    "op": "add",
     "path": "/ResourceTypes/AWS::EC2::EgressOnlyInternetGateway/Properties/VpcId/Value",
     "value": {
       "ValueType": "VpcId"

--- a/src/cfnlint/data/ExtendedSpecs/ap-northeast-1/05_pricing_property_values.json
+++ b/src/cfnlint/data/ExtendedSpecs/ap-northeast-1/05_pricing_property_values.json
@@ -232,5 +232,24 @@
       "ds2.8xlarge",
       "ds2.xlarge"
     ]
+  },
+  {
+    "op": "add",
+    "path": "/ValueTypes/DAXInstanceType/AllowedValues",
+    "value": [
+      "dax.r3.2xlarge",
+      "dax.r3.4xlarge",
+      "dax.r3.8xlarge",
+      "dax.r3.large",
+      "dax.r3.xlarge",
+      "dax.r4.16xlarge",
+      "dax.r4.2xlarge",
+      "dax.r4.4xlarge",
+      "dax.r4.8xlarge",
+      "dax.r4.large",
+      "dax.r4.xlarge",
+      "dax.t2.medium",
+      "dax.t2.small"
+    ]
   }
 ]

--- a/src/cfnlint/data/ExtendedSpecs/ap-south-1/05_pricing_property_values.json
+++ b/src/cfnlint/data/ExtendedSpecs/ap-south-1/05_pricing_property_values.json
@@ -125,6 +125,11 @@
       "db.r4.8xlarge",
       "db.r4.large",
       "db.r4.xlarge",
+      "db.r5.12xlarge",
+      "db.r5.2xlarge",
+      "db.r5.4xlarge",
+      "db.r5.large",
+      "db.r5.xlarge",
       "db.t2.2xlarge",
       "db.t2.large",
       "db.t2.medium",
@@ -151,6 +156,25 @@
       "dc2.large",
       "ds2.8xlarge",
       "ds2.xlarge"
+    ]
+  },
+  {
+    "op": "add",
+    "path": "/ValueTypes/DAXInstanceType/AllowedValues",
+    "value": [
+      "dax.r3.2xlarge",
+      "dax.r3.4xlarge",
+      "dax.r3.8xlarge",
+      "dax.r3.large",
+      "dax.r3.xlarge",
+      "dax.r4.16xlarge",
+      "dax.r4.2xlarge",
+      "dax.r4.4xlarge",
+      "dax.r4.8xlarge",
+      "dax.r4.large",
+      "dax.r4.xlarge",
+      "dax.t2.medium",
+      "dax.t2.small"
     ]
   }
 ]

--- a/src/cfnlint/data/ExtendedSpecs/ap-southeast-1/05_pricing_property_values.json
+++ b/src/cfnlint/data/ExtendedSpecs/ap-southeast-1/05_pricing_property_values.json
@@ -230,5 +230,24 @@
       "ds2.8xlarge",
       "ds2.xlarge"
     ]
+  },
+  {
+    "op": "add",
+    "path": "/ValueTypes/DAXInstanceType/AllowedValues",
+    "value": [
+      "dax.r3.2xlarge",
+      "dax.r3.4xlarge",
+      "dax.r3.8xlarge",
+      "dax.r3.large",
+      "dax.r3.xlarge",
+      "dax.r4.16xlarge",
+      "dax.r4.2xlarge",
+      "dax.r4.4xlarge",
+      "dax.r4.8xlarge",
+      "dax.r4.large",
+      "dax.r4.xlarge",
+      "dax.t2.medium",
+      "dax.t2.small"
+    ]
   }
 ]

--- a/src/cfnlint/data/ExtendedSpecs/ap-southeast-2/05_pricing_property_values.json
+++ b/src/cfnlint/data/ExtendedSpecs/ap-southeast-2/05_pricing_property_values.json
@@ -225,5 +225,24 @@
       "ds2.8xlarge",
       "ds2.xlarge"
     ]
+  },
+  {
+    "op": "add",
+    "path": "/ValueTypes/DAXInstanceType/AllowedValues",
+    "value": [
+      "dax.r3.2xlarge",
+      "dax.r3.4xlarge",
+      "dax.r3.8xlarge",
+      "dax.r3.large",
+      "dax.r3.xlarge",
+      "dax.r4.16xlarge",
+      "dax.r4.2xlarge",
+      "dax.r4.4xlarge",
+      "dax.r4.8xlarge",
+      "dax.r4.large",
+      "dax.r4.xlarge",
+      "dax.t2.medium",
+      "dax.t2.small"
+    ]
   }
 ]

--- a/src/cfnlint/data/ExtendedSpecs/eu-central-1/05_pricing_property_values.json
+++ b/src/cfnlint/data/ExtendedSpecs/eu-central-1/05_pricing_property_values.json
@@ -200,5 +200,19 @@
       "ds2.8xlarge",
       "ds2.xlarge"
     ]
+  },
+  {
+    "op": "add",
+    "path": "/ValueTypes/DAXInstanceType/AllowedValues",
+    "value": [
+      "dax.r4.16xlarge",
+      "dax.r4.2xlarge",
+      "dax.r4.4xlarge",
+      "dax.r4.8xlarge",
+      "dax.r4.large",
+      "dax.r4.xlarge",
+      "dax.t2.medium",
+      "dax.t2.small"
+    ]
   }
 ]

--- a/src/cfnlint/data/ExtendedSpecs/eu-west-1/05_pricing_property_values.json
+++ b/src/cfnlint/data/ExtendedSpecs/eu-west-1/05_pricing_property_values.json
@@ -263,5 +263,24 @@
       "ds2.8xlarge",
       "ds2.xlarge"
     ]
+  },
+  {
+    "op": "add",
+    "path": "/ValueTypes/DAXInstanceType/AllowedValues",
+    "value": [
+      "dax.r3.2xlarge",
+      "dax.r3.4xlarge",
+      "dax.r3.8xlarge",
+      "dax.r3.large",
+      "dax.r3.xlarge",
+      "dax.r4.16xlarge",
+      "dax.r4.2xlarge",
+      "dax.r4.4xlarge",
+      "dax.r4.8xlarge",
+      "dax.r4.large",
+      "dax.r4.xlarge",
+      "dax.t2.medium",
+      "dax.t2.small"
+    ]
   }
 ]

--- a/src/cfnlint/data/ExtendedSpecs/sa-east-1/05_pricing_property_values.json
+++ b/src/cfnlint/data/ExtendedSpecs/sa-east-1/05_pricing_property_values.json
@@ -153,5 +153,24 @@
       "ds2.8xlarge",
       "ds2.xlarge"
     ]
+  },
+  {
+    "op": "add",
+    "path": "/ValueTypes/DAXInstanceType/AllowedValues",
+    "value": [
+      "dax.r3.2xlarge",
+      "dax.r3.4xlarge",
+      "dax.r3.8xlarge",
+      "dax.r3.large",
+      "dax.r3.xlarge",
+      "dax.r4.16xlarge",
+      "dax.r4.2xlarge",
+      "dax.r4.4xlarge",
+      "dax.r4.8xlarge",
+      "dax.r4.large",
+      "dax.r4.xlarge",
+      "dax.t2.medium",
+      "dax.t2.small"
+    ]
   }
 ]

--- a/src/cfnlint/data/ExtendedSpecs/us-east-1/05_pricing_property_values.json
+++ b/src/cfnlint/data/ExtendedSpecs/us-east-1/05_pricing_property_values.json
@@ -265,5 +265,24 @@
       "ds2.8xlarge",
       "ds2.xlarge"
     ]
+  },
+  {
+    "op": "add",
+    "path": "/ValueTypes/DAXInstanceType/AllowedValues",
+    "value": [
+      "dax.r3.2xlarge",
+      "dax.r3.4xlarge",
+      "dax.r3.8xlarge",
+      "dax.r3.large",
+      "dax.r3.xlarge",
+      "dax.r4.16xlarge",
+      "dax.r4.2xlarge",
+      "dax.r4.4xlarge",
+      "dax.r4.8xlarge",
+      "dax.r4.large",
+      "dax.r4.xlarge",
+      "dax.t2.medium",
+      "dax.t2.small"
+    ]
   }
 ]

--- a/src/cfnlint/data/ExtendedSpecs/us-east-2/05_pricing_property_values.json
+++ b/src/cfnlint/data/ExtendedSpecs/us-east-2/05_pricing_property_values.json
@@ -204,5 +204,19 @@
       "ds2.8xlarge",
       "ds2.xlarge"
     ]
+  },
+  {
+    "op": "add",
+    "path": "/ValueTypes/DAXInstanceType/AllowedValues",
+    "value": [
+      "dax.r4.16xlarge",
+      "dax.r4.2xlarge",
+      "dax.r4.4xlarge",
+      "dax.r4.8xlarge",
+      "dax.r4.large",
+      "dax.r4.xlarge",
+      "dax.t2.medium",
+      "dax.t2.small"
+    ]
   }
 ]

--- a/src/cfnlint/data/ExtendedSpecs/us-west-1/05_pricing_property_values.json
+++ b/src/cfnlint/data/ExtendedSpecs/us-west-1/05_pricing_property_values.json
@@ -208,5 +208,24 @@
       "ds2.8xlarge",
       "ds2.xlarge"
     ]
+  },
+  {
+    "op": "add",
+    "path": "/ValueTypes/DAXInstanceType/AllowedValues",
+    "value": [
+      "dax.r3.2xlarge",
+      "dax.r3.4xlarge",
+      "dax.r3.8xlarge",
+      "dax.r3.large",
+      "dax.r3.xlarge",
+      "dax.r4.16xlarge",
+      "dax.r4.2xlarge",
+      "dax.r4.4xlarge",
+      "dax.r4.8xlarge",
+      "dax.r4.large",
+      "dax.r4.xlarge",
+      "dax.t2.medium",
+      "dax.t2.small"
+    ]
   }
 ]

--- a/src/cfnlint/data/ExtendedSpecs/us-west-2/05_pricing_property_values.json
+++ b/src/cfnlint/data/ExtendedSpecs/us-west-2/05_pricing_property_values.json
@@ -265,5 +265,24 @@
       "ds2.8xlarge",
       "ds2.xlarge"
     ]
+  },
+  {
+    "op": "add",
+    "path": "/ValueTypes/DAXInstanceType/AllowedValues",
+    "value": [
+      "dax.r3.2xlarge",
+      "dax.r3.4xlarge",
+      "dax.r3.8xlarge",
+      "dax.r3.large",
+      "dax.r3.xlarge",
+      "dax.r4.16xlarge",
+      "dax.r4.2xlarge",
+      "dax.r4.4xlarge",
+      "dax.r4.8xlarge",
+      "dax.r4.large",
+      "dax.r4.xlarge",
+      "dax.t2.medium",
+      "dax.t2.small"
+    ]
   }
 ]

--- a/test/fixtures/templates/bad/resources/properties/allowed_values.yaml
+++ b/test/fixtures/templates/bad/resources/properties/allowed_values.yaml
@@ -436,6 +436,12 @@ Resources:
       ConfigSnapshotDeliveryProperties:
         DeliveryFrequency: "Minute" # Invalid AllowedValue
       S3BucketName: !Ref "S3Bucket"
+  DAXCluster:
+    Type: "AWS::DAX::Cluster"
+    Properties:
+      IAMRoleARN: "iam"
+      NodeType: "t2.small" # Invalid AllowedValue
+      ReplicationFactor: 1
   DmsEndpoint:
     Type: "AWS::DMS::Endpoint"
     Properties:

--- a/test/fixtures/templates/good/resources/properties/allowed_values.yaml
+++ b/test/fixtures/templates/good/resources/properties/allowed_values.yaml
@@ -444,6 +444,12 @@ Resources:
       ConfigSnapshotDeliveryProperties:
         DeliveryFrequency: "Six_Hours" # Valid AllowedValue
       S3BucketName: !Ref "S3Bucket"
+  DAXCluster:
+    Type: "AWS::DAX::Cluster"
+    Properties:
+      IAMRoleARN: "iam"
+      NodeType: "dax.t2.small" # Valid AllowedValue
+      ReplicationFactor: 1
   DmsEndpoint:
     Type: "AWS::DMS::Endpoint"
     Properties:

--- a/test/rules/resources/properties/test_allowed_value.py
+++ b/test/rules/resources/properties/test_allowed_value.py
@@ -34,4 +34,4 @@ class TestAllowedValue(BaseRuleTestCase):
 
     def test_file_negative(self):
         """Test failure"""
-        self.helper_file_negative('test/fixtures/templates/bad/resources/properties/allowed_values.yaml', 136)
+        self.helper_file_negative('test/fixtures/templates/bad/resources/properties/allowed_values.yaml', 137)


### PR DESCRIPTION
*Issue https://github.com/awslabs/cfn-python-lint/issues/50, if available:*

Add all the allowed values of the [`AWS::DAX`]( https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-reference-dax.html) Resources

DAX Instance types are available from the Pricing API, so extended that. While updating got some new EC2 instance types along the way.
(The Redshift values come from the fact the allowed value has to exist for the pricing spec patches to add the allowed values. Added that along the way.)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
