### PR TITLE
Fix rule E1029 False positives on IAM variables

### DIFF
--- a/src/cfnlint/decode/cfn_json.py
+++ b/src/cfnlint/decode/cfn_json.py
@@ -51,8 +51,7 @@ def check_duplicates(ordered_pairs, beg_mark, end_mark):
             raise NullError('"{}"'.format(key))
         if key in mapping:
             raise DuplicateError('"{}"'.format(key))
-        else:
-            mapping[key] = value
+        mapping[key] = value
     return mapping
 
 
@@ -124,9 +123,8 @@ def py_scanstring(s, end, strict=True,
             if strict:
                 msg = 'Invalid control character {0!r} at'.format(terminator)
                 raise JSONDecodeError(msg, s, end)
-            else:
-                _append(terminator)
-                continue
+            _append(terminator)
+            continue
         try:
             esc = s[end]
         except IndexError:

--- a/test/fixtures/templates/bad/functions/sub_needed.yaml
+++ b/test/fixtures/templates/bad/functions/sub_needed.yaml
@@ -10,3 +10,20 @@ Resources:
     Properties:
       ImageId: "${AMIId}" # Sub without a variable
       AdditionalInfo: !Sub "${AMIId}" # We add a valid sub in to silence W2001
+  myPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      Roles:
+      - testRole
+      PolicyName: test
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+        - Effect: "Allow"
+          Action:
+            - "iam:UploadSSHPublicKey"
+          Resource: "arn:aws:iam::${AWS::AccountId}:user/${aws:username}-${AMIId}"
+  mySnsTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      TopicName: "${aws:username}-topic"

--- a/test/rules/functions/test_sub_needed.py
+++ b/test/rules/functions/test_sub_needed.py
@@ -35,4 +35,4 @@ class TestSubNeeded(BaseRuleTestCase):
 
     def test_file_negative(self):
         """Test failure"""
-        self.helper_file_negative('test/fixtures/templates/bad/functions/sub_needed.yaml', 1)
+        self.helper_file_negative('test/fixtures/templates/bad/functions/sub_needed.yaml', 3)


### PR DESCRIPTION
IAM has special variables that don't need the usage of `!Sub` (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_variables.html).

This PR:

* removes the `Resource` from the exclude list and checks for these variables.
* Removes the variable from the path to prevent multiple errors on the same property
* Added additional `bad` scenarios to the tests to validate the above (`good` template already contained the `${aws:username}`)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
