### PR TITLE
Improve the line/column information of a Match with array support

### DIFF
--- a/src/cfnlint/__init__.py
+++ b/src/cfnlint/__init__.py
@@ -812,12 +812,18 @@ class Template(object):
                 except AttributeError as err:
                     LOGGER.debug(err)
         else:
-            try:
-                for key in text:
-                    if key == path[0]:
-                        result = self._loc(key)
-            except AttributeError as err:
-                LOGGER.debug(err)
+            # If the last item of the path is an integer, and the vaue is an array,
+            # Get the location of the item in the array
+            if isinstance(text, list) and isinstance(path[0], int):
+                result = self._loc(text[path[0]])
+            else:
+                try:
+                    for key in text:
+                        if key == path[0]:
+                            result = self._loc(key)
+                except AttributeError as err:
+                    LOGGER.debug(err)
+
         return result
 
     def check_resource_property(self, resource_type, resource_property,

--- a/test/fixtures/results/quickstart/cis_benchmark.json
+++ b/test/fixtures/results/quickstart/cis_benchmark.json
@@ -7,12 +7,12 @@
         },
         "Location": {
             "Start": {
-                "ColumnNumber": 7,
-                "LineNumber": 121
+                "ColumnNumber": 11,
+                "LineNumber": 122
             },
             "End": {
-                "ColumnNumber": 16,
-                "LineNumber": 121
+                "ColumnNumber": 27,
+                "LineNumber": 122
             }
         },
         "Level": "Warning",
@@ -47,12 +47,12 @@
         },
         "Location": {
             "Start": {
-                "ColumnNumber": 7,
-                "LineNumber": 227
+                "ColumnNumber": 11,
+                "LineNumber": 228
             },
             "End": {
-                "ColumnNumber": 16,
-                "LineNumber": 227
+                "ColumnNumber": 27,
+                "LineNumber": 228
             }
         },
         "Level": "Warning",
@@ -87,12 +87,12 @@
         },
         "Location": {
             "Start": {
-                "ColumnNumber": 7,
-                "LineNumber": 421
+                "ColumnNumber": 11,
+                "LineNumber": 422
             },
             "End": {
-                "ColumnNumber": 16,
-                "LineNumber": 421
+                "ColumnNumber": 27,
+                "LineNumber": 422
             }
         },
         "Level": "Warning",
@@ -127,12 +127,12 @@
         },
         "Location": {
             "Start": {
-                "ColumnNumber": 7,
-                "LineNumber": 497
+                "ColumnNumber": 11,
+                "LineNumber": 498
             },
             "End": {
-                "ColumnNumber": 16,
-                "LineNumber": 497
+                "ColumnNumber": 27,
+                "LineNumber": 498
             }
         },
         "Level": "Warning",
@@ -167,12 +167,12 @@
         },
         "Location": {
             "Start": {
-                "ColumnNumber": 7,
-                "LineNumber": 565
+                "ColumnNumber": 11,
+                "LineNumber": 566
             },
             "End": {
-                "ColumnNumber": 16,
-                "LineNumber": 565
+                "ColumnNumber": 50,
+                "LineNumber": 566
             }
         },
         "Level": "Warning",
@@ -187,12 +187,12 @@
         },
         "Location": {
             "Start": {
-                "ColumnNumber": 7,
-                "LineNumber": 584
+                "ColumnNumber": 11,
+                "LineNumber": 585
             },
             "End": {
-                "ColumnNumber": 16,
-                "LineNumber": 584
+                "ColumnNumber": 36,
+                "LineNumber": 585
             }
         },
         "Level": "Warning",
@@ -207,12 +207,12 @@
         },
         "Location": {
             "Start": {
-                "ColumnNumber": 7,
-                "LineNumber": 606
+                "ColumnNumber": 11,
+                "LineNumber": 607
             },
             "End": {
-                "ColumnNumber": 16,
-                "LineNumber": 606
+                "ColumnNumber": 27,
+                "LineNumber": 607
             }
         },
         "Level": "Warning",
@@ -247,12 +247,12 @@
         },
         "Location": {
             "Start": {
-                "ColumnNumber": 7,
-                "LineNumber": 699
+                "ColumnNumber": 11,
+                "LineNumber": 700
             },
             "End": {
-                "ColumnNumber": 16,
-                "LineNumber": 699
+                "ColumnNumber": 27,
+                "LineNumber": 700
             }
         },
         "Level": "Warning",
@@ -287,12 +287,12 @@
         },
         "Location": {
             "Start": {
-                "ColumnNumber": 7,
-                "LineNumber": 773
+                "ColumnNumber": 11,
+                "LineNumber": 774
             },
             "End": {
-                "ColumnNumber": 16,
-                "LineNumber": 773
+                "ColumnNumber": 51,
+                "LineNumber": 774
             }
         },
         "Level": "Warning",
@@ -307,12 +307,12 @@
         },
         "Location": {
             "Start": {
-                "ColumnNumber": 7,
-                "LineNumber": 795
+                "ColumnNumber": 11,
+                "LineNumber": 796
             },
             "End": {
-                "ColumnNumber": 16,
-                "LineNumber": 795
+                "ColumnNumber": 27,
+                "LineNumber": 796
             }
         },
         "Level": "Warning",
@@ -347,12 +347,12 @@
         },
         "Location": {
             "Start": {
-                "ColumnNumber": 7,
-                "LineNumber": 863
+                "ColumnNumber": 11,
+                "LineNumber": 864
             },
             "End": {
-                "ColumnNumber": 16,
-                "LineNumber": 863
+                "ColumnNumber": 55,
+                "LineNumber": 864
             }
         },
         "Level": "Warning",
@@ -367,12 +367,12 @@
         },
         "Location": {
             "Start": {
-                "ColumnNumber": 7,
-                "LineNumber": 886
+                "ColumnNumber": 11,
+                "LineNumber": 887
             },
             "End": {
-                "ColumnNumber": 16,
-                "LineNumber": 886
+                "ColumnNumber": 27,
+                "LineNumber": 887
             }
         },
         "Level": "Warning",
@@ -407,12 +407,12 @@
         },
         "Location": {
             "Start": {
-                "ColumnNumber": 7,
-                "LineNumber": 979
+                "ColumnNumber": 11,
+                "LineNumber": 980
             },
             "End": {
-                "ColumnNumber": 16,
-                "LineNumber": 979
+                "ColumnNumber": 44,
+                "LineNumber": 980
             }
         },
         "Level": "Warning",
@@ -427,12 +427,12 @@
         },
         "Location": {
             "Start": {
-                "ColumnNumber": 7,
-                "LineNumber": 999
+                "ColumnNumber": 11,
+                "LineNumber": 1000
             },
             "End": {
-                "ColumnNumber": 16,
-                "LineNumber": 999
+                "ColumnNumber": 27,
+                "LineNumber": 1000
             }
         },
         "Level": "Warning",
@@ -467,12 +467,12 @@
         },
         "Location": {
             "Start": {
-                "ColumnNumber": 7,
-                "LineNumber": 1095
+                "ColumnNumber": 11,
+                "LineNumber": 1096
             },
             "End": {
-                "ColumnNumber": 16,
-                "LineNumber": 1095
+                "ColumnNumber": 50,
+                "LineNumber": 1096
             }
         },
         "Level": "Warning",
@@ -487,12 +487,12 @@
         },
         "Location": {
             "Start": {
-                "ColumnNumber": 7,
-                "LineNumber": 1116
+                "ColumnNumber": 11,
+                "LineNumber": 1117
             },
             "End": {
-                "ColumnNumber": 16,
-                "LineNumber": 1116
+                "ColumnNumber": 27,
+                "LineNumber": 1117
             }
         },
         "Level": "Warning",
@@ -527,12 +527,12 @@
         },
         "Location": {
             "Start": {
-                "ColumnNumber": 7,
-                "LineNumber": 1193
+                "ColumnNumber": 11,
+                "LineNumber": 1194
             },
             "End": {
-                "ColumnNumber": 16,
-                "LineNumber": 1193
+                "ColumnNumber": 56,
+                "LineNumber": 1194
             }
         },
         "Level": "Warning",
@@ -547,12 +547,12 @@
         },
         "Location": {
             "Start": {
-                "ColumnNumber": 7,
-                "LineNumber": 1213
+                "ColumnNumber": 11,
+                "LineNumber": 1214
             },
             "End": {
-                "ColumnNumber": 16,
-                "LineNumber": 1213
+                "ColumnNumber": 27,
+                "LineNumber": 1214
             }
         },
         "Level": "Warning",
@@ -587,12 +587,12 @@
         },
         "Location": {
             "Start": {
-                "ColumnNumber": 7,
-                "LineNumber": 1275
+                "ColumnNumber": 11,
+                "LineNumber": 1276
             },
             "End": {
-                "ColumnNumber": 16,
-                "LineNumber": 1275
+                "ColumnNumber": 41,
+                "LineNumber": 1276
             }
         },
         "Level": "Warning",
@@ -607,12 +607,12 @@
         },
         "Location": {
             "Start": {
-                "ColumnNumber": 7,
-                "LineNumber": 1298
+                "ColumnNumber": 11,
+                "LineNumber": 1299
             },
             "End": {
-                "ColumnNumber": 16,
-                "LineNumber": 1298
+                "ColumnNumber": 27,
+                "LineNumber": 1299
             }
         },
         "Level": "Warning",
@@ -647,12 +647,12 @@
         },
         "Location": {
             "Start": {
-                "ColumnNumber": 7,
-                "LineNumber": 1372
+                "ColumnNumber": 11,
+                "LineNumber": 1373
             },
             "End": {
-                "ColumnNumber": 16,
-                "LineNumber": 1372
+                "ColumnNumber": 45,
+                "LineNumber": 1373
             }
         },
         "Level": "Warning",
@@ -667,12 +667,12 @@
         },
         "Location": {
             "Start": {
-                "ColumnNumber": 7,
-                "LineNumber": 1394
+                "ColumnNumber": 11,
+                "LineNumber": 1395
             },
             "End": {
-                "ColumnNumber": 16,
-                "LineNumber": 1394
+                "ColumnNumber": 27,
+                "LineNumber": 1395
             }
         },
         "Level": "Warning",
@@ -707,12 +707,12 @@
         },
         "Location": {
             "Start": {
-                "ColumnNumber": 7,
-                "LineNumber": 1499
+                "ColumnNumber": 11,
+                "LineNumber": 1500
             },
             "End": {
-                "ColumnNumber": 16,
-                "LineNumber": 1499
+                "ColumnNumber": 27,
+                "LineNumber": 1500
             }
         },
         "Level": "Warning",
@@ -747,12 +747,12 @@
         },
         "Location": {
             "Start": {
-                "ColumnNumber": 7,
-                "LineNumber": 1564
+                "ColumnNumber": 11,
+                "LineNumber": 1565
             },
             "End": {
-                "ColumnNumber": 16,
-                "LineNumber": 1564
+                "ColumnNumber": 47,
+                "LineNumber": 1565
             }
         },
         "Level": "Warning",
@@ -807,12 +807,12 @@
         },
         "Location": {
             "Start": {
-                "ColumnNumber": 7,
-                "LineNumber": 1647
+                "ColumnNumber": 11,
+                "LineNumber": 1649
             },
             "End": {
-                "ColumnNumber": 16,
-                "LineNumber": 1647
+                "ColumnNumber": 48,
+                "LineNumber": 1649
             }
         },
         "Level": "Warning",
@@ -847,12 +847,12 @@
         },
         "Location": {
             "Start": {
-                "ColumnNumber": 7,
-                "LineNumber": 1681
+                "ColumnNumber": 11,
+                "LineNumber": 1683
             },
             "End": {
-                "ColumnNumber": 16,
-                "LineNumber": 1681
+                "ColumnNumber": 48,
+                "LineNumber": 1683
             }
         },
         "Level": "Warning",
@@ -887,12 +887,12 @@
         },
         "Location": {
             "Start": {
-                "ColumnNumber": 7,
-                "LineNumber": 1718
+                "ColumnNumber": 11,
+                "LineNumber": 1720
             },
             "End": {
-                "ColumnNumber": 16,
-                "LineNumber": 1718
+                "ColumnNumber": 48,
+                "LineNumber": 1720
             }
         },
         "Level": "Warning",
@@ -927,12 +927,12 @@
         },
         "Location": {
             "Start": {
-                "ColumnNumber": 7,
-                "LineNumber": 1757
+                "ColumnNumber": 11,
+                "LineNumber": 1759
             },
             "End": {
-                "ColumnNumber": 16,
-                "LineNumber": 1757
+                "ColumnNumber": 48,
+                "LineNumber": 1759
             }
         },
         "Level": "Warning",
@@ -967,12 +967,12 @@
         },
         "Location": {
             "Start": {
-                "ColumnNumber": 7,
-                "LineNumber": 1794
+                "ColumnNumber": 11,
+                "LineNumber": 1796
             },
             "End": {
-                "ColumnNumber": 16,
-                "LineNumber": 1794
+                "ColumnNumber": 48,
+                "LineNumber": 1796
             }
         },
         "Level": "Warning",
@@ -1027,12 +1027,12 @@
         },
         "Location": {
             "Start": {
-                "ColumnNumber": 7,
-                "LineNumber": 1856
+                "ColumnNumber": 11,
+                "LineNumber": 1857
             },
             "End": {
-                "ColumnNumber": 16,
-                "LineNumber": 1856
+                "ColumnNumber": 34,
+                "LineNumber": 1857
             }
         },
         "Level": "Warning",
@@ -1047,12 +1047,12 @@
         },
         "Location": {
             "Start": {
-                "ColumnNumber": 7,
-                "LineNumber": 1894
+                "ColumnNumber": 11,
+                "LineNumber": 1895
             },
             "End": {
-                "ColumnNumber": 16,
-                "LineNumber": 1894
+                "ColumnNumber": 42,
+                "LineNumber": 1895
             }
         },
         "Level": "Warning",
@@ -1067,12 +1067,12 @@
         },
         "Location": {
             "Start": {
-                "ColumnNumber": 7,
-                "LineNumber": 2183
+                "ColumnNumber": 11,
+                "LineNumber": 2185
             },
             "End": {
-                "ColumnNumber": 16,
-                "LineNumber": 2183
+                "ColumnNumber": 48,
+                "LineNumber": 2185
             }
         },
         "Level": "Warning",
@@ -1127,12 +1127,12 @@
         },
         "Location": {
             "Start": {
-                "ColumnNumber": 7,
-                "LineNumber": 2339
+                "ColumnNumber": 11,
+                "LineNumber": 2340
             },
             "End": {
-                "ColumnNumber": 16,
-                "LineNumber": 2339
+                "ColumnNumber": 45,
+                "LineNumber": 2340
             }
         },
         "Level": "Warning",

--- a/test/fixtures/results/quickstart/nist_application.json
+++ b/test/fixtures/results/quickstart/nist_application.json
@@ -113,12 +113,12 @@
         },
         "Location": {
             "Start": {
-                "ColumnNumber": 5,
-                "LineNumber": 417
+                "ColumnNumber": 7,
+                "LineNumber": 418
             },
             "End": {
                 "ColumnNumber": 14,
-                "LineNumber": 417
+                "LineNumber": 418
             }
         },
         "Level": "Warning",
@@ -680,12 +680,12 @@
         },
         "Location": {
             "Start": {
-                "ColumnNumber": 5,
-                "LineNumber": 723
+                "ColumnNumber": 7,
+                "LineNumber": 724
             },
             "End": {
-                "ColumnNumber": 14,
-                "LineNumber": 723
+                "ColumnNumber": 23,
+                "LineNumber": 724
             }
         },
         "Level": "Warning",
@@ -701,12 +701,12 @@
         },
         "Location": {
             "Start": {
-                "ColumnNumber": 5,
-                "LineNumber": 723
+                "ColumnNumber": 7,
+                "LineNumber": 725
             },
             "End": {
-                "ColumnNumber": 14,
-                "LineNumber": 723
+                "ColumnNumber": 24,
+                "LineNumber": 725
             }
         },
         "Level": "Warning",
@@ -764,12 +764,12 @@
         },
         "Location": {
             "Start": {
-                "ColumnNumber": 5,
-                "LineNumber": 759
+                "ColumnNumber": 7,
+                "LineNumber": 760
             },
             "End": {
-                "ColumnNumber": 14,
-                "LineNumber": 759
+                "ColumnNumber": 23,
+                "LineNumber": 760
             }
         },
         "Level": "Warning",
@@ -785,12 +785,12 @@
         },
         "Location": {
             "Start": {
-                "ColumnNumber": 5,
-                "LineNumber": 759
+                "ColumnNumber": 7,
+                "LineNumber": 760
             },
             "End": {
-                "ColumnNumber": 14,
-                "LineNumber": 759
+                "ColumnNumber": 24,
+                "LineNumber": 760
             }
         },
         "Level": "Warning",
@@ -848,12 +848,12 @@
         },
         "Location": {
             "Start": {
-                "ColumnNumber": 5,
-                "LineNumber": 1003
+                "ColumnNumber": 7,
+                "LineNumber": 1004
             },
             "End": {
-                "ColumnNumber": 14,
-                "LineNumber": 1003
+                "ColumnNumber": 21,
+                "LineNumber": 1004
             }
         },
         "Level": "Warning",
@@ -869,12 +869,12 @@
         },
         "Location": {
             "Start": {
-                "ColumnNumber": 5,
-                "LineNumber": 1003
+                "ColumnNumber": 7,
+                "LineNumber": 1005
             },
             "End": {
-                "ColumnNumber": 14,
-                "LineNumber": 1003
+                "ColumnNumber": 24,
+                "LineNumber": 1005
             }
         },
         "Level": "Warning",

--- a/test/fixtures/results/quickstart/nist_high_master.json
+++ b/test/fixtures/results/quickstart/nist_high_master.json
@@ -25,12 +25,12 @@
         "Level": "Warning",
         "Location": {
             "End": {
-                "ColumnNumber": 14,
-                "LineNumber": 277
+                "ColumnNumber": 28,
+                "LineNumber": 278
             },
             "Start": {
-                "ColumnNumber": 5,
-                "LineNumber": 277
+                "ColumnNumber": 7,
+                "LineNumber": 278
             }
         },
         "Message": "Obsolete DependsOn on resource (ProductionVpcTemplate), dependency already enforced by a \"Fn:GetAtt\" at Resources/ApplicationTemplate/Properties/Parameters/pAppPrivateSubnetB/Fn::GetAtt/['ProductionVpcTemplate', 'Outputs.rAppPrivateSubnetB']",
@@ -46,12 +46,12 @@
         "Level": "Warning",
         "Location": {
             "End": {
-                "ColumnNumber": 14,
-                "LineNumber": 277
+                "ColumnNumber": 28,
+                "LineNumber": 278
             },
             "Start": {
-                "ColumnNumber": 5,
-                "LineNumber": 277
+                "ColumnNumber": 7,
+                "LineNumber": 278
             }
         },
         "Message": "Obsolete DependsOn on resource (ProductionVpcTemplate), dependency already enforced by a \"Fn:GetAtt\" at Resources/ApplicationTemplate/Properties/Parameters/pDBPrivateSubnetA/Fn::GetAtt/['ProductionVpcTemplate', 'Outputs.rDBPrivateSubnetA']",
@@ -67,12 +67,12 @@
         "Level": "Warning",
         "Location": {
             "End": {
-                "ColumnNumber": 14,
-                "LineNumber": 277
+                "ColumnNumber": 28,
+                "LineNumber": 278
             },
             "Start": {
-                "ColumnNumber": 5,
-                "LineNumber": 277
+                "ColumnNumber": 7,
+                "LineNumber": 278
             }
         },
         "Message": "Obsolete DependsOn on resource (ProductionVpcTemplate), dependency already enforced by a \"Fn:GetAtt\" at Resources/ApplicationTemplate/Properties/Parameters/pDBPrivateSubnetB/Fn::GetAtt/['ProductionVpcTemplate', 'Outputs.rDBPrivateSubnetB']",
@@ -88,12 +88,12 @@
         "Level": "Warning",
         "Location": {
             "End": {
-                "ColumnNumber": 14,
-                "LineNumber": 277
+                "ColumnNumber": 28,
+                "LineNumber": 278
             },
             "Start": {
-                "ColumnNumber": 5,
-                "LineNumber": 277
+                "ColumnNumber": 7,
+                "LineNumber": 278
             }
         },
         "Message": "Obsolete DependsOn on resource (ProductionVpcTemplate), dependency already enforced by a \"Fn:GetAtt\" at Resources/ApplicationTemplate/Properties/Parameters/pDMZSubnetA/Fn::GetAtt/['ProductionVpcTemplate', 'Outputs.rDMZSubnetA']",
@@ -109,12 +109,12 @@
         "Level": "Warning",
         "Location": {
             "End": {
-                "ColumnNumber": 14,
-                "LineNumber": 277
+                "ColumnNumber": 28,
+                "LineNumber": 278
             },
             "Start": {
-                "ColumnNumber": 5,
-                "LineNumber": 277
+                "ColumnNumber": 7,
+                "LineNumber": 278
             }
         },
         "Message": "Obsolete DependsOn on resource (ProductionVpcTemplate), dependency already enforced by a \"Fn:GetAtt\" at Resources/ApplicationTemplate/Properties/Parameters/pDMZSubnetB/Fn::GetAtt/['ProductionVpcTemplate', 'Outputs.rDMZSubnetB']",
@@ -130,12 +130,12 @@
         "Level": "Warning",
         "Location": {
             "End": {
-                "ColumnNumber": 14,
-                "LineNumber": 277
+                "ColumnNumber": 28,
+                "LineNumber": 278
             },
             "Start": {
-                "ColumnNumber": 5,
-                "LineNumber": 277
+                "ColumnNumber": 7,
+                "LineNumber": 278
             }
         },
         "Message": "Obsolete DependsOn on resource (ProductionVpcTemplate), dependency already enforced by a \"Fn:GetAtt\" at Resources/ApplicationTemplate/Properties/Parameters/pAppPrivateSubnetA/Fn::GetAtt/['ProductionVpcTemplate', 'Outputs.rAppPrivateSubnetA']",
@@ -151,12 +151,12 @@
         "Level": "Warning",
         "Location": {
             "End": {
-                "ColumnNumber": 14,
-                "LineNumber": 277
+                "ColumnNumber": 28,
+                "LineNumber": 278
             },
             "Start": {
-                "ColumnNumber": 5,
-                "LineNumber": 277
+                "ColumnNumber": 7,
+                "LineNumber": 278
             }
         },
         "Message": "Obsolete DependsOn on resource (ProductionVpcTemplate), dependency already enforced by a \"Fn:GetAtt\" at Resources/ApplicationTemplate/Properties/Parameters/pProductionVPC/Fn::GetAtt/['ProductionVpcTemplate', 'Outputs.rVPCProduction']",
@@ -172,12 +172,12 @@
         "Level": "Warning",
         "Location": {
             "End": {
-                "ColumnNumber": 14,
-                "LineNumber": 277
+                "ColumnNumber": 28,
+                "LineNumber": 279
             },
             "Start": {
-                "ColumnNumber": 5,
-                "LineNumber": 277
+                "ColumnNumber": 7,
+                "LineNumber": 279
             }
         },
         "Message": "Obsolete DependsOn on resource (ManagementVpcTemplate), dependency already enforced by a \"Fn:GetAtt\" at Resources/ApplicationTemplate/Properties/Parameters/pDeepSecurityAgentDownload/Fn::GetAtt/['ManagementVpcTemplate', 'Outputs.rDeepSecurityAgentDownload']",
@@ -193,12 +193,12 @@
         "Level": "Warning",
         "Location": {
             "End": {
-                "ColumnNumber": 14,
-                "LineNumber": 277
+                "ColumnNumber": 28,
+                "LineNumber": 279
             },
             "Start": {
-                "ColumnNumber": 5,
-                "LineNumber": 277
+                "ColumnNumber": 7,
+                "LineNumber": 279
             }
         },
         "Message": "Obsolete DependsOn on resource (ManagementVpcTemplate), dependency already enforced by a \"Fn:GetAtt\" at Resources/ApplicationTemplate/Properties/Parameters/pDeepSecurityHeartbeat/Fn::GetAtt/['ManagementVpcTemplate', 'Outputs.rDeepSecurityHeartbeat']",

--- a/test/fixtures/results/quickstart/nist_vpc_management.json
+++ b/test/fixtures/results/quickstart/nist_vpc_management.json
@@ -247,12 +247,12 @@
         },
         "Location": {
             "Start": {
-                "ColumnNumber": 5,
-                "LineNumber": 479
+                "ColumnNumber": 7,
+                "LineNumber": 480
             },
             "End": {
-                "ColumnNumber": 14,
-                "LineNumber": 479
+                "ColumnNumber": 42,
+                "LineNumber": 480
             }
         },
         "Level": "Warning",
@@ -266,14 +266,14 @@
             "ShortDescription": "Check obsolete DependsOn configuration for Resources"
         },
         "Location": {
-            "Start": {
-                "ColumnNumber": 5,
-                "LineNumber": 479
-            },
-            "End": {
-                "ColumnNumber": 14,
-                "LineNumber": 479
-            }
+          "Start": {
+              "ColumnNumber": 7,
+              "LineNumber": 480
+          },
+          "End": {
+              "ColumnNumber": 42,
+              "LineNumber": 480
+          }
         },
         "Level": "Warning",
         "Message": "Obsolete DependsOn on resource (rDeepSecurityInfrastructureTemplate), dependency already enforced by \"!Fn:GetAtt\" at Resources/rMgmtBastionInstance/Metadata/AWS::CloudFormation::Init/installDeepSecurityAgent/commands/3-activate-DSA/command/Fn::Join/1/1/Fn::GetAtt/['rDeepSecurityInfrastructureTemplate', 'Outputs.DeepSecurityHeartbeat']",

--- a/test/fixtures/results/quickstart/openshift.json
+++ b/test/fixtures/results/quickstart/openshift.json
@@ -113,12 +113,12 @@
         },
         "Location": {
             "Start": {
-                "ColumnNumber": 5,
-                "LineNumber": 774
+                "ColumnNumber": 7,
+                "LineNumber": 775
             },
             "End": {
-                "ColumnNumber": 14,
-                "LineNumber": 774
+                "ColumnNumber": 13,
+                "LineNumber": 75
             }
         },
         "Level": "Warning",

--- a/test/module/cfn_json/test_cfn_json.py
+++ b/test/module/cfn_json/test_cfn_json.py
@@ -48,7 +48,7 @@ class TestCfnJson(BaseTestCase):
             },
             "vpc_management": {
                 "filename": 'test/fixtures/templates/quickstart/vpc-management.json',
-                "failures": 35
+                "failures": 33
             },
             "vpc": {
                 "filename": 'test/fixtures/templates/quickstart/vpc.json',


### PR DESCRIPTION
The line/column number did not support arrays. As a result the error/warning was always given on the property, not the actual item that causes the error. I started noticing this when working on the Allowed Values rule.

This PR handles this scenario and returns the correct line/error number if the error was in an array.

**Before:**
![image](https://user-images.githubusercontent.com/35613489/53526920-c8a9be00-3ae5-11e9-83d3-50ae486cfc6d.png)

**After:**
![image](https://user-images.githubusercontent.com/35613489/53526933-d65f4380-3ae5-11e9-9469-20539f5de0af.png)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
